### PR TITLE
fix: text style for Arabic lang/RTL

### DIFF
--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -128,4 +128,7 @@ details summary {
   font-weight: 700;
   margin-bottom: 0.6em;
 }
-
+/* This fixes the text alignment style, only for the Arabic language*/
+html[lang="ar"] body, html[lang="ar"] #site-navigation div.navbar_extra_footer {
+  text-align: inherit;
+}


### PR DESCRIPTION
  This commits add a CSS role, so that when html lang is ar. It
  would set text-align to inherit, instaed of the deafult which
  is left. See PR for screenshots
  
  Please noteice the empty space between or before the text.
  
  ## Before  

<img width="1429" alt="before" src="https://user-images.githubusercontent.com/16361375/180605291-3145e7f8-49c1-4b61-b11b-0fa31e0e214b.png">

  ## After
  
<img width="1429" alt="after" src="https://user-images.githubusercontent.com/16361375/180605302-cc39f60c-a933-4c61-a813-6c925befb24e.png">

