### PR TITLE
Add a general getting help page

### DIFF
--- a/source/documentors/quickstarts/first_documentation_pr.rst
+++ b/source/documentors/quickstarts/first_documentation_pr.rst
@@ -139,8 +139,6 @@ changes as is and merge them.
 .. note::
    .. include:: ../how-tos/reusable_content/sign_agreement.txt
 
-If you need more help with the future, check out the getting help section of
-the documentation.
-
-   TODO Link to the getting help section once that exists.
+If you need more help or run into issues, check out the :doc:`/other/getting_help`
+section of the documentation for links to some places where you could get help.
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -131,4 +131,5 @@ Open edX Documentation
       :caption: Other Topics
 
       other/feedback
+      other/getting_help
 

--- a/source/other/getting_help.rst
+++ b/source/other/getting_help.rst
@@ -13,3 +13,8 @@ The community also has a `slack workspace
 tasks.If you need help, we recommend posting in the forums over posting in
 slack.  The forums retain more history and tend to get more thoughtful
 responses.
+
+.. note::
+
+   The Open edX community has agreed apon a shared `code of conduct
+   <https://openedx.org/code-of-conduct/>`_, be sure to review it.

--- a/source/other/getting_help.rst
+++ b/source/other/getting_help.rst
@@ -2,7 +2,7 @@ Getting Help
 ############
 
 If you are unable to find what you need here or need more help than the
-documentation provides, we'de love to hear about it via the :doc:`feedback`.
+documentation provides, we'd love to hear about it via the :doc:`feedback`.
 
 To get more help we recommend checking out the `Open edX Forums
 <https://discuss.openedx.org>`_. Make sure to search the forums before posting a
@@ -10,11 +10,11 @@ new question in case others have had the same question as you.
 
 The community also has a `slack workspace
 <https://openedx-slack-invite.herokuapp.com/>`_ where we coordinate more timely
-tasks.If you need help, we recommend posting in the forums over posting in
+tasks. If you need help, we recommend posting in the forums over posting in
 slack.  The forums retain more history and tend to get more thoughtful
 responses.
 
 .. note::
 
-   The Open edX community has agreed apon a shared `code of conduct
-   <https://openedx.org/code-of-conduct/>`_, be sure to review it.
+   The Open edX community has agreed upon a shared `code of conduct
+   <https://openedx.org/code-of-conduct/>`_, please be sure to review it.

--- a/source/other/getting_help.rst
+++ b/source/other/getting_help.rst
@@ -1,0 +1,15 @@
+Getting Help
+############
+
+If you are unable to find what you need here or need more help than the
+documentation provides, we'de love to hear about it via the :doc:`feedback`.
+
+To get more help we recommend checking out the `Open edX Forums
+<https://discuss.openedx.org>`_. Make sure to search the forums before posting a
+new question in case others have had the same question as you.
+
+The community also has a `slack workspace
+<https://openedx-slack-invite.herokuapp.com/>`_ where we coordinate more timely
+tasks.If you need help, we recommend posting in the forums over posting in
+slack.  The forums retain more history and tend to get more thoughtful
+responses.


### PR DESCRIPTION
I could imagine using this multiple times so making it a separate page that we reference.
