### PR TITLE
docs: Add the openedx-proposals sub-project.

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -61,6 +61,12 @@ intersphinx_mapping = {
         f"https://docs.openedx.org/projects/donexblock/{rtd_language}/{rtd_version}",
         None,
     ),
+    "openedx-proposals": (
+        # Not setting the version on purpose because we always want the latest version
+        # of OEPs
+        f"https://docs.openedx.org/projects/openedx-proposals/{rtd_language}/latest",
+        None,
+    ),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/source/index.rst
+++ b/source/index.rst
@@ -38,7 +38,7 @@ Open edX Documentation
       Current Release: Nutmeg <https://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/nutmeg.html>
       All Release Notes <https://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/index.html>
       How to Contribute <https://openedx.atlassian.net/wiki/spaces/COMM/pages/941457737/How+to+start+contributing+to+the+Open+edX+code+base>
-      OEPs (Open edX Proposals): Community Decision Documents <https://open-edx-proposals.readthedocs.io/>
+      OEPs (Open edX Proposals): Community Decision Documents <https://docs.openedx.org/projects/openedx-proposals/en/latest/>
 
    ---
 


### PR DESCRIPTION
Add the intersphinx mapping to make it easier to reference specific OEPs
easier.

Unfortunately we can't put an intersphinx mapping into a toctree so we
just put a link to the subproject instead.
