### PR TITLE
fix: github workflow main/$default-branch distinction

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -8,13 +8,13 @@ on:
       branch:
         description: "Target branch against which to create requirements PR"
         required: true
-        default: '$default-branch'
+        default: 'main'
 
 jobs:
   call-upgrade-python-requirements-workflow:
     uses: openedx/.github/.github/workflows/upgrade-python-requirements.yml@master
     with:
-      branch: ${{ github.event.inputs.branch || '$default-branch' }}
+      branch: ${{ github.event.inputs.branch || 'main' }}
       # optional parameters below; fill in if you'd like github or email notifications
       user_reviewers: "feanil"
       # team_reviewers: ""


### PR DESCRIPTION
see https://github.com/openedx/docs.openedx.org/pull/134

see here: https://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization#creating-a-starter-workflow
> If you need to refer to a repository's default branch, you can use the $default-branch placeholder. When a workflow is created the placeholder will be automatically replaced with the name of the repository's default branch.

Reading between the lines, this indicates that `$default-branch` is a template feature, not a workflow file feature. The `$default-branch` gets read and interpolated at the time the template gets turned over into a workflow file, i.e. when the template gets used to create a new workflow. 
