### PR TITLE
 CSS styles for Arabic 

### DIFF
--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -139,3 +139,10 @@ html[lang="ar"] aside.sidebar{
   margin: 0% 0% 0% 3%;
  }
 }
+
+html[lang="ar"] div.contents ul li p a:after {
+  content: " \f060";
+}
+html[lang="ar"] pre{
+  text-align: left;
+}


### PR DESCRIPTION
 This commit does two things:

  - for pre tag (the tag which is used to show snippet) it force
 it to be aligned to left. (Since all code sippet are in English)

  - For ::after of a tag, in table of content: it overides the
  content, from '>' to '<'.

## Before 

<img width="863" alt="Screen Shot 2022-09-10 at 12 52 17" src="https://user-images.githubusercontent.com/16361375/189479606-04b81b71-635a-4bf2-8db4-74627ea6089d.png">

<img width="863" alt="Screen Shot 2022-09-10 at 12 52 33" src="https://user-images.githubusercontent.com/16361375/189479611-d4503b58-df3a-4ae0-9e44-a76b63d80f85.png">

## After

<img width="863" alt="Screen Shot 2022-09-10 at 12 51 53" src="https://user-images.githubusercontent.com/16361375/189479618-bedaede3-6f73-4ed2-9bbb-cf7e4749a80c.png">
<img width="863" alt="Screen Shot 2022-09-10 at 12 52 05" src="https://user-images.githubusercontent.com/16361375/189479620-3e275a6d-4e6a-4203-9e45-8f69c54e5a21.png">
