### PR TITLE
Add Olive.2 to list of release tags.

### DIFF
--- a/source/community/release_notes/named_release_branches_and_tags.rst
+++ b/source/community/release_notes/named_release_branches_and_tags.rst
@@ -50,6 +50,10 @@ Olive
      - 2022-12-12
      - open-release/olive.1
 
+   * - Olive.2
+     - 2023-02-09
+     - open-release/olive.2
+
 Nutmeg
 ~~~~~~
 


### PR DESCRIPTION
`open-release/olive.2` was released today. This adds the details to the table of release tags.