### PR TITLE
fix: Fix the button color contrast.

### DIFF
--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -1,3 +1,17 @@
+/*
+ * We need to override the color in the footer specifically because setting
+ * the color in the :root element doesn't work.  This custom.css is loaded befor
+ * the sphinx-design css file that it is meant to override.
+ *
+ * We shouldn't need this if https://github.com/executablebooks/sphinx-design/pull/124/files
+ * gets accepted upstream.
+ *
+ */
+.sd-card-footer {
+    --sd-color-primary: #0071bc;
+}
+
+
 div.toctree-wrapper p.caption {
   font-weight: 700;
   font-size: 1.2em;


### PR DESCRIPTION
The button is falling back to a sphinx-design color that is too light
compared to the white background to be WCAG compliant.  Explicitly set
the color for those buttons to be the same as the other links on the
page which are WCAG AA compliant with a ration of 5.13
