### PR TITLE
feat: Add more dev guidance to the developer concept docs.

### DIFF
--- a/source/developers/concepts/index.rst
+++ b/source/developers/concepts/index.rst
@@ -5,3 +5,20 @@ Concepts Home
    :glob:
 
    *
+
+
+Other External Docs
+*******************
+
+.. list-table::
+
+   * - `Open edX Technology Radar <https://radar.thoughtworks.com/?sheetId=https%3A%2F%2Fopenedx.github.io%2Fopenedx-tech-radar%2Fopen-edx-primary-radar.csv>`_
+     - A bird's eye view of the decisions, tools and technologies that have been adopted or rejected for Open edX
+       development.
+
+   * - `Open edX Proposals <https://open-edx-proposals.readthedocs.io/en/latest/>`_
+     - Technical decisions made by the Open edX community, in the form of best practices, architecture design,
+       or development processes.
+
+   * - `Architecture and Engineering Confluence page <https://openedx.atlassian.net/wiki/spaces/AC/overview>`_
+     - Confluence page for notes, thoughts, and project-related documents on Open edX architecture and engineering.

--- a/source/developers/concepts/platform_overview.rst
+++ b/source/developers/concepts/platform_overview.rst
@@ -26,7 +26,7 @@ repositories.
   in two modes: LMS and Studio.
 
   As the LMS (Learning Management System), it acts as the backend
-  for learners' data as they go through courses and programs, and it serves some 
+  for learners' data as they go through courses and programs, and it serves some
   legacy UI elements.
 
   As Studio, it is the CMS(Content Management System) where instructors and
@@ -34,7 +34,7 @@ repositories.
 
 
 * frontend-platform - This is a newer core system meant to ease the creation of
-  multiple MFEs by bundling together many common utilities that all frontends 
+  multiple MFEs by bundling together many common utilities that all frontends
   need.  This includes things like authentication workflows, logging,
   monitoring and translations related tooling.
 
@@ -82,3 +82,40 @@ Template`_ based rendering pipelines to serve frontend content to users.
 .. _cs_comments_service: https://github.com/openedx/cs_comments_service
 .. _Django Template:
 .. _Mako: https://www.makotemplates.org/
+
+Adding new Features to the Open edX Platform
+********************************************
+
+If you're looking to add new features to the Open edX Platform, we recommned
+extending the platform rather than trying to make changes to the core.  Both
+XBlocks and Plugins are a great way to extend the platform.
+
+New XBlock
+==========
+
+XBlocks build on top of a well-defined interface in the Open edX platform and do not require review from the Open edX team.
+If you want to add a new problem type or content presentation that would be shown to a learner as a part of a course, you probably want to build a new XBlock.
+
+Before you do that, check out XBlocks `that others have built`_ in case they fulfill your needs.
+
+If you're ready to build one, check out our `Intro to XBlocks`_
+
+.. _that others have built: https://openedx.atlassian.net/wiki/spaces/COMM/pages/43385346/XBlocks+Directory
+.. _Intro to XBlocks: https://openedx.atlassian.net/wiki/spaces/PLAT/pages/33358554/XBlocks
+
+New Plugin
+==========
+
+Plugins can be built independently of the core platform and do not require review from the Open edX team to build or use.
+If you want to add a new feature outside of courseware (learner/educator/operator experience) a new platform plugin might be a great option for you.
+
+Check out `this overview of our Django plugin design <https://github.com/edx/edx-django-utils/blob/master/edx_django_utils/plugins/docs/decisions/0001-plugin-contexts.rst>`_ to get started.
+
+New update to the core platform
+===============================
+
+If we don't have extension points for the kind of change you want to make, you might need to make a change to the core source.
+This can be complex and we encourage you to `reach out to us`_ to talk about the kind of changes you want to make.
+
+.. _reach out to us: https://open.edx.org/community/connect/
+


### PR DESCRIPTION
This information is ported from the index.rst in the edx-developer-docs
project.  That project is pretty small once we move one or two more
things over from it we can archive that repo.
