### PR TITLE
fix: fully qualify Diataxis URL

### DIFF
--- a/source/developers/how-tos/add-sphinx-docs-to-a-repo.rst
+++ b/source/developers/how-tos/add-sphinx-docs-to-a-repo.rst
@@ -170,4 +170,4 @@ Steps
    :doc:`/documentors/concepts/content_types`
       A quick summary on the different types of documents.
 
-.. _diataxis: diataxis.fr
+.. _diataxis: https://diataxis.fr


### PR DESCRIPTION
Visit https://docs.openedx.org/en/latest/developers/how-tos/add-sphinx-docs-to-a-repo.html?highlight=diataxis and notice links to Diataxis are broken

View fixed in https://docsopenedxorg--276.org.readthedocs.build/en/276/developers/how-tos/add-sphinx-docs-to-a-repo.html