### PR TITLE
fix: RST Quick Reference clarification on list indentation

### DIFF
--- a/source/documentors/quickstarts/first_documentation_pr.rst
+++ b/source/documentors/quickstarts/first_documentation_pr.rst
@@ -55,8 +55,8 @@ Click the :guilabel:`suggest edit` button to begin the process of changing the t
    :alt: A screenshot of the sample page with the 'suggest edit' link highlighted.
 
 
-Fork the repository(repo)
-*************************
+Fork the repository (repo)
+**************************
 
 If you have never made a pull request to this repo, you'll be asked to fork the
 repo.  A "fork" is essentially your own copy of the repository.
@@ -68,6 +68,7 @@ Go ahead and click the big green button!
 
 Make your fixes
 ***************
+
 Once you've clicked the fork button, you're ready to make your update in the
 web editor.
 
@@ -101,10 +102,11 @@ you want to take a look at your work.
 .. note::
 
    The GitHub "Preview" tab will not always show, or *render*, everything perfectly.
-   As you can see, the "Note" box, which shows fine on docs.openedx.org, does not render
-   correctly in the GitHub preview. Solutions to this problem are to install a local
-   development environment (How-To article TBD), or rely on the "pull request build",
-   discussed below.
+   As you can see, both the "Note" box and the part that starts with ``:doc:``, which
+   display correctly on docs.openedx.org, do not render correctly in the GitHub preview.
+
+   Solutions to this problem are to install a local development environment (How-To
+   article TBD), or rely on the "pull request build", discussed below.
 
 
 Save your changes

--- a/source/documentors/references/quick_reference_rst.rst
+++ b/source/documentors/references/quick_reference_rst.rst
@@ -44,6 +44,15 @@ This codeblock is used for the following published list:
 
 #. Item 2
 
+* Item 1
+
+  #. Sub-item 1
+  #. Sub-item 2
+   
+* Item 2
+
+See the `RST guide on lists <https://sublime-and-sphinx-guide.readthedocs.io/en/latest/lists.html>`_ for more detail.
+
 Linking
 *******
 

--- a/source/documentors/references/rst_samples/headings.txt
+++ b/source/documentors/references/rst_samples/headings.txt
@@ -5,6 +5,7 @@
    #########
 
    There should be only 1 Heading 1 per topic, as the topic title.
+   The underline must match the length of the text above it.
 
    Heading 2
    *********

--- a/source/documentors/references/rst_samples/nested_lists.txt
+++ b/source/documentors/references/rst_samples/nested_lists.txt
@@ -2,8 +2,14 @@
 
    #. Item 1
                            # Need this blank line between items and sub-items
-      * Sub-item 1         # Sub-items also need to be indented by 3 or more spaces
-      * Sub-item 2
+      * Sub-item 1         # Sub-items of ordered lists need to be indented by
+      * Sub-item 2         # 3 spaces
 
    #. Item 2
    
+   * Item 1
+
+     #. Sub-item 1         # Sub-items of unordered lists need to be indented
+     #. Sub-item 2         # by exactly 2 spaces
+   
+   * Item 2


### PR DESCRIPTION
Per https://sublime-and-sphinx-guide.readthedocs.io/en/latest/lists.html,
nesting inside ordered lists requires 3 spaces and nesting inside
unordered lists requires 2 spaces.
