### PR TITLE
docs: fix course URL structure in course creation how-to

### DIFF
--- a/source/educators/how-tos/reusable_content/create_course.txt
+++ b/source/educators/how-tos/reusable_content/create_course.txt
@@ -7,7 +7,7 @@
 
   The Organization, Course Number, and Course run values you enter when creating a course are part of the learner-visible course URL and cannot be changed. The base URL for the new course is in the format:
 
-  ``https://your-domain/courses/course:ORGANIZATION+COURSE_NUMBER+COURSE_RUN/``
+  ``https://your-domain/courses/course-v1:ORGANIZATION+COURSE_NUMBER+COURSE_RUN/``
 
   So take care when entering values for the new course.
 


### PR DESCRIPTION
The course key format is `course-v1:ORG+COURSE+RUN`.
The docs were missing the `-v1` suffix.

Side note: The new docs are looking real snazzy 😄 