### PR TITLE
Make a dynamic link for the latest release

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -10,3 +10,4 @@ sphinx-copybutton
 sphinxcontrib-mermaid
 sphinxcontrib-images
 sphinxcontrib-contentui
+sphinxext-rediraffe

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -67,6 +67,7 @@ sphinx==4.5.0
     #   sphinxcontrib-contentui
     #   sphinxcontrib-images
     #   sphinxcontrib-yt
+    #   sphinxext-rediraffe
 sphinx-autobuild==2021.3.14
     # via -r requirements/base.in
 sphinx-book-theme==0.3.3
@@ -95,9 +96,11 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 sphinxcontrib-yt==0.2.2
     # via -r requirements/base.in
+sphinxext-rediraffe==0.2.7
+    # via -r requirements/base.in
 tornado==6.2
     # via livereload
 urllib3==1.26.14
     # via requests
-zipp==3.12.0
+zipp==3.12.1
     # via importlib-metadata

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,9 +4,11 @@
 #
 #    make upgrade
 #
+wheel==0.38.4
+    # via -r requirements/pip.in
+
+# The following packages are considered to be unsafe in a requirements file:
 pip==23.0
     # via -r requirements/pip.in
-setuptools==67.1.0
-    # via -r requirements/pip.in
-wheel==0.38.4
+setuptools==67.2.0
     # via -r requirements/pip.in

--- a/source/community/release_notes/old_releases.rst
+++ b/source/community/release_notes/old_releases.rst
@@ -1,7 +1,7 @@
 Older Open edX Releases
 #######################
 
-These are older releases of the Open edX Platform. they are no longer supported
+These are older releases of the Open edX Platform. They are no longer supported
 and if you are currently running them, it's recommended that you update to the
 latest supported release.
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -41,10 +41,15 @@ extensions = [
     "sphinx.ext.graphviz",
     "sphinxcontrib.mermaid",
     "sphinx.ext.intersphinx",
+    "sphinxext.rediraffe",
 ]
 
 # Extension Configuration
 graphviz_output_format = "svg"
+
+rediraffe_redirects = {
+    "community/release_notes/latest.rst": "community/release_notes/olive.rst",
+}
 
 # Intersphinx Extension Configuration
 DIGITS_ONLY = r"^\d+$"


### PR DESCRIPTION
We want to be able to dynamically point to the latest release. This allows us to have one url for "latest.html" which we can point to wherever we need.

- feat: Add a redirect extension.
- chore: Run `make upgrade`
