### PR TITLE
Fix sidebar style for Arabic 

### DIFF
--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -132,3 +132,10 @@ details summary {
 html[lang="ar"] body, html[lang="ar"] #site-navigation div.navbar_extra_footer {
   text-align: inherit;
 }
+
+@media (min-width: 992px){
+html[lang="ar"] aside.sidebar{
+  width: 50%;
+  margin: 0% 0% 0% 3%;
+ }
+}


### PR DESCRIPTION
  It just override the styles for the side so it would show as
  expected. Default style assume display is always left to right.
  Check images in the PR for refs.
  
  ## Before screenshot 
  
<img width="1064" alt="Screen Shot 2022-08-31 at 14 51 27" src="https://user-images.githubusercontent.com/16361375/187672662-666f63cd-dc8e-467e-adc9-dd72915f4437.png">
<img width="1064" alt="Screen Shot 2022-08-31 at 14 51 35" src="https://user-images.githubusercontent.com/16361375/187672725-55be65ad-12bc-4069-a810-1d0f0f1b2ead.png">

  ## After screenshot

