### PR TITLE
docs: Add a link to the old operators notes.

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -74,6 +74,10 @@ intersphinx_mapping = {
         f"https://docs.openedx.org/projects/openedx-oars/{rtd_language}/{rtd_version}",
         None,
     ),
+    "edx-installing-configuring-and-running": (
+        f"https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/{rtd_language}/{rtd_version}",
+        None,
+    ),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/source/site_ops/index.rst
+++ b/source/site_ops/index.rst
@@ -1,6 +1,14 @@
 Open edX Site Operators
 ########################
 
+.. note::
+
+   This area is still under active development.  You can find the old
+   documentation here: :doc:`edx-installing-configuring-and-running:index`
+
+   For information about the lastet release of the Open edX Platform, you can
+   check out the  :doc:`/community/release_notes/index`
+
 .. toctree::
    :glob:
 
@@ -8,3 +16,4 @@ Open edX Site Operators
    how-tos/index
    concepts/index
    references/index
+


### PR DESCRIPTION
We haven't had time to migrate these yet so link to the existing docs
for now.
