### PR TITLE
docs: Connect the DoneXBlock docs to the root site.

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -14,11 +14,10 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
-from datetime import datetime
 import os
 import sys
 import urllib
-
+from datetime import datetime
 
 # -- Project information -----------------------------------------------------
 
@@ -41,11 +40,23 @@ extensions = [
     "sphinx_copybutton",
     "sphinx.ext.graphviz",
     "sphinxcontrib.mermaid",
+    "sphinx.ext.intersphinx",
 ]
 
 # Extension Configuration
 graphviz_output_format = "svg"
 autosectionlabel_prefix_document = True
+
+# Intersphinx Extension Configuration
+rtd_language = os.environ.get("READTHEDOCS_LANGUAGE", "en")
+rtd_version = os.environ.get("READTHEDOCS_VERSION", "latest")
+
+intersphinx_mapping = {
+    "DoneXBlock": (
+        f"https://docs.openedx.org/projects/donexblock/{rtd_language}/{rtd_version}",
+        None,
+    ),
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/source/conf.py
+++ b/source/conf.py
@@ -15,6 +15,7 @@
 # sys.path.insert(0, os.path.abspath('.'))
 
 import os
+import re
 import sys
 import urllib
 from datetime import datetime
@@ -48,8 +49,12 @@ graphviz_output_format = "svg"
 autosectionlabel_prefix_document = True
 
 # Intersphinx Extension Configuration
+DIGITS_ONLY = r"^\d+$"
 rtd_language = os.environ.get("READTHEDOCS_LANGUAGE", "en")
 rtd_version = os.environ.get("READTHEDOCS_VERSION", "latest")
+if re.search(DIGITS_ONLY, rtd_version):
+    # This is a PR build, use the latest versions of the other repos.
+    rtd_version = "latest"
 
 intersphinx_mapping = {
     "DoneXBlock": (

--- a/source/developers/references/references_home.rst
+++ b/source/developers/references/references_home.rst
@@ -1,2 +1,7 @@
 References Home
 ###############
+
+.. If you're adding links to othre projects here don't forget to also add the
+   relevant mapping to the ``intersphinx_mapping`` setting in conf.py
+
+* :doc:`DoneXBlock:index`


### PR DESCRIPTION
We can make more complex connections in the future but at the very least
link the repo docs to the core developer reference docs.
