### PR TITLE
feat: set tcril-oncall to be the owner for dev quickstart

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+source/developers/quickstarts/setup_a_backend_dev_environment.rst @openedx/tcril-oncall


### PR DESCRIPTION
The setup_a_backend_dev_environment.rst file was created during a tCRIL
hackathon, and we want to make sure to keep it up to date (since it's
going to be the starting place for many developers).