### PR TITLE
fix: use correct logo path for sphinx favicon configuration

### DIFF
--- a/source/developers/how-tos/add-sphinx-docs-to-a-repo.rst
+++ b/source/developers/how-tos/add-sphinx-docs-to-a-repo.rst
@@ -133,7 +133,7 @@ Steps
       # If you'd like you can temporarily copy the logo file to your `_static`
       # directory.
       html_logo = "https://logos.openedx.org/open-edx-logo-color.png"
-      html_favicon = "https://logos.openedx.org/openedx-favicon.ico"
+      html_favicon = "https://logos.openedx.org/open-edx-favicon.ico"
 
       # Set the DJANGO_SETTINGS_MODULE if it's not set.
       if not os.environ.get('DJANGO_SETTINGS_MODULE'):


### PR DESCRIPTION
# Description
This PR fixes the favicon path for the add sphinx docs how-to.

# How to test
Try entering both URL(s). The current won't work without changing `openedx` for `open-edx`.