### PR TITLE
docs: clean up heading symbols and minor fixes

### DIFF
--- a/source/community/release_notes/CSMHE/CSMHE_overview.rst
+++ b/source/community/release_notes/CSMHE/CSMHE_overview.rst
@@ -1,8 +1,7 @@
 .. _CSMH Overview:
 
-##########################################################################
 Overview of the ``courseware_studentmodulehistory`` Changes
-##########################################################################
+###########################################################
 
 This topic provides background information about the
 ``courseware_studentmodulehistory`` table and why a new database configuration
@@ -18,9 +17,8 @@ see :ref:`CSMHE Procedures`.
 .. note:: The changes described in this section are a part of the upgrade to
  the Open edX Eucalyptus release.
 
-****************************************************************
 What Is the ``courseware_studentmodulehistory`` Table?
-****************************************************************
+******************************************************
 
 The ``courseware_studentmodulehistory`` database table contains a record for
 each attempt that learners make to answer problem types that are implemented in
@@ -30,9 +28,8 @@ signed integer, and therefore has a maximum capacity of 2,147,483,647 records.
 
 .. _What Is the Issue:
 
-************************
 What Is the Issue?
-************************
+******************
 
 Typically, ``courseware_studentmodulehistory`` is the largest table in the
 database. It can be twice as large as the next largest table,
@@ -42,9 +39,8 @@ On the edx.org site, two records are written to this table every second. Before
 this table for edx.org reached even half of its maximum capacity, edX began to
 design a replacement with a higher capacity form.
 
-*******************************
 What Is the Replacement Table?
-*******************************
+******************************
 
 The new database table,
 ``coursewarehistoryextended_studentmodulehistoryextended``, uses a custom
@@ -54,9 +50,8 @@ which offers an exponentially larger storage capacity than the
 
 .. _Why Is A New Database Needed:
 
-********************************
 Why Is A New Database Needed?
-********************************
+*****************************
 
 By design, the ``coursewarehistoryextended_studentmodulehistoryextended`` table
 must be created in a new database, ``edxapp_csmh``. The new database will

--- a/source/community/release_notes/CSMHE/index.rst
+++ b/source/community/release_notes/CSMHE/index.rst
@@ -1,6 +1,5 @@
 .. _Replacing CSMH:
 
-########################################################
 Replacing the ``courseware_studentmodulehistory`` Table
 ########################################################
 

--- a/source/community/release_notes/CSMHE/migration_options.rst
+++ b/source/community/release_notes/CSMHE/migration_options.rst
@@ -1,8 +1,7 @@
 .. _Options for Updating Your Open edX Instances:
 
-##########################################################
 Options for Updating ``courseware_studentmodulehistory``
-##########################################################
+########################################################
 
 This topic outlines the options for updating to the new database and
 table configuration required by the ``courseware_studentmodulehistory`` change.
@@ -15,9 +14,8 @@ Because each Open edX installation has a unique set of constraints
 and requirements, edX recommends that you review all of these options before
 selecting one for your instance or instances.
 
-*******************************
 Keep, and Query, Both Tables
-*******************************
+****************************
 
 This option is suitable for many instances with small databases, such as a
 fullstack or small production instance, that do not have the performance
@@ -44,7 +42,6 @@ from both that table and the ``courseware_studentmodulehistory`` table in the
 
 For more information, see :ref:`CSMHE Procedures`.
 
-**************************************
 Reprovision or Reinstall Your Devstack
 **************************************
 
@@ -101,9 +98,8 @@ under the devstack directory.
 
 .. _Migrate All Data to One Table:
 
-******************************
 Migrate All Data to One Table
-******************************
+*****************************
 
 This option is suitable for installations that have a large number of records
 in the ``coursewarehistoryextended_studentmodulehistoryextended`` table, such

--- a/source/community/release_notes/CSMHE/migration_procedures.rst
+++ b/source/community/release_notes/CSMHE/migration_procedures.rst
@@ -1,6 +1,5 @@
 .. _CSMHE Procedures:
 
-############################################################
 Procedures for Replacing ``courseware_studentmodulehistory``
 ############################################################
 
@@ -18,17 +17,15 @@ Before you follow these procedures for your Open edX instance, be sure to
 review the different :ref:`options<Options for Updating Your Open edX
 Instances>` for updating ``courseware_studentmodulehistory``.
 
-*************************************
 Step 1: Create the Database
-*************************************
+***************************
 
 .. contents::
    :local:
    :depth: 2
 
-========================================
 Options for Creating the Database
-========================================
+=================================
 
 For all fullstack and production instances that follow master, you must create
 a MySQL database and set users up. To do so, you can use one of
@@ -48,7 +45,7 @@ these options.
 .. _Use the Playbook to Create the Database:
 
 Use the Playbook to Create the Database
-****************************************
+***************************************
 
 Follow the `create_db_and_users.yml playbook`_ to create the ``edxapp_csmh``
 database and its users automatically.
@@ -59,7 +56,7 @@ Database>` the ``edxapp_csmh`` database.
 .. _Create the Database Manually:
 
 Create the Database Manually
-*******************************
+****************************
 
 Create the MySQL database. For the edx.org and edX Edge instances, edX named
 this database ``edxapp_csmh``.
@@ -76,9 +73,8 @@ schemes.
 You then choose an option for :ref:`configuring<Options for Configuring the
 Database>` your new database.
 
-*************************************
 Step 2: Configure the Database
-*************************************
+******************************
 
 .. contents::
    :local:
@@ -86,9 +82,8 @@ Step 2: Configure the Database
 
 .. _Options for Configuring the Database:
 
-=====================================
 Options for Configuring the Database
-=====================================
+====================================
 
 After you create the MySQL database and set users up, you update
 ``lms.yml`` to add configuration settings to the DATABASES section. To do
@@ -112,7 +107,7 @@ so, you can use one of these options.
 .. _Update DATABASES Manually:
 
 Update DATABASES Manually
-**************************
+*************************
 
 If you create the MySQL database yourself, you configure the database by adding
 a clause to the ``lms.yml`` file.
@@ -133,9 +128,8 @@ a clause to the ``lms.yml`` file.
             "USER": "edxapp001"
         },
 
-*****************************************
 Step 3: Enable Writes to the New Table
-*****************************************
+**************************************
 
 Edit the ``lms.yml`` file to set the ``ENABLE_CSMH_EXTENDED`` feature
 flag.
@@ -147,9 +141,8 @@ flag.
 Alternatively, you can use your current Ansible overrides for updating feature
 flags to make this change.
 
-*************************************
 Step 4: Create the Table
-*************************************
+************************
 
 .. contents::
    :local:
@@ -157,9 +150,8 @@ Step 4: Create the Table
 
 .. _Options for Creating the Table:
 
-=====================================
 Options for Creating the Table
-=====================================
+==============================
 
 After you create and configure the MySQL database and enable the new table, you
 create the new table. To do so, you can use one of these options.
@@ -180,7 +172,7 @@ only writes records for interactions with CAPA problems to the
 .. _Run Migrations Manually:
 
 Run Migrations Manually
-**************************
+***********************
 
 A summary of the manual steps for running migrations follows.
 
@@ -194,9 +186,8 @@ If you choose to run migrations manually, refer to the last few lines of the
 for the commands that you must run.
 
 
-*************************************************************
 Optional Step 5: Migrate All Data to the New Table
-*************************************************************
+**************************************************
 
 After you complete all of the deployment steps (1-4) described above, you have
 the option to migrate all data from ``courseware_studentmodulehistory`` to
@@ -214,9 +205,8 @@ Table`.
 
 .. _Script Options for Migrating Data:
 
-=====================================
 Script Options for Migrating Data
-=====================================
+=================================
 
 EdX provides the following `migration scripts`_. You select the one that
 applies to your database architecture.
@@ -236,7 +226,7 @@ writes only to ``coursewarehistoryextended_studentmodulehistoryextended``. You
 can :ref:`restart<Restart a Migration>` either of the migrations if necessary.
 
 Run the Script for Separate Database Servers
-*********************************************
+********************************************
 
 EdX selected the database architecture with separate database servers, and
 implemented it by creating a read replica and then severing it from production.
@@ -271,9 +261,8 @@ Run ``migrate-same-database-instance.sh``.
 
 .. _Restart a Migration:
 
-======================
 Restart a Migration
-======================
+===================
 
 If you need to restart either migration, you can use the following command to
 find the largest ID value that was successfully inserted into the new table.
@@ -284,9 +273,8 @@ find the largest ID value that was successfully inserted into the new table.
 
 You can then rerun with MINID set to the result of this query.
 
-====================================
 Disable Reads from the Old Table
-====================================
+================================
 
 Edit the ``lms.yml`` file to set the
 ``ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES`` feature flag.
@@ -299,9 +287,8 @@ After you bring your servers back online with this configuration, the system
 only writes to and queries from the
 ``coursewarehistoryextended_studentmodulehistoryextended`` table.
 
-====================================
 Truncate the Old Table
-====================================
+======================
 
 Select one of the available MySQL techniques for slowly draining the
 ``courseware_studentmodulehistory`` table.

--- a/source/community/release_notes/birch.rst
+++ b/source/community/release_notes/birch.rst
@@ -1,6 +1,5 @@
-####################################
 Open edX Birch Release
-####################################
+######################
 
 This page lists the highlights of the Birch release.
 
@@ -13,61 +12,53 @@ This page lists the highlights of the Birch release.
  :depth: 1
  :local:
 
-************************
 Split Mongo Modulestore
-************************
+***********************
 
 The edX Platform now supports the **split mongo** modulestore for course data
 storage. Split mongo refers to the separation of identity, structure, and
 content, and it enables you to use more advanced capabilities in developing and
 managing courses.
 
-************************************
 Cohorts for Discussions and Content
-************************************
+***********************************
 
 You can now define smaller communities of students within the larger, course-
 wide community. Learners in a cohort can have private discussions. In addition,
 you can create different course experiences, including presenting different
 content, for students in different cohorts.
 
-*****************************************
-Content Libraries and Randomized Content 
-*****************************************
+Content Libraries and Randomized Content
+****************************************
 
 You can now create a content library that contains a pool of components that
 can be used in randomized assignments.
 
-********************
 Prerequisite Courses
 ********************
 
 You can now require that students pass a specific course before they enroll in
 your course.
 
-********************
 Entrance Exams
-********************
+**************
 
 You can now require that students pass an entrance exam before they access your course materials.
 
-******************** 
 Student Notes
-********************
+*************
 
 A learner can highlight text and make notes while progressing through a course.
 The learner can then review his notes in the body of the course or on a
 separate Notes tab.
 
-********************
 Course Reruns
-********************
+*************
 
 You can create a new course easily by re-running an existing course. When you
 re-run a course, most, but not all, of the original course content is
-copied into the new course. 
+copied into the new course.
 
-*******************************************
 Google Calendar and Google Drive Components
 *******************************************
 
@@ -75,18 +66,16 @@ You can embed Google calendars and Google Drive files in your course. Learners
 see the calendar or file directly in the courseware. Learners can also interact
 with Google Forms files, completing forms or surveys.
 
-**************************************************
 Support for Graded Problems in Content Experiments
 **************************************************
 
 Content experiments can now include graded problems.
 
-********** 
 REST APIs
-**********
+*********
 
 EdX has built and published documentation for the first versions of several
-REST APIs: 
+REST APIs:
 
 * Mobile API
 * Enrollment API

--- a/source/community/release_notes/bulk_email.rst
+++ b/source/community/release_notes/bulk_email.rst
@@ -1,8 +1,7 @@
 .. _Enable Bulk Email:
 
-################################
 Enabling the Bulk Email Feature
-################################
+###############################
 
 This section describes a change to the process for enabling or disabling the
 bulk email feature. This change was released to the edx-platform repository on
@@ -14,9 +13,8 @@ procedure described in this section.
    :local:
    :depth: 1
 
-**********************
 About This Change
-**********************
+*****************
 
 Prior to this change, you enabled or disabled the bulk email feature by making
 manual updates to several files, including the ``lms/envs/common.py`` Python
@@ -29,7 +27,6 @@ file. The two relevant settings in the FEATURES section of this file were
 To simplify the process of changing the bulk email settings, a **Bulk_Email**
 option is now available in the Django administration console.
 
-*******************************
 Changing the Bulk Email Setting
 *******************************
 

--- a/source/community/release_notes/cypress.rst
+++ b/source/community/release_notes/cypress.rst
@@ -1,8 +1,7 @@
 .. _Open edX Cypress Release:
 
-####################################
 Open edX Cypress Release
-####################################
+########################
 
 This page lists the highlights of the Cypress release.
 
@@ -15,9 +14,8 @@ This page lists the highlights of the Cypress release.
  :depth: 1
  :local:
 
-**************
 New Features
-**************
+************
 
 The following new features are included in the Open edX Cypress release.
 
@@ -25,9 +23,8 @@ The following new features are included in the Open edX Cypress release.
  :depth: 1
  :local:
 
-=========
 Badges
-=========
+======
 
 Badges provide a way for learners to share their course achievements. For
 courses that have badges enabled, learners receive a badge when they receive a
@@ -38,9 +35,8 @@ Open edX supports Open Badges, an open standard originally developed by the
 Mozilla Foundation. For more information about Open Badges, see
 http://openbadges.org/.
 
-=========
 Cohorts
-=========
+=======
 
 Course teams now create and manage cohorts on the Instructor Dashboard in the
 LMS, instead of on the **Advanced Settings** page in Studio. Course teams can
@@ -48,9 +44,8 @@ use the new Cohorts page there to add and rename cohorts, change a cohort's
 assignment method, associate cohorts with content groups, and specify whether
 course-wide and content-specific discussions are divided by cohort.
 
-==========================
 Course Certificates
-==========================
+===================
 
 You can now create one certificate configuration per course. This configuration
 serves as the template for certificates issued for all of the enrollment tracks
@@ -58,9 +53,8 @@ available for your course (such as "honor code" or "verified"). Honor code
 certificates use the organization logo and signatory information, but do not
 include signature images, which are used only for verified certificates.
 
-==========================
 Course Search
-==========================
+=============
 
 Learners can now search much of the content of your Open edX courses, including
 the course title, description, text, and video transcripts. Learners can search
@@ -71,25 +65,22 @@ When the search engine returns results, either for an individual course or
 across all courses, you can select any search result to view that result in the
 courseware.
 
-=====================
 Creative Commons
-=====================
+================
 
 Course teams can now specify either "All Rights Reserved" or a Creative Commons
 license for a course. Course teams can also select different license options
 for each video.
 
-=====================
 Custom Courses
-=====================
+==============
 
 Course teams can create a custom course experience (CCX) to reuse
 course content. By using a CCX, course teams can run some or all of an existing
 course for a group of students on a new schedule.
 
-====================================================
 Grade Report Enhancements
-====================================================
+=========================
 
 The grade report now includes new columns with certificate status and
 enrollment track information. When course teams generate the grade report from
@@ -101,19 +92,17 @@ each learner.
 
 * Verification status, to identify learners in the verified or professional
   track who have completed identity verification with edX.
-
 * Certificate eligibility status, to identify learners who have earned the
   passing grade in the course at the time of the grade report generation.
 
 * Certificate delivery status, to identify learners who have received their
-  certificates. 
+  certificates.
 
 * The type of certificate, for learners who are eligible to receive a
   certificate.
 
-======================================
 Feedback and Hints in Common Problems
-======================================
+=====================================
 
 Course teams can now add feedback, hints, or both to the following problem
 types.
@@ -127,7 +116,6 @@ types.
 In Studio, course teams can use new templates to add sample problems that use
 the feedback and hint syntax.
 
-==========================
 HTML Spell Check in Studio
 ==========================
 
@@ -135,9 +123,8 @@ When you edit an HTML component in Studio, an automated spell checker indicates
 any misspelled words. The spell checker automatically uses the dictionary that
 is set for your browser.
 
-=====================
 Learner Profiles
-=====================
+================
 
 With the new Open edX Learner Profile feature, course teams and learners can
 share information about themselves with the community. The profile can include
@@ -145,9 +132,8 @@ an image that identifies the user on the Open edX site as well as the
 user's location and other biographical information. Course teams and other
 learners in the course can view others' profiles.
 
-=============
 LTI Provider
-=============
+============
 
 New options that leverage learning tools interoperability (LTI) are available
 in this release.
@@ -166,17 +152,15 @@ Authentication between the campus system and the edX system that provides the
 content can be configured either to anonymously provision students or to prompt
 for account creation.
 
-==========================
 New Studio Templates
-==========================
+====================
 
 This release includes new templates for HTML and problem components. These
 templates provide updated guidelines and examples, accessibility information,
 and links to documentation.
 
-======================================================
 Original Open Response Assessment Problems Deprecated
-======================================================
+=====================================================
 
 When you access a course that contains an open response assessment created
 using the original version of this assignment type (ORA 1), Studio now displays
@@ -186,43 +170,37 @@ A newer version of the open response assessments feature (ORA 2) was released
 over a year ago, and the ability to add ORA 1 problems was removed from Studio
 in May 2014.
 
-=====================
 Poll and Survey Tools
 =====================
 
 Course teams can now include two new types of components in courses.
-
-* Use the Poll tool to pose a question to learners and have them select an
+ Use the Poll tool to pose a question to learners and have them select an
   answer from a set list.
-
-* Use the Survey tool to pose multiple questions to learners and have them
+ Use the Survey tool to pose multiple questions to learners and have them
   select an answer for each question from a set list.
 
 When polls and surveys are included in a course, course teams can analyze the
 responses and also choose whether to let learners see the aggregate answers for
 the class.
 
-======================================
 Problem Appearance Changes
-======================================
+==========================
 
 To make the Open edX LMS easier to use on mobile devices, the appearance of
 common problem types has changed. For example, a border surrounds options for
 multiple choice and checkbox problems, and the entire area within the border is
 selectable, making it easier for learners to select an option.
 
-==========================
 Problem Grade Report
-==========================
+====================
 
 For any course, course teams can now calculate grades for problems and generate
 a report that can be downloaded from the Instructor Dashboard. This new report
 includes, for each graded problem, a learner's earned and possible points, and
 her total score, expressed as a decimal.
 
-==========================
 Randomized Content Blocks
-==========================
+=========================
 
 Course teams can now include a new type of component, a randomized content
 block, in their courses. These components randomly draw problems from a
@@ -233,18 +211,16 @@ courses. All of an organization's course teams can work collaboratively to
 develop the problems that the libraries contain. Each library can then be
 referenced by randomized content blocks in any of that organization's courses.
 
-====================================================
 Report of Not-Yet Enrolled Students
-====================================================
+===================================
 
 Course teams for invitation-only courses can now track enrollment status from
 the Instructor Dashboard. The Data Download page of the Instructor Dashboard
 now includes a downloadable report of learners who have been invited to enroll
 in a course, but who have not yet done so.
 
-======================================
 Third Party Authentication
-======================================
+==========================
 
 To enhance sign in options for your users, you can enable third party
 authentication between institutional authentication systems and your
@@ -252,7 +228,6 @@ implementation of Open edX. After you enable third party authentication and
 integrate with SAML or OAuth2 identity providers, users can register and sign
 in to your Open edX site with their campus or institutional credentials.
 
-===================================================
 Uploading ORA2 Files to Alternative Storage Systems
 ===================================================
 
@@ -263,7 +238,7 @@ With the Cypress release, you can configure ORA2 to store files in an alternate
 system. To have learners' files stored in a system other than Amazon S3, you
 must complete the following steps.
 
-#. Implement the ``BaseBackend`` class defined in the `base.py`_ file. 
+#. Implement the ``BaseBackend`` class defined in the `base.py`_ file.
 
    For example, the `S3.py`_ file in the same directory is an implementation of
    ``BaseBackend`` for Amazon S3. You must implement the equivalent class for
@@ -285,9 +260,8 @@ must complete the following steps.
 .. _init file: https://github.com/openedx/edx-ora2/blob/a4ce7bb00190d7baff60fc90fb613229565ca7ef/openassessment/fileupload/backends/__init__.py
 
 
-==========================================
 YouTube API 3.0 API Key
-==========================================
+=======================
 
 The Open edX Platform uses Version 3 of the YouTube API, which requires that
 the application use an API key.
@@ -296,9 +270,8 @@ If you intend for courses on your Open edX instance to include videos that are
 hosted on YouTube, you must get a YouTube API key and set the key in the Open
 edX Platform.
 
-*****************
 REST API Changes
-*****************
+****************
 
 EdX has built and published documentation for the following REST APIs, which
 are available in the Open edX Cypress release.
@@ -309,9 +282,8 @@ are available in the Open edX Cypress release.
 
 * Profile Images API Version 1.0
 
-*************
 New Events
-*************
+**********
 
 The following list includes new or changed events in the Open edX Cypress
 release.
@@ -347,9 +319,8 @@ For more information about events, see :ref:`Event Reference`. Note that this do
 courses on edx.org. However, the event listing applies to Open edX instances as
 well.
 
-************************************************
 Accessibility Updates
-************************************************
+*********************
 
 In keeping with edX's commitment to creating accessible content for everyone,
 everywhere, the Open edX Cypress release contains several accessibility
@@ -357,7 +328,7 @@ enhancements in the Open edX LMS and discussions.
 
 * Keyboard navigation in open response assessments has been improved by
   restoring keyboard focus outline indicators.
-  
+
 * The LMS now has a region with a role of main and a descriptive aria-label
   allowing users to quickly navigate to the main content area using landmarks.
 
@@ -369,7 +340,7 @@ enhancements in the Open edX LMS and discussions.
 
 * The workflow for checking how ASCII math is converted to MathML or MathJax
   format has been streamlined for screen reader users.
-  
+
 * Nonessential information is no longer included in aria-live regions, which
   improves the experience for screen reader users.
 
@@ -382,7 +353,7 @@ enhancements in the Open edX LMS and discussions.
 * The main blue colors used throughout the LMS user interface
   were changed to meet WCAG AA guidelines for contrast.
 
-* The LMS now includes an aria-live region to contain HTML for problems. 
+* The LMS now includes an aria-live region to contain HTML for problems.
 
 * Submission buttons have been removed from the aria-live div scope.
 
@@ -412,9 +383,8 @@ enhancements in the Open edX LMS and discussions.
   navigation. The focus is on the discussion when a new topic is loaded, and
   changes to a new post when it appears.
 
-************************************************
 Supported Browser Changes
-************************************************
+*************************
 
 Note that in this release the edX platform no longer supports Internet Explorer
 9.x.

--- a/source/community/release_notes/dogwood.rst
+++ b/source/community/release_notes/dogwood.rst
@@ -1,8 +1,7 @@
 .. _Open edX Dogwood Release:
 
-####################################
 Open edX Dogwood Release
-####################################
+########################
 
 This page lists the highlights of the Dogwood release.
 
@@ -15,9 +14,8 @@ This page lists the highlights of the Dogwood release.
  supported. This page remains in these release notes as a record of when new
  features were included in Open edX.
 
-**************
 New Features
-**************
+************
 
 The following new features are included in the Open edX Dogwood release.
 
@@ -25,7 +23,6 @@ The following new features are included in the Open edX Dogwood release.
  :depth: 1
  :local:
 
-==============
 New LTI XBlock
 ==============
 
@@ -44,9 +41,8 @@ embedded in a course page.
 For more information, see opencoursestaff:LTI Component in the *Building
 and Running an Open edX Course* guide.
 
-=====================================
 Course Preview as a Specific Learner
-=====================================
+====================================
 
 A new preview mode in the LMS allows course team members to see the courseware
 as a specific learner sees it. For courses that use randomized content
@@ -57,9 +53,8 @@ necessary.
 For more information, see the Grades section in *Building and
 Running an Open edX Course*.
 
-=================
 Partial Credit
-=================
+==============
 
 In Studio, course teams can now configure the following problem types so that
 learners can receive partial credit for a problem if they submit an answer that
@@ -73,9 +68,8 @@ is partly correct.
 For more information, see Awarding Partial Credit for a
 Problem in *Building and Running an Open edX Course*.
 
-====================================
 Open edX Analytics Developer Stack
-====================================
+==================================
 
 Developers who are interested in extending Open edX Insights can now set up a
 separate development environment, the Open edX Analytics Developer stack, to
@@ -89,9 +83,8 @@ edX Platform* guide.
 .. note:: EdX does not currently provide installation or support of Insights
  for Open edX installations.
 
-=========================================
 Initial Version of Comprehensive Theming
-=========================================
+========================================
 
 The initial version of comprehensive theming is now available. Sites that are
 running Open edX can now create and use themes to change the default branding
@@ -103,9 +96,8 @@ without coding changes.
 For more information, see Changing the Way Open edX Looks
 in the *Installing, Configuring, and Running the Open edX Platform* guide.
 
-========================================================
 Additional File Types for Open Response Assessments
-========================================================
+===================================================
 
 Course teams can now specify, and learners submit, additional types of files
 along with text responses to open response assessment problems. When course
@@ -127,9 +119,8 @@ file types that learners cannot upload.
 For more information, see
 Configuring ORA2 to Prohibit Submission of File Types.
 
-===============
 Certificates
-===============
+============
 
 This release includes several updates to web certificates.
 
@@ -157,7 +148,6 @@ in progress to move all existing course certificate tools and logic to this new
 service. Be sure to watch for more changes in the Eucalyptus release and other
 future Open edX releases.
 
-===========================
 Search Feature for DevStack
 ===========================
 
@@ -166,9 +156,8 @@ enabled by default. For more information about how you can configure this
 feature, see Enable edX Search. For more information about
 how learners can use this feature, see SFD Search.
 
-=========================
 Timed Exams Feature
-=========================
+===================
 
 This release includes the timed exams feature. Course teams can configure a
 course subsection so that learners have a specific period of time to complete
@@ -186,17 +175,15 @@ the *Building and Running an Open edX Course* guide.
 
 .. _Otto Ecommerce Service:
 
-=======================
 E-commerce Service
-=======================
+==================
 
 Open edX installations can now add an e-commerce service. The edX
 `e-commerce service`_ is a Django application that manages and handles
 orders for product catalogs.
 
-=========================================
 TPA Sign In Without Account Activation
-=========================================
+======================================
 
 Learners who register and sign in using third party authentication, such as
 with a Google or Facebook account, can now sign in immediately. They can sign
@@ -208,9 +195,8 @@ A learner who enters an incorrect email address, and who therefore does not
 receive the activation email message, can correct the email address by
 selecting the menu next to his username, and then selecting **Account**.
 
-==========================================================
 Consistent Team Role Names in Studio and LMS
-==========================================================
+============================================
 
 The labels that identify two of the course team member roles in the LMS now
 match the labels for those same roles in Studio. In the LMS, on the Instructor
@@ -224,25 +210,22 @@ Running an Open edX Course* guide.
 .. note:: No changes were made to the privileges that system administrators
   set in the Django admin console, or to their labels.
 
-====================================================
 Icon Change for Graded Subsections
-====================================================
+==================================
 
 In the LMS, the icon that indicates a graded subsection in the course
 navigation is now a paper and pencil symbol instead of an alarm clock.
 
-=========================================
 Command Change for SAML Testing
-=========================================
+===============================
 
 The recent edX platform upgrade to Django 1.8 required a change to the
 management command used when testing an enabled SAML
 identity provider. This command now uses the
 syntax ``lms saml --pull`` instead of ``lms saml pull``.
 
-**************************
 New and Changed Events
-**************************
+**********************
 
 The following list includes new or changed events in the Open edX Dogwood
 release.
@@ -264,9 +247,8 @@ release.
 
 For more information about these events, see :ref:`Event Reference`.
 
-***********************
 Accessibility Updates
-***********************
+*********************
 
 In keeping with edX's commitment to creating accessible content for everyone,
 everywhere, the Open edX Dogwood release contains numerous accessibility
@@ -300,9 +282,8 @@ enhancements and improvements to readability and navigability.
 * Keyboard navigation in open response assessments was improved by restoring
   keyboard focus outline indicators.
 
-===================================
 Design Updates to the Video Player
-===================================
+==================================
 
 This release includes several updates to the edX video player.
 
@@ -321,9 +302,8 @@ This release includes several updates to the edX video player.
 * To enhance the experience of learners who use screen readers, changes that
   improve spoken announcements and simplify navigation are also included.
 
-*********************
 Deprecated Features
-*********************
+*******************
 
 Several features are deprecated as of the Open edX Dogwood release.
 
@@ -331,9 +311,8 @@ Several features are deprecated as of the Open edX Dogwood release.
  :depth: 1
  :local:
 
-=============
 Shoppingcart
-=============
+============
 
 The "shoppingcart" functionality is deprecated as of the Dogwood release, and
 it will be removed in a future release. Similar services are now provided by
@@ -343,17 +322,15 @@ the Otto Ecommerce Service.
 .. Removed support for the outdated ``ispublic`` field on the Course Module, including its corresponding ACCESS_REQUIRE_STAFF_FOR_COURSE feature flag.  Instead, operators should use COURSE_CATALOG_VISIBILITY_PERMISSION and COURSE_ABOUT_VISIBILITY_PERMISSION settings.
 
 
-==================
 Studio Checklist
-==================
+================
 
 The **Tools** menu in Studio no longer offers the **Checklists** option. For a
 template checklist, see the Course Launch Checklist
 topic in the *Building and Running an Open edX Course* guide.
 
-=========================
 Original ORA Problems
-=========================
+=====================
 
 When you access a course that contains an open response assessment created
 using the original version of this assignment type (ORA 1), Studio now
@@ -363,9 +340,8 @@ A newer version of the open response assessments feature (ORA 2) was released
 over a year ago, and the ability to add ORA 1 problems was removed from Studio
 in May 2014.
 
-============================
 Legacy Instructor Dashboard
-============================
+===========================
 
 Support has ended for the "legacy" Instructor Dashboard. The Legacy Instructor
 Dashboard is now disabled by default, and the LMS presents a single version of
@@ -380,9 +356,8 @@ to download a report of all learner submissions for a specified problem.
 Previously, this report was available only from the Legacy Instructor Dashboard
 through a view on a Django app.
 
-============================
 XModules and Tools
-============================
+==================
 
 The following XModules and tools are deprecated in the Dogwood release.
 
@@ -393,9 +368,8 @@ The following XModules and tools are deprecated in the Dogwood release.
 * Support has ended for the graphical_slider_tool. Code for this tool will
   be removed entirely in the Open edX Eucalyptus release.
 
-============
 Django Apps
-============
+===========
 
 The following Django apps are deprecated in the Dogwood release.
 
@@ -403,7 +377,6 @@ The following Django apps are deprecated in the Dogwood release.
 
 * The Licenses Django app.
 
-==================
 Wiki Notifications
 ==================
 
@@ -411,16 +384,15 @@ The recent edX platform upgrade to Django 1.8 required edX to deprecate the
 wiki notifications feature. The wiki notifications feature was disabled to make
 the Django 1.8 upgrade possible, and this feature has not been reimplemented.
 
-********************
 Django 1.8 Upgrade
-********************
+******************
 
 The edX platform was upgraded from Django 1.4 to Django 1.8.7. This section
 summarizes the effects of this upgrade.
 
-==================
 Transactions
-==================
+============
+
 
 * For Django 1.8, edX recommends that you use the ``transaction.atomic``
   decorator to start transactions for the code. For more information, see the
@@ -446,9 +418,9 @@ Transactions
 .. _Database Transactions: https://docs.djangoproject.com/en/1.8/topics/db/transactions
 .. _Django website: https://www.djangoproject.com
 
-==================
 Model Migrations
-==================
+================
+
 
 * All Django Python South schema migrations have been incorporated into each
   initial "0001" Django schema migration.
@@ -456,7 +428,6 @@ Model Migrations
 * Data migrations that seed data are now idempotent. All other data migrations
   have been discarded.
 
-==================
 Model Meta Classes
 ==================
 
@@ -465,9 +436,8 @@ more information, see `app_label`_ on the `Django website`_.
 
 .. _app_label: https://docs.djangoproject.com/en/1.8/ref/models/options/#app-label
 
-==================
 More Information
-==================
+================
 
 To view the release notes for Django versions 1.5—1.8, see the following
 resources.
@@ -482,11 +452,9 @@ resources.
 .. _Django 1.7: https://docs.djangoproject.com/en/1.8/releases/1.7
 .. _Django 1.8: https://docs.djangoproject.com/en/1.8/releases/1.8
 
-**************
 Patch Releases
 **************
 
-=======================
 9 March 2016: Dogwood.1
 =======================
 
@@ -496,7 +464,6 @@ Patch Releases
   *Building and Running an Open edX Course* guide.
 
 
-========================
 14 April 2016: Dogwood.2
 ========================
 
@@ -511,7 +478,6 @@ Patch Releases
 * A number of security issues are fixed.
 
 
-========================
 25 April 2016: Dogwood.3
 ========================
 

--- a/source/community/release_notes/eucalyptus.rst
+++ b/source/community/release_notes/eucalyptus.rst
@@ -1,8 +1,7 @@
 .. _Open edX Eucalyptus Release:
 
-####################################
 Open edX Eucalyptus Release
-####################################
+###########################
 
 This page lists the highlights of the Eucalyptus release.
 
@@ -16,9 +15,8 @@ This page lists the highlights of the Eucalyptus release.
  :depth: 1
  :local:
 
-**************
 New Features
-**************
+************
 
 The following new features are included in the Open edX Eucalyptus release.
 
@@ -26,16 +24,14 @@ The following new features are included in the Open edX Eucalyptus release.
  :depth: 1
  :local:
 
-================================
 Self-Paced Course Configuration
-================================
+===============================
 
 When course teams create a course, they can now select the way a course is
 delivered to learners. You can set a schedule for the course, including due
 dates for assignments or exams, or you can specify that the course is
 self-paced, which allows learners to work at their own pace.
 
-========================
 Subsection Prerequisites
 ========================
 
@@ -43,7 +39,6 @@ Course teams can now control the visibility of subsections based on the scores
 that learners earn in other subsections. This feature prevents learners from
 viewing content before they earn a minimum score for previous content.
 
-=================
 Course Navigation
 =================
 
@@ -60,7 +55,6 @@ Several changes have been made to navigation options in the LMS.
 * Learners can now use the left and right arrow buttons at the ends of the unit
   navigation bar to move to the previous unit or the next unit.
 
-=====
 Teams
 =====
 
@@ -69,22 +63,19 @@ a team and invite other learners to take part in group activities relating to
 one of the topics. Team activities provide opportunities for small group
 interactions and projects in your course.
 
-=========
 Bookmarks
 =========
 
 The bookmarks feature allows a learner to add a bookmark to any unit in the LMS
 so that the page can be found later on the **My Bookmarks** page.
 
-=================================
 Drag and Drop Problem XBlock
-=================================
+============================
 
 A new, mobile-ready and accessible drag and drop problem type is now available.
 This version replaces the original drag and drop problem type, which is now
 deprecated.
 
-=======================
 Peer Instruction XBlock
 =======================
 
@@ -93,14 +84,12 @@ Instruction learning system. A multiple choice question gives online learners
 an opportunity to review the answers, and rationales, provided by other course
 participants, and arrive at a deeper understanding of concepts.
 
-=============================
 Completion XBlock
-=============================
+=================
 
 The completion XBlock adds a toggle control that allows learners to mark the
 associated section of course content as complete.
 
-=============================
 CourseTalk for Course Reviews
 =============================
 
@@ -109,7 +98,6 @@ then appear on the course's **About** page. When you add the CourseTalk widget
 to an Open edX instance, the widget is enabled for every course on that
 instance.
 
-==================================
 Configurable Data Storage Services
 ==================================
 
@@ -119,15 +107,13 @@ addition to S3, you can now configure an OpenStack Swift Object Store as the
 cloud storage provider for certain system features.
 
 
-==========================
 Themes for Multiple Sites
-==========================
+=========================
 
 With this release, it is now possible to configure themes for multiple sites in
 a single installation of the Open edX platform.
 
 
-===================================================
 Staff Grading Options for Open Response Assessments
 ===================================================
 
@@ -143,15 +129,13 @@ responses in open response assessments.
   evaluate the learner's response. The learner's grade for the assignment is
   updated to the grade that results from the staff assessment.
 
-====================================
 Learner ORA Response Report
-====================================
+===========================
 
 A new report is available for ORA assignments that includes each learner's
 response, assessment details and scores, the final score for the assignment,
 and any feedback provided by the learner about the peer assessment process.
 
-==============================
 Updates to E-Commerce Checkout
 ==============================
 
@@ -160,7 +144,6 @@ that is presented by the edX e-commerce service. The functionality of this
 page has not changed, and learners can continue to check out using their credit
 cards or PayPal.
 
-===============================
 Badges for Custom Course Events
 ===============================
 
@@ -169,9 +152,8 @@ milestone achievements. Example achievements include enrolling in a certain
 number of courses, completing a certain number of courses, or completing a
 specific set of courses.
 
-===============================
 Updates to Course Discussions
-===============================
+=============================
 
 This release includes the following changes to course discussions.
 
@@ -212,32 +194,28 @@ This release includes the following changes to course discussions.
   their Open edX instances. Fields can be of different types, including
   dropdown and text entry.
 
-=====================
 Updates to Bulk Email
 =====================
 
 The way the bulk email feature is enabled and disabeld has change, see
 :doc:`bulk_email` for more details.
 
-***************************************************
 Updates to Analytics Events and Database Tables
-***************************************************
+***********************************************
 
 .. contents::
  :depth: 1
  :local:
 
-=====================================================
 Changes to ``courseware_studentmodulehistory`` Table
-=====================================================
+====================================================
 
 There were significant changes to how we manage the
 ``courseware_studentmodulehistory`` table in the LMS and CMS.  Please see
 :doc:`CSMHE/index` for more information.
 
-=============================
 New Non-Certificate Statuses
-=============================
+============================
 
 The ``audit_notpassing`` and ``audit_passing`` statuses have been added to the
 ``certificates_generatedcertificate`` table.
@@ -252,9 +230,8 @@ No certificate is generated for learners who have either of these statuses.
 Learners who are enrolled in the audit track see a message on the **Progress**
 page that indicates that the audit track does not include a certificate.
 
-==============================================
 New and Updated Video Player Events
-==============================================
+===================================
 
 Changes to the video player's controls resulted in the following new and
 updated events.
@@ -277,9 +254,8 @@ updated events.
   ``edx.video.language_menu.hidden`` events include a new ``event`` member
   field, ``language``.
 
-=======================
 New Events
-=======================
+==========
 
 The following analytics events reflect course navigation actions in the LMS.
 
@@ -322,9 +298,8 @@ response assessments.
 * ``openassessmentblock.staff_assess``
 
 
-***********************
 Accessibility Updates
-***********************
+*********************
 
 In keeping with edX's commitment to creating accessible content for everyone,
 everywhere, the Open edX Eucalyptus release contains numerous accessibility
@@ -334,9 +309,8 @@ enhancements and improvements to readability and navigability.
  :depth: 1
  :local:
 
-===================
 Video Player
-===================
+============
 
 The video player now includes closed captions, which are overlaid on the video
 while it plays. Users can view closed captions and transcripts separately or at
@@ -344,9 +318,8 @@ the same time. Those who choose to view the closed captioning for a video can
 drag the captions to a different place on the video. In addition, the video
 player now includes accessible labels for every control.
 
-==========================
 HTML Component Templates
-==========================
+========================
 
 To ensure that all headings on a course page in the LMS are rendered correctly
 by screen readers, the Heading 1 and Heading 2 options have been removed from
@@ -384,9 +357,9 @@ accessibility of controls in the edX LMS.
   **Edit**, and **Settings**, now appear next to, rather than in, the shaded
   area below the article.
 
-*******************************
 System Upgrades and Updates
-*******************************
+***************************
+
 
 * You can now enable or disable the bulk email feature from the Django
   administration console, rather than editing different configuration files.
@@ -417,9 +390,8 @@ System Upgrades and Updates
 * JavaScript tests are now run using Karma rather than JS-Test-Tool.
 
 
-***********************
 Mobile App Updates
-***********************
+******************
 
 The Open edX Eucalyptus release supports versions 2.5.1 (Android) and 2.5.3
 (iOS) of the mobile app, and includes the following mobile app features.
@@ -443,9 +415,8 @@ The Open edX Eucalyptus release supports versions 2.5.1 (Android) and 2.5.3
   multiple choice, text input, and numerical input).
 
 
-*********************
 Deprecated Features
-*********************
+*******************
 
 Several features are deprecated, or deleted, by the Open edX Eucalyptus
 release.
@@ -454,7 +425,6 @@ release.
  :depth: 1
  :local:
 
-====================
 Deprecated REST APIs
 ====================
 
@@ -467,7 +437,6 @@ deprecated.
 * Use the ``/api/user/v1/accounts/`` web service instead of the deprecated
   profile image web service.
 
-==================================
 Deprecated Tools and Problem Types
 ==================================
 
@@ -478,9 +447,8 @@ Deprecated Tools and Problem Types
 * The original drag and drop problem type is now deprecated. A new mobile-
   ready, accessible drag and drop problem type is available.
 
-==============================
 Deleted Tools and XModules
-==============================
+==========================
 
 * The graphical slider tool is no longer available.
 
@@ -493,11 +461,9 @@ Deleted Tools and XModules
 * The ``ENABLE_JWT_AUTH`` feature flag has been removed.
 
 
-**************
 Patch Releases
 **************
 
-==============================
 2 September 2016: Eucalyptus.2
 ==============================
 

--- a/source/community/release_notes/ficus.rst
+++ b/source/community/release_notes/ficus.rst
@@ -1,6 +1,5 @@
 .. _Open edX Ficus Release:
 
-######################
 Open edX Ficus Release
 ######################
 
@@ -10,7 +9,6 @@ This page lists the highlights of the Ficus release.
  :depth: 1
  :local:
 
-************
 New Features
 ************
 
@@ -21,7 +19,6 @@ The Open edX Ficus release includes the following updates.
  :local:
 
 
-===
 LMS
 ===
 
@@ -36,7 +33,6 @@ LMS
 
 * Learners can quickly see whether problems are graded or ungraded.
 
-===========
 Discussions
 ===========
 
@@ -48,7 +44,6 @@ Discussions
   list, and an enhanced UI that indicates unread posts, comments, and
   responses. You can also now sort discussions by votes.
 
-============================
 Studio & Course Author Tools
 ============================
 
@@ -95,9 +90,8 @@ Studio & Course Author Tools
   "verification status".
 
 
-***************************************************
 Updates to Analytics Events and Database Tables
-***************************************************
+***********************************************
 
 * Insights now offers per-learner data and a new "Participated in Discussions
   Last Week" metric.
@@ -116,9 +110,8 @@ Updates to Analytics Events and Database Tables
 
 
 
-***********************
 Accessibility Updates
-***********************
+*********************
 
 In keeping with edX's commitment to creating accessible content for everyone,
 everywhere, the Open edX Ficus release contains numerous accessibility
@@ -160,9 +153,9 @@ enhancements and improvements to readability and navigability.
 
 
 
-*******************************
 System Upgrades and Updates
-*******************************
+***************************
+
 
 * Administrators can now configure third party authentication differently for
   each of their sites.
@@ -192,11 +185,9 @@ System Upgrades and Updates
     TBD
 
 
-**************
 Patch Releases
 **************
 
-======================
 29 March 2017: Ficus.2
 ======================
 
@@ -214,7 +205,6 @@ Patch Releases
 * Fixes to some automated tests.
 
 
-======================
 21 April 2017: Ficus.3
 ======================
 
@@ -233,7 +223,6 @@ Patch Releases
   launch new gunicorn web server processes.
 
 
-=======================
 10 August 2017: Ficus.4
 =======================
 

--- a/source/community/release_notes/ginkgo.rst
+++ b/source/community/release_notes/ginkgo.rst
@@ -1,14 +1,12 @@
 .. _Open edX Ginkgo Release:
 
-#########################
 Open edX Ginkgo Release
-#########################
+#######################
 
 .. contents::
  :depth: 1
  :local:
 
-************
 New Features
 ************
 
@@ -19,7 +17,6 @@ The Open edX Ginkgo release includes the following updates.
  :local:
 
 
-===
 LMS
 ===
 
@@ -57,7 +54,6 @@ LMS
    or other assistive technology.
 
 
-===============================
 Studio and Course Author Tools
 ===============================
 
@@ -98,32 +94,27 @@ Studio and Course Author Tools
   permanently. Using this feature, course teams can hide exam scores until
   the exam due date, or administer surveys without revealing responses.
 
-=======================
 Insights and Analytics
-=======================
+======================
 
-*  A new **Courses** page in Insights provides a dashboard view of all of your
+  A new **Courses** page in Insights provides a dashboard view of all of your
    courses. For information, see Courses_Page in the Insights Documentation.
 
-*****************
 Service Upgrades
-*****************
+****************
 
-=================
 Catalog Service
-=================
+===============
 
 The Catalog service has been upgraded to RabbitMQ 3.6.9.
 
-=======================
 Credentials Service
-=======================
+===================
 
 The Credentials service now requires Python 3.5.
 
-======================
 E-Commerce Service
-======================
+==================
 
 * The Open edX platform now supports only the integrated Otto
   receipt page. Users can no longer redirect to the ``LMS/shopping_cart``
@@ -152,9 +143,8 @@ E-Commerce Service
   this user must have the ``student:userprofile:can_deactivate_users``
   permission.
 
-*******************************
 System Upgrades and Updates
-*******************************
+***************************
 
 The Ginkgo release makes version updates to a number of system components.
 
@@ -187,9 +177,8 @@ The Ginkgo release makes version updates to a number of system components.
   ES2015+.
 
 
-***********************
 Deprecated Features
-***********************
+*******************
 
 Several features are deprecated or deleted in the Open edX Ginkgo release.
 

--- a/source/community/release_notes/hawthorn.rst
+++ b/source/community/release_notes/hawthorn.rst
@@ -1,6 +1,5 @@
 .. _Open edX Hawthorn Release:
 
-#########################
 Open edX Hawthorn Release
 #########################
 
@@ -11,7 +10,6 @@ This page lists the highlights of the Hawthorn release of the Open edX platform.
  :depth: 1
  :local:
 
-*************************
 New and Improved Features
 *************************
 
@@ -22,60 +20,58 @@ The Open edX Hawthorn release includes the following updates.
  :local:
 
 
-========================
 LMS and Learner Features
 ========================
 
 * We’ve enhanced the learner profiles so that they now include the date a
   learner joined the platform and any course credentials they have received.
-  Learner profiles link to social media accounts and help learners share 
-  information with one another. 
+  Learner profiles link to social media accounts and help learners share
+  information with one another.
 * Learners now have the ability to purchase all the courses in a
   program in just one transaction. This avoids the hassle of having to enter
   payment information multiple times.
-* New discussion notifications now send an email message the first time a 
-  learner's post receives a comment. The message contains the comment and a 
-  link back to the course discussions for easy access. Inline discussions are 
-  expanded by default. This change has led to a threefold increase in 
+* New discussion notifications now send an email message the first time a
+  learner's post receives a comment. The message contains the comment and a
+  link back to the course discussions for easy access. Inline discussions are
+  expanded by default. This change has led to a threefold increase in
   discussion participation on edx.org.​
 
 
-===============================
 Studio and Course Author Tools
-===============================
+==============================
 
-* Course teams now have the ability to override learner scores for individual 
-  problems. This can be done through a setting on both the instructor dashboard 
+* Course teams now have the ability to override learner scores for individual
+  problems. This can be done through a setting on both the instructor dashboard
   and the Staff Debug viewer.
-* Course Reviews can now be viewed and added by learners from within the course 
-  experience. Open edX system administrators can configure a reviews provider, 
+* Course Reviews can now be viewed and added by learners from within the course
+  experience. Open edX system administrators can configure a reviews provider,
   such as CourseTalk, to allows learners to leave reviews for a particular course.
-* Proctored exams have been improved, enabling course teams to add specific exam 
+* Proctored exams have been improved, enabling course teams to add specific exam
   instructions in the Studio proctored exam settings.
-* The Files & Uploads page has been updated to significantly simplify the 
-  experience of adding all types of files to a course. This includes the 
+* The Files & Uploads page has been updated to significantly simplify the
+  experience of adding all types of files to a course. This includes the
   ability to search and a Hide File Preview option.
-* The ORA problem editor has been improved. A new interface offers the same 
-  formatting options for the prompt that are available for HTML components. 
-  You no longer have to create a separate HTML component above the ORA 
+* The ORA problem editor has been improved. A new interface offers the same
+  formatting options for the prompt that are available for HTML components.
+  You no longer have to create a separate HTML component above the ORA
   assignment.
-* Weekly course highlight messages can now be sent to encourage learners to 
-  remain engaged with self-paced courses. Specify a few highlights for each 
-  course section, and the platform sends out a weekly email message that lists 
-  these highlights. Courses on edx.org that enabled weekly highlights had 
+* Weekly course highlight messages can now be sent to encourage learners to
+  remain engaged with self-paced courses. Specify a few highlights for each
+  course section, and the platform sends out a weekly email message that lists
+  these highlights. Courses on edx.org that enabled weekly highlights had
   higher verification rates than ones without.
-* The HTML components have been updated to give you even more easy formatting 
-  options such as aligning your text the way you want: aligned to the left or 
-  right, centered, or fully justified. Images in HTML components can be added 
-  right inside the HTML component itself, without having to upload files 
+* The HTML components have been updated to give you even more easy formatting
+  options such as aligning your text the way you want: aligned to the left or
+  right, centered, or fully justified. Images in HTML components can be added
+  right inside the HTML component itself, without having to upload files
   beforehand.
-* The Video Uploads page is enabled by default. For course teams who partner 
-  with 3Play Media and cielo24, transcripts (including translations of 
+* The Video Uploads page is enabled by default. For course teams who partner
+  with 3Play Media and cielo24, transcripts (including translations of
   transcripts) are added to Studio automatically.
-* You can establish a password policy to require a minimum strength and 
+* You can establish a password policy to require a minimum strength and
   complexity for passwords.
 
-Changes to OLX <transcript> Element for Videos 
+Changes to OLX <transcript> Element for Videos
 **********************************************
 
 The primary storage for video transcripts on edx.org is now Amazon S3. In
@@ -88,14 +84,14 @@ OLX ``<video>`` element, showing the way transcripts are now handled.
 
 .. code-block:: xml
 
-    <video sub="" display_name="Test Video" edx_video_id="9c563e7d-c86c" 
+    <video sub="" display_name="Test Video" edx_video_id="9c563e7d-c86c"
            youtube_id_1_0="FEWSxCV">
         <video_asset client_video_id="test.mp4" duration="319.94" image="">
-            <encoded_video bitrate="174" file_size="69880" profile="mobile_low" 
+            <encoded_video bitrate="174" file_size="69880" profile="mobile_low"
                            url="https://abc.cloudfront.net/ABC_MB2.mp4"/>
             <encoded_video bitrate="192" file_size="76816" profile="audio_mp3"
                            url="https://def.cloudfront.net/ABC_MB1.mp3"/>
-            <encoded_video bitrate="279" file_size="112012" profile="desktop_mp4" 
+            <encoded_video bitrate="279" file_size="112012" profile="desktop_mp4"
                            url="https://ghi.cloudfront.net/ABC_MB4.mp4"/>
             <encoded_video bitrate="0" file_size="0" profile="youtube" url="FEWSxCV"/>
             <transcripts>
@@ -105,14 +101,13 @@ OLX ``<video>`` element, showing the way transcripts are now handled.
         </video_asset>
     </video>
 
-Transcript content files are stored in the course's ``/static`` directory, 
-using the file name format ``[edx_video_id]-[language_code].srt``. For example, in 
-the preceding example, there should be a transcript file with the name 
+Transcript content files are stored in the course's ``/static`` directory,
+using the file name format ``[edx_video_id]-[language_code].srt``. For example, in
+the preceding example, there should be a transcript file with the name
 ``9c563e7d-c86c-en.srt`` in the ``/static`` directory.
 
-*******************************
 System Upgrades and Updates
-*******************************
+***************************
 
 The Hawthorn release makes version updates to a number of system components.
 
@@ -136,9 +131,8 @@ The Hawthorn release makes version updates to a number of system components.
      - Redis replaces Rabbit
 
 
-***********************
 Deprecated Features
-***********************
+*******************
 
 Several features are deprecated or deleted in the Open edX Hawthorn release.
 
@@ -148,7 +142,7 @@ Several features are deprecated or deleted in the Open edX Hawthorn release.
   release. We recommend switching this flag to ``True``, so that you will not
   experience any change with the next release.
 * ``django-simple-history`` has been deprecated and removed.
-* The ``LogoutViewConfiguration`` model has been removed. Single logout is now 
-  permanently enabled. This meants that logging out of the LMS or an IDA logs 
+* The ``LogoutViewConfiguration`` model has been removed. Single logout is now
+  permanently enabled. This meants that logging out of the LMS or an IDA logs
   you out of all systems.
 

--- a/source/community/release_notes/index.rst
+++ b/source/community/release_notes/index.rst
@@ -1,6 +1,5 @@
 .. _Open edX Release Notes:
 
-###############################
 Open edX Platform Release Notes
 ###############################
 

--- a/source/community/release_notes/ironwood.rst
+++ b/source/community/release_notes/ironwood.rst
@@ -1,6 +1,5 @@
 .. _Open edX Ironwood Release:
 
-#########################
 Open edX Ironwood Release
 #########################
 
@@ -20,19 +19,18 @@ This page lists the highlights of the Ironwood release of the Open edX platform.
  :depth: 1
  :local:
 
-============================
 Authoring Experience Updates
-============================
+****************************
 
 Studio Login via the LMS
-------------------------
+========================
 
 Now logging in to Studio is done by redirecting the user to the LMS to log in,
 and then redirecting back to Studio.  This can be disabled by site operators
 using the new DISABLE_STUDIO_SSO_OVER_LMS feature flag.
 
 Course Launch & Best Practices Checklist
-----------------------------------------
+========================================
 
 We have reintroduced the Studio checklist feature from 2014 to help
 automatically track important course launch steps. Previously this was a manual
@@ -50,7 +48,7 @@ listed.
 
 
 Video Status Indicators
------------------------
+=======================
 
 For Open edX instances using the video uploads page, this view now conveys the
 status of each video as it relates to its transcoding (through edx-VEDA) and
@@ -61,7 +59,7 @@ in our documentation`__.
 .. __: https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/video/upload_video.html#video-processing-statuses
 
 Gradebook Application
----------------------
+=====================
 
 The gradebook will give you a central location where you can view and manage
 grades for all learners in a course. It will provide you with improved search
@@ -77,7 +75,7 @@ You can read more about this in the documentation for the `Gradebook Application
 
 
 Learner Data for a Specific Problem
------------------------------------
+===================================
 
 Thanks to the Open edX community, the downloadable Student State report
 received readability enhancements and now contains new columns for single
@@ -85,12 +83,11 @@ problems or for all problems in a unit, subsection, or section, as well as for
 all problems in the course.
 
 
-==========================
 Learner Experience Updates
-==========================
+**************************
 
 Transferrable Learner Records
------------------------------
+=============================
 
 The credentials service which previously powered program certificates now also
 supports learner program records. Where certificates function as a sharable
@@ -109,7 +106,7 @@ looking to transfer or share their valuable credentials to employer and credit
 pathways.
 
 Password Complexity Requirements
---------------------------------
+================================
 
 We have updated the syntax for setting password complexity of your instance. We
 also added some default checks to ensure that your password isn't trivial. You
@@ -118,7 +115,7 @@ rules or logic for password complexity.
 
 
 Expanded Language Support for course experience
------------------------------------------------
+===============================================
 
 We have added support for beta languages on the platform. These languages
 become a selectable option in the account settings dropdown alongside fully
@@ -129,7 +126,7 @@ platform into that language as a member of that language team.
 
 
 Anonymous Course Content Access
--------------------------------
+===============================
 
 This feature enables learners to preview course content without necessarily
 being logged into a given learning environment. It was implemented by adding a
@@ -142,7 +139,7 @@ public outline, or public.
 * Public (lets learners view HTML & Video content in the course, but hides unsupported XBlocks - such as problems and inline discussions)
 
 Feature Based Enrollments
--------------------------
+=========================
 
 Feature Based Enrollments, the basis of edX.org’s new revenue model, is
 available in Ironwood. FBE allows you to differentiate what features are
@@ -155,9 +152,8 @@ end. This functionality is defaulted to off at the platform level, and can
 additionally be configured by course run or organization.
 
 
-===============================
 Mobile Application Improvements
-===============================
+*******************************
 
 Between Hawthorn and Ironwood, the Mobile application releases spanned 2.15 →
 2.17.1 The details of these releases are captured in our release documentation
@@ -165,7 +161,7 @@ for the mobile applications. Included below is a summary of the learner facing
 and operator facing changes to mobile.
 
 Learner Facing Mobile Changes
------------------------------
+=============================
 
 A major experience improvement to landscape and rotation support arrived in
 version 2.15. This was a key driver of lower ratings and reviews for our
@@ -189,7 +185,7 @@ provides clarity into when learners will lose access to a course. More details
 around this are included in the `Feature Based Enrollments`_ update.
 
 Developer Facing Mobile Changes
--------------------------------
+===============================
 
 For the iOS code base, we upgraded to support Xcode 10.1, we have updated our
 Firebase configuration now that Fabric has been deprecated as a service, and we
@@ -207,9 +203,8 @@ to KitKat (API Level 19), upgraded gradle and other libraries, updated Fabric
 and Firebase configurations,  and implemented pull to refresh functionality on
 the course outline page.
 
-=========================
 Platform Operator Updates
-=========================
+*************************
 
 Starting in Ironwood, the configuration repo will no longer ship with a default
 Django secret key for edx-platform.  This means that if you have been deploying

--- a/source/community/release_notes/juniper.rst
+++ b/source/community/release_notes/juniper.rst
@@ -1,6 +1,5 @@
 .. _Open edX Juniper Release:
 
-########################
 Open edX Juniper Release
 ########################
 
@@ -9,7 +8,7 @@ largest yet. Our previous release (Ironwood) was released in January 2019, so
 Juniper spans January 2019 through May 2020. You can also review details about
 `earlier releases`_ or learn more about the `Open edX Platform`_ if you are new to
 Open edX. Below is a summary of the changes for each of the main platform
-areas, along with a way to jump down to each section of the release notes. 
+areas, along with a way to jump down to each section of the release notes.
 
 .. _earlier releases: https://edx.readthedocs.io/projects/edx-developer-docs/en/latest/named_releases.html
 .. _Open edX Platform: https://open.edx.org
@@ -22,9 +21,8 @@ areas, along with a way to jump down to each section of the release notes.
    juniper_educator
    juniper_developer
 
-===================
 Learner Experiences
-===================
+*******************
 
 Many areas of the learner experience have started their necessary transitions
 to modern micro-frontends, including the Learner Profile, Account Settings,
@@ -35,9 +33,8 @@ been added enabling learner schedule personalization, team assignment
 submissions, as well as major updates to the mobile application video
 experience.
 
-====================
 Educator Experiences
-====================
+********************
 
 For Educators many updates have been made to the Studio experience in support
 of improving authoring speed for frequent actions like component naming, unit
@@ -45,11 +42,10 @@ creation, problem markdown editing, and learning sequence navigation.
 Additionally, updates to the platform grading tools are a key part of these
 updates. For instances using programs, various program operations have been
 updated through the introduction of a new registrar service and a way for
-external systems to set enrollments for program learners. 
+external systems to set enrollments for program learners.
 
-=====================
 Developer Experiences
-=====================
+*********************
 
 Many things have changed in our largest release yet, but a few key highlights
 include major core requirement upgrades to support Python 3 and Django 2.

--- a/source/community/release_notes/juniper_developer.rst
+++ b/source/community/release_notes/juniper_developer.rst
@@ -1,15 +1,13 @@
 .. _juniper_developer:
 
-############################################
 Juniper release notes: Developer Experiences
 ############################################
 
-=================
 Platform Services
-=================
+*****************
 
 Notifier Service
-----------------
+================
 
 **Notifier Service Deprecation:** We made the decision to deprecate the
 notifier service powering the discussion forum daily digest feature. In the
@@ -23,12 +21,11 @@ edX ACE infrastructure.
     Internal Notes on v1.1 Content: Cut from v1, TBD on what the update is for this service. Referenced already in program operations / console
 
 
-===================================
 Continuous Integration & Deployment
-===================================
+***********************************
 
 Front End Pipeline
-------------------
+==================
 
 **Shared Frontend Platform Services:** In support of centralized configuration
 of baseline micro-frontend requirements, we have created the `Frontend
@@ -71,7 +68,7 @@ for Segment.
 .. __: https://github.com/openedx/frontend-platform/blob/master/src/analytics/interface.js
 
 Mobile Site Build Pipeline
---------------------------
+==========================
 
 **Mobile Test Automation Pipeline:** A major investment was made into `test
 automation tooling`__ and containers for both the iOS and Android applications,
@@ -80,7 +77,7 @@ enabling improved mobile app test suite automation and builds.
 .. __: https://github.com/openedx/edx-app-test
 
 Authentication & Account Services
----------------------------------
+=================================
 
 **MFE Service - Authentication:** In support of expanded use of
 micro-frontends, a foundational service focused on configuring authentication
@@ -98,7 +95,7 @@ and removed in favor of a single secure implementation. Details are in the
 
 
 Internationalization Pipeline
------------------------------
+=============================
 
 **MFE Service - Internationalization:** In support of expanded use of
 micro-frontends, a foundational service focused on internationalization support
@@ -110,7 +107,7 @@ strings from Transifex, our crowdsource platform text translation community.
 
 
 Devstack
---------
+========
 
 
 ..
@@ -123,7 +120,7 @@ Devstack
     Kubernetes pilot - Notes service
 
 Video Delivery Pipeline
------------------------
+=======================
 
 **VEDA Performance Enhancements:** The team put time into making key VEDA
 performance enhancements, improving stability and scaling of our video uploads
@@ -147,7 +144,7 @@ details about its replacement - VEM.
     BokChoy Updates: ...
 
 Accessibility Support
----------------------
+=====================
 
 **WCAG 2.1 Enhancements:** Across many areas of the platform we have completed
 improvements that move our platform's target WCAG support level up to 2.1 from
@@ -156,12 +153,11 @@ such as improved contrast and visibility, semantic page structure updates, as
 well as landmark container improvements that are all a part of the 2.1
 specification.
 
-============================
 Pattern Library & Components
-============================
+****************************
 
 Paragon
--------
+=======
 
 We have updated the Paragon Component Library. Paragon now includes Bootstrap
 SCSS directly and contains Paragon extensions. It should now be considered the
@@ -177,7 +173,7 @@ that end, a parallel effort has begun to remove legacy pattern library styling
 from the platform though this work was not fully completed in Juniper.
 
 Site Headers & Footers
-----------------------
+======================
 
 For each MFE, the header and footer must be configured to echo the rest of the
 site or product experience to which it is connected. We have published various
@@ -187,12 +183,11 @@ cookie message banner, and others`__.
 .. __: https://github.com/openedx?q=frontend-component&type=&language=
 
 
-==========================
 Core Platform Requirements
-==========================
+**************************
 
 Python
-------
+======
 
 About 55% of the Open edX platform is written in Python, meaning a large
 fraction of the code written over the past 8 or so years was reviewed and
@@ -206,7 +201,7 @@ rely on Python themselves.
 .. _INCR-1: https://openedx.atlassian.net/browse/INCR-1
 
 Django
-------
+======
 
 A major, Juniper-release-defining upgrade to the platform was completed in
 service of upgrading the Open edX Platform and all its dependencies to support
@@ -223,19 +218,18 @@ of life support dates.
 
 
 xModule / XBlocks
------------------
+=================
 
 **xModule to xBlock Conversions:**  Across several of the core course content
 blocks, we have migrated away from the legacy xModule format in support of its
 eventual deprecation. Discussions, HTML, Video, and Problems have all been
 converted to XBlocks as part of this work.
 
-==========================
 Platform Health Monitoring
-==========================
+**************************
 
 Repository Dashboard
---------------------
+====================
 
 With nearly 400 git repositories across 4 different GitHub organizations, it's
 becoming both more important and more difficult to answer questions like "which
@@ -259,12 +253,11 @@ The aggregated data for many files is output as a csv.
 .. _pytest-repo-health: https://github.com/openedx/pytest-repo-health
 
 
-==========================
 LMS / Studio Configuration
-==========================
+**************************
 
 JSON to YAML
-------------
+============
 
 Most Open edX applications read a single YAML file.  However the LMS and Studio historically
 read multiple JSON ones. We are making the LMS and Studio behave the same as other applications
@@ -275,12 +268,11 @@ Technical details of converting your existing files are here:
 .. __: https://openedx.atlassian.net/wiki/spaces/AC/pages/1822916664/How+to+convert+your+lms+and+studio+json+configuration+files+to+yaml
 
 
-==============================
 Feature & Update Documentation
-==============================
+******************************
 
 Deprecation Process
--------------------
+===================
 
 Building on the deprecation process defined in OEP-21 (`Open edX Proposal
 21`_), we have flagged many areas for deprecation, including areas mentioned

--- a/source/community/release_notes/juniper_educator.rst
+++ b/source/community/release_notes/juniper_educator.rst
@@ -1,26 +1,24 @@
 .. _juniper_educator:
 
-###########################################
 Juniper release notes: Educator Experiences
 ###########################################
 
-===========================
 Course Authoring Experience
-===========================
+***************************
 
 Content Authoring
------------------
+=================
 
 Course Outline & Structure
-..........................
+--------------------------
 
 **In-Context Unit Naming:** You can now quickly edit the name of a Unit page
 directly from the Studio Course Outline page, speeding up course scaffolding
 and authoring in this quick edit page where changes are applied without needing
-a draft or publish step, as is the case on the Unit Pages today. 
+a draft or publish step, as is the case on the Unit Pages today.
 
 Learning Sequence Authoring
-...........................
+---------------------------
 
 **Educator Jump Navigation:** To start, we plan to update the Unit page title
 area breadcrumbs adding dropdowns that let you jump to other sections or
@@ -37,16 +35,16 @@ the right sidebar of Unit pages.
 instructor bar in the learner experience now includes two actions linking to
 Studio and Insights. As part of this work we have removed the “View Unit in
 Studio” button that rendered previously in the content area of the learner
-experience.  
+experience.
 
 **Display Name Editing:** Courses often contain thousands of components, so any
 time we can save course authors on an individual component we expect that time
 will add up! We have updated the component editing window to allow you to edit
 the component display name in context in the title area of the window, meaning
-you no longer have to go to the Settings tab to update the display name. 
+you no longer have to go to the Settings tab to update the display name.
 
 Course Enrollment Page Publishing
-.................................
+---------------------------------
 
 **Publisher Tool:**  A `new micro-frontend`_ was built which integrates with
 the course discovery and ecommerce services as a new catalog publishing and
@@ -60,7 +58,7 @@ provided with the authoring experience.
 
 
 Weekly Highlights
-.................
+-----------------
 
 This feature has been updated to also be available for both self and instructor
 paced courses. This change will make it easier for course teams to pre-program
@@ -75,29 +73,29 @@ learner.
     --------------------------
 
     Group Configuration & Visibility Rules
-    Internal Notes on v1.1 Content: 
+    Internal Notes on v1.1 Content:
     Feature Based Enrollment Overrides?
     Special Exams: Proctored
-    Internal Notes on v1.1 Content: 
+    Internal Notes on v1.1 Content:
     Deen - Streamlined proctoring integration
     Deen - Proctortrack* (link here)
     RPNow Virtual Proctoring Update (V4)* (link here)
     Proctor track integration (Master's, MM) / New proctoring tools/vendor?
-    Deen - Proctoring API changes? 
+    Deen - Proctoring API changes?
     Special Exams: Timed
-    Internal Notes on v1.1 Content: 
-    Deen - any changes here to timed exam config that made it to Juniper? 
+    Internal Notes on v1.1 Content:
+    Deen - any changes here to timed exam config that made it to Juniper?
 
 Learning App Configuration
---------------------------
+==========================
 
 Teams Configuration
-...................
+-------------------
 
 **Team Management Improvements:** The Teams application has been improved to
 provide a way for instructors to create and manage teams and team memberships
 within the Teams application. Staff can also bulk view, create, and modify team
-membership via CSV download and upload. 
+membership via CSV download and upload.
 
 Staff (including TAs) can now create “instructor managed” team sets. Only
 course staff can create teams and manage team membership in these team sets.
@@ -107,35 +105,34 @@ Students cannot create teams or leave and/or join teams in these team sets.
 either be Public or Private. In Public team sets, students can view other
 teams, their membership, and their team discussions. In Private team sets,
 students cannot view other teams, nor the membership or discussions of these
-other teams. 
+other teams.
 
 ..
     Course Asset Management
     -----------------------
 
-    Internal Notes on v1.1 Content: 
-    Seth - updates here? Cut from v1 but I suspect video management might have had updates? 
+    Internal Notes on v1.1 Content:
+    Seth - updates here? Cut from v1 but I suspect video management might have had updates?
 
 ..
     Settings & Configuration
     ------------------------
 
     Schedule & Dates
-    Internal Notes on v1.1 Content: 
+    Internal Notes on v1.1 Content:
     Kaitlin / Shelby - updates here?  Perhaps nothing in Juniper? (improvements to scheduler + relative data storage?
     Enrollment Tracks / Commerce
-    Internal Notes on v1.1 Content:  
-    FBE Exception documented? 
+    Internal Notes on v1.1 Content:
+    FBE Exception documented?
     Special Exam Providers
-    Internal Notes on v1.1 Content: 
-    Deen - any changes here to proctoring config that made it to Juniper? 
+    Internal Notes on v1.1 Content:
+    Deen - any changes here to proctoring config that made it to Juniper?
 
-=============================
 Content Blocks & Interactives
-=============================
+*****************************
 
 Core Course Content Blocks
---------------------------
+==========================
 
 ..
     Video Block
@@ -144,18 +141,18 @@ Core Course Content Blocks
     **HLS Support and Delivery:** Through our video pipeline, videos now support
     HTTP Live Streaming (HLS), enabling learners to view videos at the quality
     level that fits their current network bandwidth for both the web and mobile
-    application video experiences. 
+    application video experiences.
 
 
 Common Problem Blocks
-.....................
+---------------------
 
 **Problem Markdown Editor Learnability & Usability:** Problem authoring can be
 time intensive, especially as problems become more complex through hints,
 feedback, and explanations. We have updated the icons in the common problem
 markdown editor so that the name of the problem template is more obvious. For
 new course authors we also hope this improves the learnability of this markdown
-editor. 
+editor.
 
 **Problem Markdown Reference Sheet Visibility:** Another set of changes relates
 to the markdown reference sheet, which will now be visible by default. As part
@@ -165,12 +162,12 @@ the authoring space was not reduced with the addition of the reference sheet.
 
 
 Open Response Assessments
-.........................
+-------------------------
 
 **Improved File Management:** It is now possible to incrementally add and
 delete individual files while submitting an ORA problem that has file upload
 enabled. Learners also can see the file name for their uploads as well. As part
-of this work the file size limit was increased to 500MB (from 20MB). 
+of this work the file size limit was increased to 500MB (from 20MB).
 
 **Staff Graded Team Assignments:** As referenced in the Teams application area,
 instructors can now create team ORA assignments whereby groups of students can
@@ -179,7 +176,7 @@ evaluate the submission and assign a team grade. Staff can enable an Open
 Response Assessment for team submission and attach a team set to it. Only
 students on a team in that team set will be able to submit a response. One team
 member can submit for the group. Staff can assign the same assignment grade and
-provide the same feedback to all members of a team. 
+provide the same feedback to all members of a team.
 
 ..
     Drag Drop Block
@@ -188,22 +185,22 @@ provide the same feedback to all members of a team.
     Summary of changes coming from OpenCraft
 
 External Content Blocks
------------------------
+=======================
 
 LTI Content Block
-.................
+-----------------
 
 **Interactive Content Icon:** Previously LTI blocks were not recognized as
 graded content, meaning that in the learning sequence bar LTI unit pages were
 represented as text. The icon is now the problem / assessment icon which makes
-it clear that this page in the sequence bar has interactive content. 
+it clear that this page in the sequence bar has interactive content.
 
 **LTI v1.3 Base Implementation:** Initial support behind the scenes for LTI
 v1.3 was merged in March, though the full functionality requires updating the
 LTI consumer xblock to its June release to fully support this additional
 specification option. Once enabled educators will be able to configure LTI
 ungraded components relying on the LTI v1.3 specification. Koa will include
-full LTI v1.3 support including graded passback support. 
+full LTI v1.3 support including graded passback support.
 
 **LTI Plugin Parameters:** A community contribution added the ability to pass
 extra parameters such as the team and cohort of a student to the LTI provider,
@@ -212,39 +209,38 @@ learning content.
 
 
 Custom External Graders
-.......................
+-----------------------
 
 **Python 3 Support for CodeJail:** ...
 
 Specialized, Experimental, or Advanced Blocks
----------------------------------------------
+=============================================
 
-Additional details to follow about improvements to this platform area. 
+Additional details to follow about improvements to this platform area.
 
 ..
-    Internal Notes on v1.1 Content: 
-    Deen - Zoom integration (Master's, MM), edX Live* (?) 
+    Internal Notes on v1.1 Content:
+    Deen - Zoom integration (Master's, MM), edX Live* (?)
     Deen - Staff Grade Points
     xBlock/LTI-backed course extensions and applications
 
 
-=================
 Course Operations
-=================
+*****************
 
 Grading Tools
--------------
+=============
 
-Additional details to follow about improvements to this platform area. 
+Additional details to follow about improvements to this platform area.
 
 ..
-    Internal Notes on v1.1 Content: 
+    Internal Notes on v1.1 Content:
     Deen - Gradebook v2 (only available for MM and Masters)*
     Deen - Bulk grade mgmt
-    Deen - Master's grade API 
+    Deen - Master's grade API
 
 Course Team Roles & Membership
-..............................
+------------------------------
 
 **Institutional Course Data Researchers:** A new role has been created to
 provide more granular controls for the ability to download learner information
@@ -255,32 +251,31 @@ in Django admin or for a specific course run in the Course Team Management area
 of the Membership tab of the Instructor Dashboard by a course administrator.
 
 Data Downloads
-..............
+--------------
 
 **Offline Report Download Age-Off:** A change was introduced to the table of
 downloaded instructor dashboard reports that seeks to limit the offline use and
 presence of learner data. After 90 days downloaded reports are now removed from
 the list of report downloads and a summary of this policy change is described
-near the downloaded report area. 
+near the downloaded report area.
 
-============================
 Program Operations / Console
-============================
+****************************
 
-Additional details to follow about improvements to this platform area. 
+Additional details to follow about improvements to this platform area.
 
 ..
     All sub-sections here cut from Juniper Release Notes v1
     Program Console
-    Internal Notes on v1.1 Content: 
-    Deen - Console + Registrar Service / 
+    Internal Notes on v1.1 Content:
+    Deen - Console + Registrar Service /
     Deen - Program Bulk Enrollments
     Program - Intervention report
     ADA Accommodations*
     Degree Lead Management
-    Internal Notes on v1.1 Content: 
+    Internal Notes on v1.1 Content:
     Deen - Lead Management for Masters Programs*
     Enhanced Lead management
     Program Data Downloads
-    Internal Notes on v1.1 Content: 
+    Internal Notes on v1.1 Content:
     Deen - Program Analytics*

--- a/source/community/release_notes/juniper_learner.rst
+++ b/source/community/release_notes/juniper_learner.rst
@@ -1,25 +1,23 @@
 .. _juniper_learner:
 
-##########################################
 Juniper release notes: Learner Experiences
 ##########################################
 
-=================
 Course Experience
-=================
+*****************
 
 Primary Content Experience
---------------------------
+==========================
 
 Course Home Experience
-......................
+----------------------
 
 **Course Outline Depth:** For some time the course outline was shifted to
 rendering sections, subsections, and units. The resulting outline was long and
 provided detail that learners could navigate once in a subsection (aka learning
 sequence). The course outline has been updated to once again show only sections
 and subsections. As a part of this change we have made sure graded subsections
-show an icon to better highlight that they are graded. 
+show an icon to better highlight that they are graded.
 
 **Graded Question Count:** The course outline now highlights the number of
 graded questions included in a subsection. The additional information added to
@@ -28,13 +26,13 @@ the effort of a given graded assignment or exam.
 
 
 Learning Sequence Experience
-............................
+----------------------------
 
 **New Course MFE:** A major platform change for the learner experiences comes
 in the form of a new `micro-frontend application`__ to modernize the course
 learning experience. The primary Juniper focus of this application is an
 overhaul of the learning sequence experience, though we anticipate other views
-like Course Home will eventually also make their way into this new application. 
+like Course Home will eventually also make their way into this new application.
 
 .. __: https://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/juniper.html
 
@@ -45,7 +43,7 @@ to render content into the application, as a side-effect does limit the ability
 to use Javascript on the page to interact with elements outside of the content
 frame, like the navigation or other areas of the page. The use of iframes here
 improves site security and code sandboxing, helping ensure stability for
-learners on the new application. 
+learners on the new application.
 
 **Course Home Clarity:** A home icon was also introduced to the breadcrumbs to
 reinforce the Course tab as the main home page for the course. Learners will
@@ -57,7 +55,7 @@ how it responds to screen size and length of learning sequences. When learning
 sequences have too many items to properly render the icons and completion
 status, or when you are viewing the course on a mobile browser,  we replace the
 sequence bar with a dropdown that retains the unit type icon and completion
-status. 
+status.
 
 **Next & Previous Action Clarity:** The next and previous buttons at the bottom
 of the page will be easier to spot and click, focusing on the “Next” action.
@@ -66,7 +64,7 @@ the course rather than show the next button at the bottom of the page.
 
 
 Visual Course Progress
-......................
+----------------------
 
 In the new course experience, visual completion is more obvious for learners
 with the elevated use of green checkmarks to convey progress. A recent
@@ -78,11 +76,11 @@ trigger completion rules.
     Special Exams Experience
     ........................
 
-    Internal Notes on v1.1 Content: 
+    Internal Notes on v1.1 Content:
     Various end learner proctoring changes? Or cover in educator experience since most changes are behind the scenes?
 
 Course Dates & Milestones
-.........................
+-------------------------
 
 **Personalized Schedules:** Though self-paced courses offer the significant
 advantage of being available on-demand when a learner wants them, they lack the
@@ -92,7 +90,7 @@ learner, and clearly showing the suggested dates and timeline in the course.
 These schedules are based off of the course’s expected duration, and customized
 for each learner’s unique start date. We’ve also retained the advantages of
 flexibility --- should a learner fall behind, they are able to adjust their
-schedule. 
+schedule.
 
 **Full Page Dates View:** To improve visibility into dates for both
 instructor-paced and self-paced courses, we have also introduced a dedicated
@@ -102,76 +100,74 @@ will also add the ability for learners to add these dates to their calendars.
 
 
 Content Search Tools
-....................
+--------------------
 
 A key improvement to the learner experience is course content search and the
 ability for learners to find results within their courses. This existing
 feature has been updated to support improved scaling and performance for larger
-courses and instances. 
+courses and instances.
 
 
 Course Welcome & Updates
-........................
+------------------------
 
 The visual height of welcome messages has been capped, adding a “Show More”
 action for longer posts that might have previously obscured view of the course
-outline for new learners visiting a course. 
+outline for new learners visiting a course.
 
 
 Learning Apps: Individual Support
----------------------------------
+=================================
 
 **Bookmarks:** Bookmarks were updated to also work in the new learner sequence
-experience. 
+experience.
 
 **Notes App:** The Notes tool that enables / disables notes in a learning
 sequence was updated to work for the new course micro-frontend.
 
 **Calculator:** The Calculator experience has been updated to work in the new
 course micro-frontend, making the markdown help tools easier to use and read as
-well. 
+well.
 
 
 Learning Apps: Peer & Community
--------------------------------
+===============================
 
 Discussion Forum Application
-............................
+----------------------------
 
 **Discussion Forum Daily Digests + Notifier Service:** We have marked this
 service as deprecated and disabled the discussion forum daily digest feature.
 We may revisit or reimplement this in the future but the experience was used by
 few learners, and the service that powered this capability was prone to
-instability and needed many upgrades to remain viable. 
+instability and needed many upgrades to remain viable.
 
 Teams Application
-.................
+-----------------
 
 **Team Assignments:** Educators can now create team assignments, enabling a
 team of students to collaborate on the assignment and submit a team response
 through a linked Open Response Assessment problem. (Additional details in the
-Open Response Assessment updates section).  
+Open Response Assessment updates section).
 
 **Private Teams:** In addition, new “private team sets” allow for teams that
 are not viewable to non-team members and which automatically create discussion
 forums for these teams that are visible only to team members and course staff.
-
 **Multiple Team Support:** It is now possible for learners to join more than
-one team in a given course. 
+one team in a given course.
 
 
-==========================
 Identity and Account Tools
-==========================
+**************************
 
 Learner Profile
----------------
+===============
 
 A complete rewrite of the learner profile experience was completed during this
 time. The new experience is powered by a `new micro-frontend`__ and the latest
 version of our `Paragon component library`_. If configured, this new experience
 provides improved visibility controls and new optional fields that can be shown
-on the profile. 
+on the profile.
 
 .. __: https://github.com/openedx/frontend-app-profile
 
@@ -180,19 +176,18 @@ on the profile.
 One aspect of the earlier learner profiles that was not migrated to the new
 experience is the  badges experience section of the profile. We are hoping to
 update our credentials infrastructure which will enable us to add these back
-into the updated learner profile in the future. 
+into the updated learner profile in the future.
 
 
 Account Settings
-----------------
+================
 
 **New Account Experience:** A new `Account micro-frontend`_ now also powers an
 updated account settings experience on the platform. The account settings page
 can now be more easily extended with plugins, and all features available on the
-previous account settings page were migrated over to this updated experience. 
+previous account settings page were migrated over to this updated experience.
 
 .. _Account micro-frontend: https://github.com/openedx/frontend-app-account
-
 
 **Beta Language Support:** Learners can now go to their account settings to see
 a longer list of languages including both fully supported languages and any
@@ -202,39 +197,38 @@ partially translated. Additionally there are buttons to quickly switch back to
 their previous language or head to Transifex to join the open community that
 helps us translate the platform if they would like to contribute. Included
 below are visuals of the language dropdown as well as an example message shown
-for partially supported languages. 
+for partially supported languages.
 
 **Recovery Email Address:** A new field was added to the account settings
 allowing learners to specify a recovery email address, which also needs to be
 activated to be set fully. When this feature is enabled, learners also see a
 message on their learner dashboard notifying them that their recovery email
-address has not been set or fully activated yet. 
+address has not been set or fully activated yet.
 
 
 ..
     Identity Verification
     .....................
 
-    Internal Notes on v1.1 Content: 
+    Internal Notes on v1.1 Content:
     Any Updates? Deen to check, it may not have made it into Juniper
- 
+
 
 Order History
-.............
+-------------
 
 A `new micro-frontend`_ was created for ecommerce related views, and the Order
 History page experience was added to this new tool. The new experience shows
-all ecommerce orders with links to the order detail pages. 
+all ecommerce orders with links to the order detail pages.
 
 .. _new micro-frontend: https://github.com/openedx/frontend-app-ecommerce
 
 
-===========
 Credentials
-===========
+***********
 
 Assignment Badges
------------------
+=================
 
 As called out in the Learner Profile section, this feature has not been
 migrated to the new learner profile experience and is thus no longer visible to
@@ -251,12 +245,12 @@ edx-platform code.
     Programs Home
     -------------
 
-    Internal Notes on v1.1 Content: Updates TBD  
+    Internal Notes on v1.1 Content: Updates TBD
 
     Degree Home
     -----------
 
-    Internal Notes on v1.1 Content: 
+    Internal Notes on v1.1 Content:
     - Master's learner portal & SSO integration
         - Master's integrations/student portal/SSO (Master's only) / Portal designer to allow for configurable landing pages (like for Master's programs)
     - Portal Designer*
@@ -264,24 +258,23 @@ edx-platform code.
     Program Tools
     -------------
 
-    Internal Notes on v1.1 Content: 
+    Internal Notes on v1.1 Content:
     - Deen - Master's face to face interaction (edXLive)
     - Deen - Master's program structure, student access, enrollment API
 
 
-===========================
 Upgrade Messaging & Payment
-===========================
+***************************
 
 Course Upsell Messaging and Payment
------------------------------------
+===================================
 
 **New Payment MFE:** A `new micro-frontend`__ has been created and scoped just
 to the checkout experience for those using the ecommerce tools and services
 built into the platform. This application supports Apple Pay, PayPal, and
 Cybersource credit card payment types. The improved checkout flow should
 improve checkout conversion rates and provide avenues for other plugins or
-integrations as well. 
+integrations as well.
 
 .. __: https://github.com/openedx/frontend-app-payment
 
@@ -290,25 +283,24 @@ first time purchasers. In our experimentation, we have found a meaningful
 impact to initial purchase rate.
 
 ..
-    Internal Notes on v1.1 Content: 
+    Internal Notes on v1.1 Content:
     Cut FBE + First Purchase Discount, can add back in if details are ready for support / use
 
     Bundled Program Purchases and Redemption
-    Internal Notes on v1.1 Content: 
-    Deen - Program upsell 
+    Internal Notes on v1.1 Content:
+    Deen - Program upsell
     Coupon Codes (Enrollment, Redemption)
-    Internal Notes on v1.1 Content: 
+    Internal Notes on v1.1 Content:
     Deen - Updates TBD
 
 
-===================
 Mobile Applications
-===================
+*******************
 
 The first Mobile app release to be packaged from the start of Juniper was
 `version 2.18`_, and `version 2.22`_ was released May 13th, 2020 before Juniper
 was cut. Additional details about Mobile App changes can also be found in the
-`Mobile Versions / Releases page`__. 
+`Mobile Versions / Releases page`__.
 
 .. _version 2.18: https://openedx.atlassian.net/wiki/spaces/LEARNER/pages/931693785/Mobile+Release%3A+2.18
 .. _version 2.22: https://openedx.atlassian.net/wiki/spaces/LEARNER/pages/1373306918/Mobile+Release+2.22
@@ -316,20 +308,20 @@ was cut. Additional details about Mobile App changes can also be found in the
 
 
 Mobile App Discovery
---------------------
+====================
 
 **Deep-Linking Integration with Branch.io:** Our applications can optionally be
 configured now to integrate with Branch.io, a tool that can `deep-link`_ new or
 existing app users directly to the app store listing and then through to the
 specific view screen from the app, improving retention especially for new
-users. 
+users.
 
 .. _deep-link: https://branch.io/what-is-deep-linking/
 
 **Journeys Integration with Branch.io:** Additionally through Branch.io, we are
 using their `Journey banners`_ to let learners on mobile web browsers quickly
 jump into the application or discover that mobile apps are an option for new
-learners. 
+learners.
 
 .. _Journey banners: https://branch.io/journeys/
 
@@ -340,68 +332,68 @@ around the mobile app refresh token that was forcing learners to log back in
 when not expected.
 
 Mobile Course Experience
-------------------------
+========================
 
 My Courses Mobile View
-......................
+----------------------
 
 **iPad Experience for My Courses Screen:**  Layout improvements to the My
 Courses view now show course cards in a grid, taking advantage of the iPad
-screen size in both portrait and landscape viewing modes.                                                                                                                                                                                                                                                                                                      
+screen size in both portrait and landscape viewing modes.
 
 Mobile App Upgrade Experience
-.............................
+-----------------------------
 
 Subsections and components within the
 content experience now provide clarity on when certain content is not
 visible in the currently active learner enrollment track.  Similarly for
 courses that use feature based enrollments where content access is set to
 expire some time after enrollment, this date is now more clear for learners
-within the courses and on course cards in the My Courses view.  
+within the courses and on course cards in the My Courses view.
 
 Mobile App Video Experience
-...........................
+---------------------------
 
 **Chromecast Support:** We have added support for Chromecast to the videos
 across both the iOS and Android applications. You can cast your videos now to
-other displays that support chromecast, including many Smart TVs. 
+other displays that support chromecast, including many Smart TVs.
 
 **In-App Youtube Player:** We also now have the ability to render Youtube
 videos within the application experience thanks to a major contribution.
 Previously learners would be redirected out of the application to view videos
-on Youtube. 
- 
+on Youtube.
+
 **Removed Legacy Videos Support:** We have removed the code for the legacy My
 Videos page, instead shifting to a new videos tab view within the course
-experience.  
+experience.
 
 **Increased Video Playback Speed Options:** We have added the ability for the
 mobile applications to adjust playback speed for videos, allowing for
-adjustments between 0.25x and 2x video speed. 
+adjustments between 0.25x and 2x video speed.
 
 **Video Rewind and Forward Controls:** Additional rewind and forward controls
 have been added to the video screen when learners tap on the video to expose
 play pause and video settings actions. A rewind action takes learners back 10
-seconds and they can also jump forward 15 seconds at a time. 
+seconds and they can also jump forward 15 seconds at a time.
 
 **Offline SD Card Storage Support:** You can now choose to have your videos
 stored on an SD card if you have one, with a new setting shown in the settings
-area if an SD card is detected on your Android device. 
+area if an SD card is detected on your Android device.
 
 **Mobile App Video HLS Delivery:** Through our video pipeline, mobile app
 videos now support HTTP Live Streaming (HLS), enabling learners to view videos
 at the quality level that fits their current network bandwidth for the and
-mobile application video experiences. 
+mobile application video experiences.
 
 Mobile Content Discovery
-------------------------
+========================
 
 **Program & Degree Discovery:** You can now search programs and degrees using
 the mobile application, additional views added to our existing discovery
-experience that loads webviews for each of these discovery facets. 
+experience that loads webviews for each of these discovery facets.
 
 App-Wide Learner Improvements
------------------------------
+=============================
 
 **Expanded Language Support:** Across both iOS and Android applications, you
 can now view the app experience in French, German, Portuguese, Chinese,
@@ -411,12 +403,12 @@ setting.
 
 **Firebase Analytics & Push Notifications:** The application has removed its
 support for the now deprecated Fabric analytics tool, and we have made it easy
-to toggle on Firebase as an analytics and push notification provider. 
+to toggle on Firebase as an analytics and push notification provider.
 
 **iOS Dynamic Type Support:** In support of improved text accessibility our iOS
 application supports dynamic type across the application, helping with
 legibility of text for learners with varying text sizes configured on their iOS
-devices. 
+devices.
 
 **Webview Performance: Discovery + Content Views:** We have done some work to
 improve xBlock caching and preloading for the mobile web views rendered in the

--- a/source/community/release_notes/koa.rst
+++ b/source/community/release_notes/koa.rst
@@ -1,6 +1,5 @@
 .. _Open edX Koa Release:
 
-####################
 Open edX Koa Release
 ####################
 
@@ -13,42 +12,41 @@ These are the release notes for the Koa release, the 11th community release of t
  :depth: 1
  :local:
 
-===================
 Learner Experiences
-===================
+*******************
 
 Course Experience
------------------
+=================
 
 Special Exams Experience
-........................
+------------------------
 
 **Self-Service Proctoring Provider Selection**: Proctored exam settings have been added to the new front end created to contain future course authoring improvements. A new view, exposed within Studio, has been created to surface proctoring provider selection and settings related to proctoring. This also includes a drop down for selecting a proctored exam provider from a list of available providers.
 
 **IDV experience improvements**: The ID verification (IDV) workflow user experience has been improved by breaking down the steps with clear instructions and examples. Accessibility improvements such as face tracking and voice-over have also been added. This new experience can be viewed in the account micro-frontend.
 
 Course Dates & Milestones
-.........................
+-------------------------
 
 **Personalized Learner Schedules** present learners in self-paced courses with suggested assignment due dates based on their enrollment date and the expected course duration. Learners are able to adjust the schedule if they fall behind and miss an assignment. By providing flexibility while also encouraging accountability, Personalized Learner Schedules help keep learners on track to complete their course.
 
 **Progress Milestones** are in-course celebrations that mark key achievements in the learner's course journey.  When a learner achieves one of these milestones, they see a celebration modal with a congratulatory message and links to share the achievement with friends on social media.
 
 Content Search Tools
-....................
+--------------------
 
 **Course Content Search Updates**: Visual updates to the course content search results page now clarifies the result location and type for learners.
 
 
 Mobile Application Experiences
-------------------------------
+==============================
 
 **Mobile Log In & Registration**: A few updates to the iOS and Android registration experiences are important to call out with the aim of improving ease of use. Instead of scrolling and selecting a country now a user can write into the spinner view and this will filter accordingly. Input fields are now validated once a user's focus changes to the next field (previously the validation used to happen on the fly as the user typed into a field). A new API is now used to validate the registration prior to submission. Please see details in the `full API list`__.
 
 __ https://openedx.atlassian.net/wiki/spaces/LEARNER/pages/17727783/Endpoints+Mobile+Talks+To
 
 Mobile Course Experience
-........................
+------------------------
 
 **Native Dates Area**: Previously we used to display a webview on the Dates screen which loaded a course's important dates. This has now been implemented in a native view fully built on mobile. More implementation details of the native dates tab can be found `here`__.
 
@@ -59,17 +57,16 @@ The API details for updated course experience can be found in the 'course' secti
 
 __ https://openedx.atlassian.net/wiki/spaces/LEARNER/pages/17727783/Endpoints+Mobile+Talks+To
 
-=====================
 Authoring Experiences
-=====================
+*********************
 
 Core Course Content Blocks
---------------------------
+==========================
 
 **xModule to xBlock Conversions**:  We have continued our migration away from the legacy xModule format in support of its eventual deprecation. The Conditional, Library Content Descriptor, Randomize Descriptor, Split Test Descriptor, Annotatable Descriptor, and Word Cloud Descriptor have all been converted to XBlocks as part of this work.
 
 Open Response Assessments
--------------------------
+=========================
 
 **Username details Added to ORA Report Download**: In several moderation situations, course teams rely on the downloadable ORA report from the Data Downloads tab. We have added usernames to this report to help make triage of issues faster, as this report previously only included anonymous IDs. We have kept anonymous IDs in the report for now in case anyone has scripts that rely on the anonymous user ID.
 
@@ -87,27 +84,26 @@ __ https://github.com/openedx/edx-ora2/pulls?q=is%3Apr+is%3Aclosed+merged%3A%3E2
 
 
 External Content Blocks
------------------------
+=======================
 
 LTI Content Block
-.................
+-----------------
 
-**LTI v1.3 Support**: As part of a broader effort to enhance the platform's support for external content integrations, we have updated the LTI consumer XBlock to support the LTI v1.3 specification. For those unfamiliar with LTI, this is a specification widely used to integrate different learning tools and platforms through well defined rules of communication and configuration. Open edX previously supported the LTI 1.1 / 1.2 specification, but we now also support the latest LTI 1.3 specification.
+LTI v1.3 Support**: As part of a broader effort to enhance the platform's support for external content integrations, we have updated the LTI consumer XBlock to support the LTI v1.3 specification. For those unfamiliar with LTI, this is a specification widely used to integrate different learning tools and platforms through well defined rules of communication and configuration. Open edX previously supported the LTI 1.1 / 1.2 specification, but we now also support the latest LTI 1.3 specification.
 
 
 Library Authoring
------------------
+=================
 
 **Content Libraries v2**: A new micro-frontend has been introduced to the platform for a revamped Content Library Authoring experience backed by Blockstore. The current experience renders "legacy" v1 content libraries not powered by blockstore while also introducing basic support for v2 blockstore-backed video, problem and complex libraries. The new experience also provides improved search and filtering capabilities for the Library listing view. This work is in active development, and interested parties should reach out to the Open edX team to explore potential contributions and improvements to this experience.
 
 
 
-=========================
 Administrator Experiences
-=========================
+*************************
 
 Dependency updates
-------------------
+==================
 
 These dependencies were upgraded for the Open edX Native Installation:
 
@@ -118,31 +114,29 @@ These dependencies were upgraded for the Open edX Native Installation:
 - Python was upgraded from 3.5 to 3.8.
 
 
-=============================
 Researcher & Data Experiences
-=============================
+*****************************
 
 
-=====================
 Developer Experiences
-=====================
+*********************
 
 Pattern Library & Components: Paragon
--------------------------------------
+=====================================
 
 Beyond the technical improvements noted below, people and processes supporting Paragon have undergone significant changes. Originally conceived as a React component library, Paragon has been expanded to serve as a design system for Open edX. To this end, the new `Design System Documentation`_ on Confluence is now the source of truth for all things Paragon. https://edx.github.io/paragon will continue to serve its critical function as technical documentation, but will not be expanded to include design documentation in the near term.
 
 .. _Design System Documentation: https://openedx.atlassian.net/wiki/spaces/BPL/overview
 
 Paragon has a new governance model
-..................................
+----------------------------------
 
 The edX Experience Team serves as owner and facilitator for Paragon. Questions, concerns, or ideas from the community regarding Paragon can be directed to the #paragon-design-system channel in the `Open edX Slack workspace`_.
 
 .. _Open edX Slack workspace: https://open.edx.org/community/connect/#slack
 
 Sections worth exploring in the Paragon Design System Documentation
-...................................................................
+-------------------------------------------------------------------
 
 - `Governance <https://openedx.atlassian.net/wiki/spaces/BPL/pages/1917977064/Governance>`_
 - `Component Documentation <https://openedx.atlassian.net/wiki/spaces/BPL/pages/1916338871/Components>`_
@@ -150,7 +144,7 @@ Sections worth exploring in the Paragon Design System Documentation
 - `Component Proposals <https://openedx.atlassian.net/wiki/spaces/BPL/pages/1918304774/Component+Proposals>`_
 
 Summary of release notes 9.0.0 to 12.4.1
-........................................
+----------------------------------------
 
 Significant improvements and new features include the latest release (May to December 2020) include:
 
@@ -196,7 +190,7 @@ __ https://edx.github.io/paragon/components/toast
 .. _v12.1.0 release notes: https://github.com/openedx/paragon/releases/tag/v12.1.0
 
 Deprecations
-------------
+============
 
 These components have been removed:
 

--- a/source/community/release_notes/lilac.rst
+++ b/source/community/release_notes/lilac.rst
@@ -1,6 +1,5 @@
 .. _Open edX Lilac Release:
 
-######################
 Open edX Lilac Release
 ######################
 
@@ -13,12 +12,11 @@ These are the release notes for the Lilac release, the 12th community release of
  :depth: 1
  :local:
 
-===================
 Learner Experiences
-===================
+*******************
 
 Open-Response Assessments
--------------------------
+=========================
 
 - Learners can submit rich text responses
 - Grading status message
@@ -26,7 +24,7 @@ Open-Response Assessments
 - See the Authoring Experience section below for more ORA enhancements
 
 Account Micro-frontend
-----------------------
+======================
 
 The Account MFE is enabled by default and provides private user settings UIs, including:
 
@@ -35,12 +33,12 @@ The Account MFE is enabled by default and provides private user settings UIs, in
 - IDV (Identity Verification)
 
 Checkout Micro-frontend
------------------------
+=======================
 
 The Checkout MFE is enabled by default. Prior checkout UIs may not be PCI compliant.
 
 Learning Micro-frontend
------------------------
+=======================
 
 The Learning MFE is *not* enabled by default, because theming and internationalizations support is incomplete. However, we expect that this is the last named release to support the Legacy courseware frontend.
 
@@ -55,7 +53,7 @@ If the Learning MFE is installed using the MFE Deployer Ansible role then certai
   - course_home.course_home_mfe_progress_tab: Display the “Progress” course tab in the MFE.
 
 Course Dates & Milestones
--------------------------
+=========================
 
 When a learner reaches the end of the course, they will see a new navigation button directing them to “Complete the course” if they’ve passed or completed an audit course. The new Course Completion page also provides clarity for common learner questions - Did I complete the course? Did I achieve a certificate? Am I still eligible to upgrade?
 
@@ -64,7 +62,7 @@ The 3-day Streak Milestone is live and celebrates learners who engage with their
 See https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-FEATURES['ENABLE_MILESTONES_APP'] for information on how to turn on and configure these Milestones features.
 
 Mobile Experience
------------------
+=================
 
 - The fonts, text and colors have been updated to match the rebrand, giving users a consistent cross platform experience.
 - Mobile learners can now understand the benefits of the upgrade option, especially when they encounter locked content.
@@ -78,23 +76,22 @@ Mobile Experience
 
 
 Special Exams Experience
-------------------------
+========================
 
 Proctortrack Onboarding UX Improvements: Based on learner feedback, we’ve added new messaging and entrance locations to the Proctortrack onboarding experience to make the process more clear. (TBD image)
 
 
 
-=====================
 Authoring Experiences
-=====================
+*********************
 
 Studio
-------
+======
 
 - In-Context Unit Naming: Authors can now rename units from the course outline.
 
 Open-Response Assessments
--------------------------
+=========================
 
 - Toggle rubric visibility for learners: Course staff can now choose to show learners the rubric for an ORA as they complete their ORA submission, more easily allowing learners to understand how they will be evaluated.
 - ORA Problems as Component Category: We have elevated Open Response components as a category in the Studio Unit page so that they are easier to drop into a unit page with pre-configured templates. You can quickly add some of the most commonly configured ORA problems
@@ -109,15 +106,17 @@ Open-Response Assessments
 
 
 LTI 1.3 and LTI Advantage Support
----------------------------------
+=================================
+
 lti-consumer-xblock (also known as xblock-lti-consumer) has been updated to support LTI 1.3, as well as the Deep Linking (LTI-DL) and Assignments and Grades services (LTI-AGS) features of LTI Advantage. Note that this xBlock is not installed in Lilac by default. Information on configuring lti-consumer-xblock can be found at https://github.com/openedx/xblock-lti-consumer/blob/master/README.rst
 
 Gradebook MFE
--------------
+=============
+
 The Gradebook MFE is *not* enabled by default because theming and internationalizations support is incomplete. It allows editing of individual learners' grades. Also supports bulk uploads of grades, but requires additional configuration. See https://github.com/openedx/frontend-app-gradebook/blob/open-release/lilac.master/README.md for more information.
 
 Special Exams Experience
-------------------------
+========================
 
 - Proctortrack Onboarding Status Menu: Helps course teams better identify which learners have been onboarded and which have not. See https://partners.edx.org/announcements/proctortrack-onboarding-status-menu for more information. The dashboard can be found under *Instructor Dashboard > Special Exams > Student Onboarding Status*. Requires integration with the `ProctorTrack Service from Verificient`_.
 - Reset an Errored Proctortrack Exam Attempt: We added the ability to reset an errored Proctortrack exam attempt to be “Ready to resume” status. Learners will be able to resume the exam immediately once the course team allows it. The exam time will resume from where they last experienced an error.  For example, if the learner errored 45 minutes into the exam, and the allowed duration of the exam is 2 hours, the learner will only have 1 hour and 15 minutes to complete the rest of the exam.
@@ -125,16 +124,15 @@ Special Exams Experience
 .. _ProctorTrack Service from Verificient: https://www.verificient.com/proctortrack/
 
 Credentials (for Programs)
---------------------------
+==========================
 
 Program Completion Emails: Added `ProgramCompletionEmailConfiguration`_ that enables an email to be customized and sent to learners when triggered by the generation of a program certificate. These email messages are especially useful to remind a learner of their accomplishment at the appropriate time if a course in the program has a `certificate availability date`_ set in the future. These messages can be customized on a per program basis.
 
-=========================
 Administrator Experiences
-=========================
+*************************
 
 Migrations
-----------
+==========
 
 An index was added to the ``courseware_studentmodule`` table. This can be a VERY EXPENSIVE MIGRATION which may take hours or days to run depending on size. Depending on your database, it may also lock this table, causing courseware to be non-functional during that time.
 
@@ -146,7 +144,7 @@ way (separate from your release pipeline), the SQL needed is::
 You can then `fake the migration`_.
 
 Course Upsell Messaging and Payment
------------------------------------
+===================================
 
 - Reduce PCI compliance burden by replacing checkout fields which collect relevant PII data with Cybersource hosted fields. This way we do not collect and sensitive information and do not have to
 - Allows setting default currency from environment
@@ -154,7 +152,8 @@ Course Upsell Messaging and Payment
 
 
 Settings and Toggles Documentation
-----------------------------------
+==================================
+
 Documentation for settings and toggles is much improved, but still incomplete. See https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/index.html
 
 New settings introduced in Lilac include:
@@ -163,7 +162,7 @@ TBD
 
 
 Dependency updates
-------------------
+==================
 
 - Mongo was upgraded from 3.0 to 4.0.
 - Switched from Elasticsearch 1 to Elasticsearch 7 across Open edX. This may require some syntax changes for custom scripts that used search APIs.
@@ -173,12 +172,12 @@ Dependency updates
   - Please change queries against course-discovery that used pacing to pacing_type
 
 New Settings
-------------
+============
 
 - Use of edx-proctoring with the ProctorTrack vendor now requires a setting PROCTORING_USER_OBFUSCATION_KEY – it should be initially set to the same value as SECRET_KEY, in both LMS and Studio. This allows it to be changed independently, although there is not yet a way to rotate it without breaking integration.
 
 Changes to edx-organizations
-----------------------------
+============================
 
 - Uniqueness constraint added to Organization.short_name
 
@@ -209,7 +208,7 @@ Changes to edx-organizations
     - However, future releases may make use of the data in these tables; hence, it is best to run the backfill now.
 
 Certificates
-------------
+============
 
 - Various bug fixes and updates around course certificate generation
 
@@ -224,7 +223,7 @@ Certificates
 - Added a new export-course-metadata-to-storage feature. In order to use it set COURSE_METADATA_EXPORT_BUCKET and COURSE_METADATA_EXPORT_STORAGE. Useful for external services you might have that want to scrape course data.'
 
 Deprecations
-------------
+============
 
 - The sysadmin dashboard is no longer supported.
 
@@ -237,19 +236,17 @@ Deprecations
 - Xblock URL token signing can now be migrated to use a new multi-key mechanism rather than being tied to SECRET_KEY. It is recommended that you perform this migration, as it permits easier rotation of SECRET_KEY.
 
 Branding Update
----------------
+===============
 
 Open edX logos, colors and fonts have been updated.
 
-=============================
 Researcher & Data Experiences
-=============================
+*****************************
 
 - Tracking metrics based on the anonymized session ID will experience a discontinuity or other anomaly at the time of deployment, as the anonymized IDs will change. [PR] This will likely appear as if everyone logged out and back in again, although only from a metrics perspective. In a green-blue deployment scenario, it may briefly appear as if there are twice as many sessions active.
 
-=====================
 Developer Experiences
-=====================
+*********************
 
 - Import unqualified packages from lms/djangoapps, cms/djangoapps, or common/djangoapps is no longer supported. Doing so will cause instances of import_shims.warn.DeprecatedEdxPlatformImportError to be raised. See https://github.com/openedx/edx-platform/blob/master/docs/decisions/0007-sys-path-modification-removal.rst  for details and context.
 

--- a/source/community/release_notes/maple.rst
+++ b/source/community/release_notes/maple.rst
@@ -1,6 +1,5 @@
 .. _Open edX Maple Release:
 
-######################
 Open edX Maple Release
 ######################
 
@@ -13,12 +12,11 @@ These are the release notes for the Maple release, the 13th community release of
  :depth: 1
  :local:
 
-================
 Breaking Changes
-================
+****************
 
 Tutor is the supported distribution
------------------------------------
+===================================
 
 `Tutor`_ is now the official, community-supported distribution of open edX for production. It replaces `edX configuration`_. The Tutor changelog for the Maple release is at https://github.com/overhangio/tutor/blob/master/CHANGELOG.md#v1300
 
@@ -28,13 +26,13 @@ Tutor is the supported distribution
 
 
 Learning Micro-Frontend (MFE) becomes the default courseware experience
------------------------------------------------------------------------
+=======================================================================
 
 .. warning:: Entrance exams, non-standard XML and HTML tags, and non-standard course hierarchies are not supported. See below for more details.
 
 
 Studio login changed to OAuth
------------------------------
+=============================
 
 In versions prior to Maple, Studio (CMS) shared a session cookie with the LMS, and redirected to the LMS for login.
 Studio is changing to become an OAuth client of the LMS, using the same SSO configuration that other IDAs use. (See
@@ -48,7 +46,7 @@ upgrading to Maple. For devstack, run::
 .. _Studio OAuth migration runbook: https://github.com/openedx/edx-platform/blob/open-release/maple.master/docs/guides/studio_oauth.rst
 
 django-cors-headers version updgraded
--------------------------------------
+=====================================
 
 django-cors-headers is upgraded to version 3.2.0. The setting :code:`CORS_ORIGIN_WHITELIST` now requires URI schemes.
 You will need to update your whitelist to include schemes, for example from this::
@@ -60,17 +58,17 @@ to this::
     CORS_ORIGIN_WHITELIST = ["https://foo.com"]
 
 
-===================
 Learner Experiences
-===================
+*******************
 
 Learning Micro-Frontend (MFE)
------------------------------
+=============================
 
 The Learning MFE (including both "courseware" and the "course home") is the default course experience in Maple. With the new experience, learners will notice a reduction in load times and better site performance. The Nutmeg release will drop support for the legacy (that is, LMS-rendered) course experience entirely.
 
 Configuration
-^^^^^^^^^^^^^
+-------------
+
 - MFE branding elements can be set in the Tutor MFE plugin. See the `tutor mfe plugin README`_ for more details.
 - The :code:`courseware.use_legacy_frontend` and :code:`course_home.course_home_use_legacy_frontend` Waffle flags can be toggled on (either globally or per-course-run) in order to revert to the legacy (LMS Django-rendered) courseware experience.
 - The domain name for your learning MFE should be added to the :code:`CORS_ORIGIN_WHITELIST` for ecommerce, discovery, lms, and studio.
@@ -78,7 +76,8 @@ Configuration
 .. _tutor mfe plugin README: https://github.com/overhangio/tutor-mfe#customise-mfes-logos
 
 Removed Features
-^^^^^^^^^^^^^^^^
+----------------
+
 - Entrance Exams are slated to be deprecated and are never enabled on the MFE. Attempting to start a course with an entrance exam on the MFE results in an error. Using the waffle flags to enable the legacy experience should enable their usage for the time being, but their deprecation is forthcoming.
 - Problemsets and videosequences, which are deprecated variations of the Sequence block will not render in the MFE. Note, these could have only been added in raw OLX. This cannot affect courses authored entirely in Studio.
 - **Non-standard course hierarchies** Legacy courseware was willing to render some content that didn’t strictly follow that hierarchy, and that content will break in the MFE. This should only affect courses authored directly in OLX. Studio-authored courses already follow these hierarchy requirements. Essentially, courses must follow a stricter hierarchy in order to work in the MFE:
@@ -88,7 +87,8 @@ Removed Features
   * Children of the Subsections should be "Unit-like" blocks (most commonly Verticals, but HTML/Problem/etc are okay too)
 
 Altered Features
-^^^^^^^^^^^^^^^^
+----------------
+
 - The ability for course authors to preview units in the learner experience before they are published will preview in the legacy experience, not the MFE. Work enabling preview using the MFE is anticipated.
 - According to the HTML standard, <script> and <iframe> tags are not self-closing; they must be closed with </script> and </iframe> tags. Legacy courseware incidentally corrected this error when it occurred in course content. MFE courseware does not do that correction. Course authors should update their courses to use well-formed HTML if they happened to rely on self-closing <script> or <iframe> tags.
 - Courses which use the  course key pattern ORG/COURSE/RUN instead of the new pattern, course-v1:ORG+COURSE+RUN,  are stored in our legacy storage service, Old Mongo, and will not be served by the new MFE. Instead they default to the legacy experience. But this pattern has been deprecated and will be removed.
@@ -107,7 +107,8 @@ Altered Features
 - If all content inside a unit should be invisible to a cohort, but the sequence or the unit is not hidden, learners may be able to still see the titles of the content on the course outline, as well as the title of the sequence which contains only what should be hidden content to that learner. This issue can be removed by setting the :code:`learning_sequences.use_for_outlines` waffle flag to :code:`true`.
 
 Maintained Features
-^^^^^^^^^^^^^^^^^^^
+-------------------
+
 - Features which remain functional within MFE courses, but still will be served by the legacy experience in Maple are:
 
   * The XBlock student view, as exposed via the unit iframe in MFE courseware
@@ -120,7 +121,8 @@ Maintained Features
 - Special exams (timed and proctored) will be functional within the Learning MFE for MFE enabled courses.
 
 Added Features
-^^^^^^^^^^^^^^
+--------------
+
 - To enable faster movement through course content, staff users will now see jump navigation selectors to augment the existing course breadcrumb in the learning sequence experience (Learning MFE). With this deployment, a staff user can select a section or subsection, a menu will appear, and the user can jump to a particular unit within a course.
 - Course outlines will now feature automatic effort estimates for subsections. Courses have to be republished before they show estimates, and all videos in the course must also have durations in `edx-val`_, the Open edX video abstraction layer.
 - There are some in-course celebrations of progress. A modal popup when a learner finishes their first section. And a 3-day streak celebration modal popup. This is configurable using the waffle toggles :code:`mfe_progress_milestones` and :code:`mfe_progress_milestones_streak_celebration`
@@ -129,7 +131,7 @@ Added Features
 .. _edx-val: https://github.com/openedx/edx-val
 
 Certificates
-------------
+============
 
 Various bug fixes and updates around course certificate generation
 
@@ -158,26 +160,28 @@ Various bug fixes and updates around course certificate generation
 .. _document in Confluence: https://openedx.atlassian.net/wiki/spaces/PT/pages/2594275334/Course+Import+Work
 
 Open-Response Assessments
--------------------------
+=========================
+
 - extend frontend feedback limit to 1k chars
 - Make submission feedback full-width
 
 
 Account Micro-frontend
-----------------------
+======================
 
 - removed hard-coded edX string
 
 Payment Micro-frontend
------------------------
+=======================
 
 The Payment MFE is the only supported UI for ecommerce in this release. Cybersource and PayPal backends have been tested. See the Tutor Ecommerce plugin for configuration details: https://overhang.io/tutor/plugin/ecommerce
 
 Mobile Experience
------------------
+=================
 
 Android
-^^^^^^^
+-------
+
 - Allow word_cloud as supported xBlock
 - allow specialExam xBlock to open through View on Web
 - open rendered HTML block having iframe in mobile browser
@@ -186,25 +190,25 @@ Android
 - add alerts prior to course due dates
 
 iOS
-^^^
+---
+
 - Open rendered HTML block that contains an iframe in the mobile browser
 - add word cloud to acceptable list of xblocks
 - add course events to calendar
 - Add support of lti_consumer xblocks
 
 Special Exams Experience
-------------------------
+========================
 
 - Created a new page in the account frontend to host proctoring instructions and requirements. This content can be dynamic to the need of each proctoring provider and potentially each course.
 - Allow learners to resume an exam after hitting a proctoring error, without forcing them to restart the exam, or to use an exam attempt.
 
 
-======================
 Instructor Experiences
-======================
+**********************
 
 Studio
-------
+======
 
 - Course and library creation rights can now be granted on a per-organization basis.
   * Controlled content creation rights feature must be enabled via the FEATURES['ENABLE_CREATOR_GROUP'] flag.
@@ -217,7 +221,7 @@ Studio
   * However, administrators can safely modify the organization settings on existing creation right grants if they would like to retroactively use this feature.
 
 Course Authoring Import Messaging & Validation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+----------------------------------------------
 
 While many course teams do not commonly use this course import, educators cannot continue course authoring when it does fail. Previously, course teams would occasionally encounter issues importing a new version of their course through Studio. Existing error messaging made the root cause hard to discern, requiring course teams to reach out to an admin for assistance. Educators blocked by the import tool were not unable to update or launch their course without admin intervention, delaying authoring and publishing timelines for courses.
 
@@ -225,7 +229,7 @@ Now educators will see specific error messages in the course import area of Stud
 
 
 Uploading Errors
-================
+****************
 
 - **File Chunk Missed During Upload** - The most common error that was captured, “Chunk Missed Error”. When a Course Import file (tar.gz) is larger than 20MB, it is divided into equal chunks and uploaded to the server. Due to our server configuration, it is possible to lose a chunk that could fail the course import while combining on the server.
 
@@ -234,7 +238,7 @@ Uploading Errors
 - **Incompatible File** - This error is raised if a user accidentally tries to upload an incompatible file. This check exists in the frontend as well.
 
 Unpacking Errors
-================
+****************
 
 - **Invalid User** - Raised if the provided user_id does not exist. The check is redundant if the import is submitted via Studio frontend, but is a valid sanity check for API submissions
 
@@ -249,12 +253,12 @@ Unpacking Errors
 - **Unknown Exception** - There can still be unknown events that may occur during the course import, for those further information will be logged in the system logs but there is not a clear and useful user facing error.
 
 Verifying Stage
-===============
+***************
 
 - **Verify Root Name** - The root name for a course import is ``course.xml`` and for a library it's ``library.xml``. If that file does not exist then this error is thrown.
 
 Updating Errors
-===============
+***************
 
 The errors can occur after the XML validation and during the data update in the course.
 
@@ -273,10 +277,10 @@ The errors can occur after the XML validation and during the data update in the 
    More information about the development process can be found in this `document in Confluence`_.  However that is not a public document and only left here for admins and future reference. The error details above have been extracted from that document.
 
 Open-Response Assessments
--------------------------
+=========================
 
 Reusable Rubrics
-^^^^^^^^^^^^^^^^
+----------------
 
 Course staff can now reuse a rubric from an existing Open Response Assessment (ORA) in a course when creating a new ORA in the same course. Using a Block ID, course staff can now specify which ORA’s rubric they want to clone into another ORA within the same course.
 
@@ -288,7 +292,7 @@ Once the correct Block ID is selected, they can select “Clone” and all of th
 
 
 Other ORA features
-^^^^^^^^^^^^^^^^^^
+------------------
 
 - Learners can now provide feedback with an expanded character limit of 1k
 - Add a new button to edit an ORA in Studio
@@ -297,7 +301,7 @@ Other ORA features
 
 
 LTI 1.3 and LTI Advantage Support
----------------------------------
+=================================
 
 lti-consumer-xblock (also known as xblock-lti-consumer) has been updated to support LTI 1.3, as well as the Deep Linking (LTI-DL) and Assignments and Grades services (LTI-AGS) features of LTI Advantage. Information on configuring lti-consumer-xblock can be found at https://github.com/openedx/xblock-lti-consumer/blob/master/README.rst
 
@@ -312,7 +316,7 @@ lti-consumer-xblock (also known as xblock-lti-consumer) has been updated to supp
 
 
 Gradebook Micro-FrontEnd
-------------------------
+========================
 
 Gradebook allows course staff to view, filter, and override subsection grades for a course. For configuration details, see https://github.com/openedx/frontend-app-gradebook
 
@@ -323,36 +327,36 @@ There are some limitations to the version in Maple:
 
 
 Special Exams Experience
-------------------------
+========================
 
 - We added a view to the Instructor Dashboard for seeing onboarding progress for Proctored Exams. This tab includes all students enrolled in the course and their onboarding state, even if they have never attempted the exam. This list should be filterable to quickly identify the list of learners where action may be needed to encourage onboarding soon.
 - Instructors can give learners permission to resume an exam after encountering a proctoring error. Grades/certificates will not be released until all active attempts have been reviewed and marked as passing.
 
 
-=========================
 Administrator Experiences
-=========================
+*************************
 
 
 Password Complexity
--------------------
+===================
 
 Implemented and rolled out new password complexity requirements to meet PCI compliance. For more detail, see https://github.com/openedx/edx-platform/blob/open-release/maple.master/common/djangoapps/util/password_policy_validators.py
 
 
 Migrations
-----------
+==========
 
 See the sections above on OAuth and Certificates.
 
 
 Settings and Toggles
---------------------
+====================
+
 Documentation for settings and toggles is much improved, but still incomplete. See https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/index.html
 
 
 Dependency updates
-------------------
+==================
 
 - **Django 3.2** We upgraded Django to version 3.2, the next LTS (long term support) release. More details available at https://openedx.atlassian.net/wiki/spaces/AC/pages/2844426436/Django+3.2+Upgrade
 - **ElasticSearch 7.10** We upgraded all IDAs, using ElasticSearch (edx-platform, Blockstore, discovery, notes, analytics-api, cs-c comments-service) to ElasticSearch 7.10.
@@ -360,31 +364,29 @@ Dependency updates
 
 
 Deprecations
-------------
+============
 
 - The sysadmin dashboard has been removed. Similar functionality is available via the (unsupported) edx-sysadmin plugin from https://github.com/mitodl/edx-sysadmin/
 - The :code:`AUDIT_CERT_CUTOFF_DATE` setting was removed. This setting allowed organizations that previously offered course certificates to audit track learners to discontinue generation of this type of certificate. Instead, the logic of :code:`CourseMode.is_eligible_for_certificate()` will be used. In this logic, the audit mode is not eligible for a course certificate. The honor mode may or may not be eligible, depending on whether the :code:`DISABLE_HONOR_CERTIFICATES` feature is enabled. Other modes are eligible for certificates.
 - The management command named :code:`cert_whitelist` has been removed. In its place, please use the Certificate Allowlist, which can be accessed from the Instructor tab on the course page in the LMS. (`DEPR-156`_)
 
 
-=============================
 Researcher & Data Experiences
-=============================
+*****************************
 
 - Tracking metrics based on the anonymized session ID will experience a discontinuity or other anomaly at the time of deployment, as the anonymized IDs will change. This will likely appear as if everyone logged out and back in again, although only from a metrics perspective. In a green-blue deployment scenario, it may briefly appear as if there are twice as many sessions active.
 - Removed certificate generation segment event. We will continue to track certificate creation/generation using the existing :code:`edx.certificate.created` event.
 
-=====================
 Developer Experiences
-=====================
+*********************
 
 Hooks Extension Framework
--------------------------
+=========================
 
 Hooks are predefined places in the edx-platform core where externally defined functions can take place. In some cases, those functions can alter what the user sees or experiences in the platform. Other cases are informative only. All cases are meant to be extended using Open edX plugins and configuration. For documentation, see https://github.com/eduNEXT/edx-platform/blob/open-release/maple.master/docs/guides/hooks/index.rst You can find code for a sample hook at https://github.com/eduNEXT/openedx-events-2-zapier
 
 Course Certificate Generation Logic Improvement
------------------------------------------------
+===============================================
 
 We have replaced the back-end code (no UX changes) that generates course certificates with a new version to condense the number of conflicting generation logic patterns, make it easier to troubleshoot/support, and to better defend generated certificates against errant revocation.
 
@@ -393,7 +395,8 @@ By creating this new, unified course certificate generation logic we have improv
 Learners and partners should not notice any change. The only effect is that they should see a reduced time to resolution if they ever encounter a problem related to certificates or credentials.
 
 Learning Micro-Frontend (MFE)
------------------------------
+=============================
+
 To increase development speed and site performance, we've made improvements to the learning sequence experience (Learning MFE) on edX-platform, to use a React-based frontend that emulates the legacy experience. The Learning MFE code repository is at https://github.com/openedx/frontend-app-learning
 
 After a year of diligently working to overhaul the learning sequence experience to use a React-based micro-frontend, it is now live for learners. This update to the underlying infrastructure of the learning sequence experience aims to drive innovation and experimentation that will ultimately foster greater learner engagement. With the new experience, learners will notice a reduction in load times and better site performance. However, the true beneficiaries of this work are internal development teams who will be able to quickly and efficiently build in this area of the system.

--- a/source/community/release_notes/named_release_branches_and_tags.rst
+++ b/source/community/release_notes/named_release_branches_and_tags.rst
@@ -1,4 +1,3 @@
-########################################
 Open edX Named Release Branches and Tags
 ########################################
 
@@ -8,7 +7,7 @@ Open edX releases are named alphabetically with botanical tree names.
 
 
 Latest Open edX Release
------------------------
+***********************
 
 The latest supported release line is Olive_, based on code from 2022-10-11.
 
@@ -18,7 +17,7 @@ __ https://openedx.atlassian.net/wiki/spaces/COMM/pages/3552938822/Palm
 
 
 All Open edX Releases
----------------------
+*********************
 
 .. contents::
    :local:
@@ -33,7 +32,7 @@ Every release line (Ginkgo, Hawthorn, etc) has a branch that accumulates changes
 If an installation of a tag fails, try the corresponding release line master branch, it may have a fix.
 
 Olive
-~~~~~
+=====
 
 * **Code cut date:** 2022-10-11
 * **Status:** supported
@@ -55,7 +54,7 @@ Olive
      - open-release/olive.2
 
 Nutmeg
-~~~~~~
+======
 
 * **Code cut date:** 2022-04-12
 * **Status:** unsupported
@@ -81,7 +80,7 @@ Nutmeg
      - open-release/nutmeg.3
 
 Maple
-~~~~~
+=====
 
 * **Code cut date:** 2021-10-15
 * **Status:** unsupported
@@ -99,7 +98,7 @@ Maple
      - open-release/maple.1
 
 Lilac
-~~~~~
+=====
 
 * **Code cut date:** 2021-04-09
 * **Status:** unsupported
@@ -121,7 +120,7 @@ Lilac
      - open-release/lilac.1
 
 Koa
-~~~
+===
 
 * **Code cut date:** 2020-11-12
 * **Status:** unsupported
@@ -151,7 +150,7 @@ Koa
      - open-release/koa.1
 
 Juniper
-~~~~~~~
+=======
 
 * **Code cut date:** 2020-05-27
 * **Status:** unsupported
@@ -177,7 +176,7 @@ Juniper
      - open-release/juniper.1
 
 Ironwood
-~~~~~~~~
+========
 
 * **Code cut date:** 2019-01-17
 * **Status:** unsupported
@@ -203,7 +202,7 @@ Ironwood
      - open-release/ironwood.1
 
 Hawthorn
-~~~~~~~~
+========
 
 * **Code cut date:** 2018-07-03
 * **Status:** unsupported
@@ -226,7 +225,7 @@ Hawthorn
      - open-release/hawthorn.1
 
 Ginkgo
-~~~~~~
+======
 
 A note about Vagrant box files:
 
@@ -270,7 +269,7 @@ A note about Vagrant box files:
           * 990d5fdb5bbc7683c158dd99d5732064932c9cdd
 
 Ficus
-~~~~~
+=====
 
 * **Code cut date:** 2017-01-10
 * **Status:** unsupported
@@ -303,7 +302,7 @@ Ficus
           * a7fb2200ccdb9f847bee7acd97f5e4e1434776b3
        * `fullstack <https://s3.amazonaws.com/edx-static/vagrant-images/ficus-fullstack-2017-04-20.box?torrent>`__
           * ficus-fullstack-2017-04-20
-          * 64eb0a247d99454bccf0eed7ec49b076cbb9cd69 
+          * 64eb0a247d99454bccf0eed7ec49b076cbb9cd69
 
    * - Ficus.2
      - 2017-03-29
@@ -313,7 +312,7 @@ Ficus
           * a7fb2200ccdb9f847bee7acd97f5e4e1434776b3
        * `fullstack <https://s3.amazonaws.com/edx-static/vagrant-images/ficus-fullstack-2017-03-28.box?torrent>`__
           * ficus-fullstack-2017-03-28
-          * fc6aa0d3b686c83e38e8c7fa1b1f172fcf7f71c1 
+          * fc6aa0d3b686c83e38e8c7fa1b1f172fcf7f71c1
 
    * - Ficus.1
      - 2017-02-23
@@ -323,10 +322,10 @@ Ficus
           * a7fb2200ccdb9f847bee7acd97f5e4e1434776b3
        * `fullstack <https://s3.amazonaws.com/edx-static/vagrant-images/ficus-fullstack-2017-02-15.box?torrent>`__
           * ficus-fullstack-2017-02-15
-          * cd6310ffc1e6b374d2c3d59aab5191500f9d5d6f 
+          * cd6310ffc1e6b374d2c3d59aab5191500f9d5d6f
 
 Eucalyptus
-~~~~~~~~~~
+==========
 
 * **Code cut date:** 2016-07-13
 * **Status:** unsupported
@@ -349,7 +348,7 @@ Eucalyptus
           * a26c8fdbb431279863654161d0145732ee36ed66
        * `fullstack <https://s3.amazonaws.com/edx-static/vagrant-images/eucalyptus-devstack-2016-09-01.box?torrent>`__
           * eucalyptus-fullstack-2017-01-10
-          * 64fd2a6efd656a7170127cccdf4458699ea04978 
+          * 64fd2a6efd656a7170127cccdf4458699ea04978
 
    * - Eucalyptus.2
      - 2016-09-02
@@ -368,7 +367,7 @@ Eucalyptus
           * eucalyptus-fullstack-2016-08-25
 
 Dogwood
-~~~~~~~
+=======
 
 * **Code cut date:** 2015-12-15
 * **Status:** unsupported
@@ -416,7 +415,7 @@ Dogwood
           * dogwood-fullstack-rc2
 
 Cypress
-~~~~~~~
+=======
 
 * **Code cut date:** 2015-07-07
 * **Status:** unsupported
@@ -438,7 +437,7 @@ Cypress
        * `fullstack <https://s3.amazonaws.com/edx-static/vagrant-images/cypress-fullstack.box?torrent>`__
 
 Birch
-~~~~~
+=====
 
 * **Code cut date:** 2015-01-29
 * **Status:** unsupported
@@ -472,7 +471,7 @@ Birch
        * `fullstack <https://s3.amazonaws.com/edx-static/vagrant-images/20150224-birch-fullstack.box?torrent>`__
 
 Aspen
-~~~~~
+=====
 
 * **Code cut date:** 2014-09-05
 * **Status:** unsupported
@@ -494,7 +493,7 @@ Aspen
 
 
 Future Releases
----------------
+***************
 
 Upcoming releases have wiki pages for engineers to collect information that will be needed for their release on the
 `Open edX Release Planning`_ page.
@@ -502,7 +501,7 @@ Upcoming releases have wiki pages for engineers to collect information that will
 .. _Open edX Release Planning: https://openedx.atlassian.net/wiki/spaces/COMM/pages/13205845/Open+edX+Release+Planning
 
 Security Updates
-----------------
+****************
 
 If security vulnerabilities or other serious problems (such as data loss) are discovered in the most recent Open edX
 release, edX will release a new version of that release that includes the fix. We will not make patches of any releases
@@ -512,7 +511,7 @@ vulnerability. If you have found a security vulnerability in the Open edX codeba
 email to security@openedx.org. Please do not post the vulnerability to the public.
 
 Feedback
---------
+********
 
 If you find a problem in the release candidate, please report them to the Build-Test-Release Working Group.  You can
 do so by `creating a new issue`_.

--- a/source/community/release_notes/nutmeg.rst
+++ b/source/community/release_notes/nutmeg.rst
@@ -1,6 +1,5 @@
 .. _Open edX Nutmeg Release:
 
-#######################
 Open edX Nutmeg Release
 #######################
 
@@ -13,26 +12,27 @@ These are the release notes for the Nutmeg release, the 14th community release o
  :depth: 1
  :local:
 
-================
 Breaking Changes
-================
+****************
 
 SafeSessionMiddleware
----------------------
+=====================
+
 Before upgrade: Check that your logs do not contain warnings starting with "SafeCookieData user at request", or that these warnings are very rare. If they are common, see the SafeSessionMiddleware section below in the Administrators and Operators Section.
 
 Django Admin login disabled by default
---------------------------------------
+======================================
+
 Default Django admin login window is disabled and now one has to login from the LMS.
 
-===================
 Learner Experiences
-===================
+*******************
 
 * Bug fix: facebook share links now work on the course about page.
 
 User Tours
-----------
+==========
+
 User Tours are walkthroughs that can be presented to users in micro-frontends (MFEs). The default tours that exist are: "Course Home New User Tour" (`screencast`_), "Course Home Existing User Tour", and "Courseware New User Tour".
 In order for User Tours to properly work, the backpopulate user tours management command should be run.
 
@@ -44,7 +44,8 @@ In order for User Tours to properly work, the backpopulate user tours management
 
 
 Dates Tab
----------
+=========
+
 The Dates Tab has been added as a default static tab on all courses. All new courses will automatically include the Dates Tab. In order to properly have the Dates Tab show up for all your existing courses, a backfill course tabs management command has been created.
 
 .. code-block:: shell
@@ -55,13 +56,14 @@ The Dates Tab has also been removed from the legacy learner experience. It is on
 
 
 Weekly Course Goals
--------------------
+===================
+
 The old course goals feature has been replaced with a new weekly learning goals feature. Users set a goal for how frequently they want to learn per course and get reminder emails about their goals. See `Enabling the Weekly Learning Goals Feature`_ for instructions on how to configure this feature and more details on how the feature works. The new weekly learning goals feature is controlled with the same flag as the previous course goals feature.
 
 .. _Enabling the Weekly Learning Goals Feature: https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/enable_weekly_learning_goals.html
 
 Learning Micro-Frontend (MFE)
------------------------------
+=============================
 
 * When an XBlock fails to render, the user will now see an error message "An unexpected error occurred. Please click the button below to refresh the page."
 * RTL languages are now supported
@@ -69,7 +71,7 @@ Learning Micro-Frontend (MFE)
 
 
 Account Micro-frontend (MFE)
-----------------------------
+============================
 
 The `Account Micro-frontend (MFE)`_ is now enabled by default. The legacy account pages will be removed in the next release, Olive.
 
@@ -77,7 +79,7 @@ The `Account Micro-frontend (MFE)`_ is now enabled by default. The legacy accoun
 
 
 Mobile Experience
------------------
+=================
 
 * Added support for notices in apps.
 * Added an activation opt in checkbox (default checked) so user can agree to receive marketing messages. See `LEARNER-8652`_ for a screenshot.
@@ -86,14 +88,13 @@ Mobile Experience
 .. _LEARNER-8652: https://openedx.atlassian.net/browse/LEARNER-8652
 
 Special Exams Experience
-------------------------
+========================
 
 To take a proctored exam, the learner must now be enrolled in a :code:`verified` course track. Previously, a learner enrolled in any track could take a proctored exam. Note that ID verification (IDV) is not required.
 
 
-======================
 Instructor Experiences
-======================
+**********************
 
 * Default course tabs have a new, standard order. Course authors may still change the order of their custom static tabs, but the ordering of the default tabs cannot be changed. This ensures a more uniform location across courses.
 * When setting grading policies, course authors can now set the minimum grade cutoff to 99. Previously it could not be higher than 97.
@@ -101,7 +102,7 @@ Instructor Experiences
 
 
 LTI Support
------------
+===========
 
 * Course authors can now define static and dynamic custom parameters that will be sent to the LTI Tool Provider at launch. See the `Custom LTI Parameter section of the LTI Consumer XBlock Readme`_ for more details.
 * Mobile apps can now support LTI by opening it in a browser
@@ -109,15 +110,14 @@ LTI Support
 .. _Custom LTI Parameter section of the LTI Consumer XBlock Readme: https://github.com/openedx/xblock-lti-consumer/blob/master/README.rst#custom-lti-parameters
 
 Gradebook Micro-frontend (MFE)
-------------------------------
+==============================
 
 * Added support for transifex translations.
 * Added support for custom theming.
 
 
-==========================
 Administrators & Operators
-==========================
+**************************
 
 * Various improvements and bugfixes have been applied to `Tutor`_, the officialy-supported Open edX distribution and installation method. Notable features include an overhauled Tutor Plugin API and a new CLI for mounting repositories during development. You can see the full list by viewing `Tutor's changelog, starting at v13.0.1`_ (the first Tutor release after Maple) and reading upwards until v14.0.0 (the first Tutor release supporting Nutmeg).
 
@@ -148,7 +148,7 @@ Administrators & Operators
 * Bug fix: When using GMSTP (Gmail) for sending bulk email, retriable SMTP exceptions were not caught and bulk sending failed. This has been fixed.
 
 Bulk Course Email Tool
-----------------------
+======================
 
 * Added the ability to filter recipients of bulk course emails based on the last_login date of Users enrolled in a course run. This feature can be enabled by setting a value for the :code:`BULK_COURSE_EMAIL_LAST_LOGIN_ELIGIBILITY_PERIOD` setting. Its value should be an integer (representing months) that represents the eligibility period from the current date to receive a message. The new setting defaults to None which keeps this new feature disabled (and there will be no change in behavior in how recipients are filtered/selected for a message).
 
@@ -158,7 +158,7 @@ Bulk Course Email Tool
 
 
 SafeSessionMiddleware rejects mismatching requests and sessions
----------------------------------------------------------------
+===============================================================
 
 Background: :code:`SafeSessionMiddleware` is an existing middleware that provides several protections against vulnerabilities that could result from cache misconfigurations or other bugs resulting in one user getting a different user's session.
 
@@ -168,13 +168,13 @@ Before upgrade: Check that your logs do not contain warnings starting with "Safe
 
 
 Migrations
-----------
+==========
 
 There are no known migrations that will cause compatibility issues when deployed. As always migrations should be run before the new code is deployed.
 
 
 Pre-Alpha Features
--------------------
+===================
 
 The following Micro-frontends (MFEs) are in a "pre-alpha" state. They exist on GitHub but are not yet supported in Tutor. Additionally, they may lack key features such as support for theming, internationalization, and path-based deployments. We include mention of them because we expect all of them to be supported in the next release, Olive.
 
@@ -189,7 +189,7 @@ The following Micro-frontends (MFEs) are in a "pre-alpha" state. They exist on G
 .. _Open-Response Assessments (ORA) Grading Micro-frontend (MFE): https://github.com/edx/frontend-app-ora-grading
 
 Settings and Toggles
---------------------
+====================
 
 New settings and toggles added since the Maple release:
 
@@ -255,16 +255,16 @@ the following settings were removed:
 
 
 Dependency updates
-------------------
+==================
 
 There are no notable dependency updates in nutmeg.
 
-============
 Deprecations
-============
+************
 
 Removed in Nutmeg
------------------
+=================
+
 - django-ratelimit-backend has been removed from edx-platform. Now the django-ratelimit library will be used for rate limiting. See `DEPR-150`_ for more details. Related to this, the default Django admin login window is disabled and now one has to login from LMS.
 - The `edx-certificates repo`_ has been archived. See `DEPR-160`_ for more details.
 - “Old Mongo” course access has finally been fully removed. This means course runs that have keys like :code:`Org/Course/Run` rather than :code:`course-v1:Org+Course+run`  cannot be accessed by learners. New runs of this type haven’t been able to be created since 2015, but now learner access has also been removed. See `[DEPR] Issue #62`_ for more information on the continuing removal of Old Mongo technology.
@@ -276,7 +276,7 @@ Removed in Nutmeg
 .. _[DEPR] Issue #62: https://github.com/openedx/public-engineering/issues/62
 
 Deprecated in Nutmeg (or earlier) and scheduled to be removed in the Olive release
-----------------------------------------------------------------------------------
+==================================================================================
 
 * `bokchoy test suites`_
 * the `frontend-learner-portal-base`_ library
@@ -295,22 +295,20 @@ Deprecated in Nutmeg (or earlier) and scheduled to be removed in the Olive relea
 .. _import legacy OLX attributes: https://github.com/openedx/public-engineering/issues/74
 
 Future deprecations and removals
---------------------------------
+================================
 
 .. note:: Major deprecation work is being funded between now and the Olive release, scheduled for December 2022. Please review the `DEPR: Deprecation & Removal`_ board on Github to be sure you have stopped using deprecated technologies.
 
 .. _DEPR\: Deprecation & Removal: https://github.com/orgs/openedx/projects/9/views/4
 
-=============================
 Researcher & Data Experiences
-=============================
+*****************************
 
 * added a :code:`complete_video` event that fires when a user has watched a video to the end. Requires the waffle switch :code:`completion.enable_completion_tracking`
 
 
-=====================
 Developer Experiences
-=====================
+*********************
 
 * Added support for custom xBlock editors in Studio. Read the `pluggable_override docstring`_ to learn more.
 * Added an API for updating user's email opt-in setting.
@@ -321,7 +319,8 @@ Developer Experiences
 .. _PR 29376: https://github.com/openedx/edx-platform/pull/29376
 
 Events and Filters Extension Framework
---------------------------------------
+======================================
+
 Core extensibility: We have added a new way of extending the core through `Open edX Events & Filters`_ (part of `OEP-50: Hooks Extension Framework`_)
 
 Open edX Events: this standardized version of Django Signals allows extension developers to extend functionality just by listening to the event that’s sent after a key process finishes, e.g after enrollment, login, register, etc.

--- a/source/community/release_notes/olive.rst
+++ b/source/community/release_notes/olive.rst
@@ -1,6 +1,5 @@
 .. _Open edX Olive Release:
 
-######################
 Open edX Olive Release
 ######################
 
@@ -14,11 +13,12 @@ These are the release notes for the Olive release, the 15th community release of
  :local:
 
 Breaking Changes
-================
+****************
 
 
 All grades are persisted
-------------------------
+========================
+
 The Persistent Grades feature was added as an option in Hawthorne. Legacy, non-persistent grades were deprecated in Nutmeg and enabled by default in Tutor. Now, persistent grades are required.
 
 If you are not using Tutor, and have not turned on persistent grades in your installation yet, grades will disappear from learners' Progress pages and in Instructors' data downloads when you upgrade to Olive. You must follow the instructions in `Migrating to Persistent Grading`_ for grades to appear. This process can take a significant amount of time, depending on how many graded problems are in your installation, and how long those grades take to be calculated. While we recommend this be run before the upgrade, to ensure learners experience no disruptions to their Progress pages, it will still work if it is run after the upgrade.
@@ -26,7 +26,8 @@ If you are not using Tutor, and have not turned on persistent grades in your ins
 .. _Migrating to Persistent Grading: https://openedx.atlassian.net/wiki/spaces/AC/pages/755171487/Migrating+to+Persistent+Grading
 
 Learning MFE is now required
-----------------------------
+============================
+
 The Learning Micro Frontend (MFE) is no longer optional, and must be run as part of your installation. In Tutor, this means that the `MFE plugin`_ must be installed and enabled.
 
 .. _MFE Plugin: https://github.com/overhangio/tutor-mfe
@@ -34,18 +35,20 @@ The Learning Micro Frontend (MFE) is no longer optional, and must be run as part
 The Learning MFE has been the default since the Maple release, with a setting that allowed for opting out. The setting :code:`courseware.use_legacy_frontend` has been removed. (See :ref:`deprecations-and-removals` for more).
 
 MFE settings are no longer supported in Tutor configuration
------------------------------------------------------------
+===========================================================
+
 Instead, :ref:`mfe-runtime-configuration` should now be used to manage MFE settings. See the :ref:`upgrade-note` for specific MFE variables that have been removed.
 
 JWT access tokens expire in 1 hour
-----------------------------------
+==================================
+
 The default expiration for JWT access tokens was changed from ten hours to one hour. This default setting can be overriden now, by setting :code:`JWT_ACCESS_TOKEN_EXPIRE_SECONDS`.
 
 Learner Experiences
-===================
+*******************
 
 Authentication Micro-frontend (MFE)
------------------------------------
+===================================
 
 The Authentication MFE is responsible for the login, registration and password reset functionality. It is enabled by default in Olive and has all the same features as the legacy login and registration pages. You can revert to the legacy experience by setting :code:`FEATURES['ENABLE_AUTHN_MICROFRONTEND']` to False. Although the deprecation process for the legacy experiences has not yet started, they could be removed as soon as the next release, Palm.
 
@@ -58,7 +61,7 @@ There are a number of settings that affect this experience. See the `Authenticat
 
 
 Discussions Micro-frontend (MFE)
---------------------------------
+================================
 
 The Discussions MFE is included in the Olive release and enabled by default. You can control which learners will see it with the waffle flag :code:`discussions.enable_discussions_mfe`. To configure course discussions, the :ref:`course-authoring-mfe` must be enabled as well. Although the deprecation process for the legacy discussion experiences has not yet started, they could be removed as soon as the next release, Palm.
 
@@ -78,18 +81,18 @@ See the `New discussions forum experience wiki page`_ for a detailed explanation
 
 
 Other Learner Experience changes
---------------------------------
+================================
 
 - add reset option to the Randomized Content Block. See this `video demo <https://www.loom.com/share/91b7224cb8a74cf2891a240b6e4fb8c6>`_ for the new user experience.
 - "Live" tab displayed on course when live content is enabled (for example, Zoom or Big Blue Button). More information about Zoom integration is available in two blog posts in the wiki, `Course-Level Zoom Integration <https://openedx.atlassian.net/wiki/spaces/OEPM/blog/2022/10/21/3560243384/2U+Course-Level+Zoom+Integration>`_ and `Program & Degree level Zoom Integration <https://openedx.atlassian.net/wiki/spaces/OEPM/blog/2022/10/21/3560833066/2U+Program+Degree+level+Zoom+Integration>`_
 
 Instructor Experiences
-======================
+**********************
 
 .. _course-authoring-mfe:
 
 Course Authoring Micro-frontend (MFE)
--------------------------------------
+=====================================
 
 The Course Authoring Micro-frontend is included and enabled by default in the Olive release, but only the :ref:`pages-and-resources` feature is turned on. The MFE can be disabled by setting :code:`COURSE_AUTHORING_MICROFRONTEND_URL` to False. The Course Authoring MFE also allows for new course editors in Studio, although only the new :ref:`text-html-editor` is production ready. More details on each of these features are below, and in the `Course Authoring MFE README`_.
 
@@ -98,7 +101,7 @@ The Course Authoring Micro-frontend is included and enabled by default in the Ol
 .. _pages-and-resources:
 
 Pages & Resources
------------------
+=================
 
 Part of the :ref:`course-authoring-mfe`, when this feature is enabled course authors can now get to the Pages & Resources view from the Content menu (it replaces the "Pages" menu item). This is a modular interface for settings for various course applications and tools. Depending on which ones are enabled, they can include Progress, Discussion, Notes, Wiki, Calculator, Custom pages, Proctoring, and Textbooks. The waffle flag :code:`discussions.pages_and_resources_mfe` must be set to enable access to Pages & Resources.
 
@@ -108,7 +111,7 @@ Part of the :ref:`course-authoring-mfe`, when this feature is enabled course aut
 .. _text-html-editor:
 
 Text / HTML Editor
--------------------
+===================
 
 Formerly known as the HTML Component, the newly renamed Text Component includes updates that make it even easier to include text and images in your course content. This editor is part the of :ref:`course-authoring-mfe`. To enable it, set the waffle flag :code:`new_core_editors.use_new_text_editor`.
 
@@ -123,7 +126,7 @@ The newly updated editor:
 .. _video-editor:
 
 Video Editor
-------------
+============
 
 Part of the :ref:`course-authoring-mfe`, the new video editor is not production ready. If you want to experiment with it, you can enable it by setting the waffle flag :code:`new_core_editors.use_new_video_editor`
 
@@ -131,12 +134,12 @@ Part of the :ref:`course-authoring-mfe`, the new video editor is not production 
     :alt: new Video Editor in Studio
 
 Discussions
------------
+===========
 
 An email can now be sent out to discussion moderators when content (post/response/comment) is reported.  To use it, set the :code:`discussions.enable_reported_content_email_notifications` waffle flag.  See https://github.com/openedx/edx-platform/pull/30276 for more details.
 
 Other Instructor Experience changes
------------------------------------
+===================================
 
 - Course authors can optionally set Randomized Content Blocks to display a reset option. This allows students to use the Randomize Content Block as a problem-bank for studying. See this `video demo <https://www.loom.com/share/91b7224cb8a74cf2891a240b6e4fb8c6>`_ for the new user experience.
 - Upgraded TinyMCE version 4 to version 5.5.1 in Studio.
@@ -144,14 +147,14 @@ Other Instructor Experience changes
 
 
 Administrators & Operators
-==========================
+**************************
 
 Relevant changes to Tutor are in the `Tutor Changelog <https://github.com/overhangio/tutor/blob/olive/CHANGELOG.md>`_.
 
 .. _mfe-runtime-configuration:
 
 MFE runtime configuration support
----------------------------------
+=================================
 
 Where up until Nutmeg it was only possible to change a micro-frontend's settings at build time, it is now possible to do so at both server *and* browser runtime via a new configuration mechanism.  In addition to the added convenience, this significantly reduces the frequency at which MFE container images need to be rebuilt.  Many operators will never have to build them to begin with, as pre-built ones can be (and are) provided, thus saving up precious time and resources on deployment.
 
@@ -160,7 +163,7 @@ This behavior is optional and controlled by the :code:`ENABLE_MFE_CONFIG_API` Dj
 .. _upgrade-note:
 
 Upgrade note
-~~~~~~~~~~~~
+------------
 
 In Tutor, :code:`ENABLE_MFE_CONFIG_API` is enabled and used by default by all supported MFEs.  Because of it, a previously supported mechanism of setting some MFE settings via Tutor configuration is no longer available.  When upgrading from Nutmeg to Olive, the following variables can no longer be set via :code:`tutor config save --set`:
 
@@ -180,12 +183,13 @@ Also note that if you've maintained such a plugin prior to Olive, the following 
 You must instead migrate your MFE settings to the LMS settings hooks as described above.
 
 Other Operator Experience changes
----------------------------------
+=================================
+
 - A performance issue that occurs when using multiple themes in a docker environment was fixed by using an LRU cache when searching themes.
 
 
 Features not supported in Tutor
--------------------------------
+===============================
 
 The following Micro-frontends (MFEs) are in a "pre-alpha" state. They exist on GitHub but are not yet supported in Tutor. Additionally, they may lack key features such as support for theming, internationalization, and path-based deployments. We include mention of them because we expect all of them to be supported in the next release, Palm.
 
@@ -196,7 +200,7 @@ The following Micro-frontends (MFEs) are in a "pre-alpha" state. They exist on G
 .. _ORA Grading Micro-frontend (MFE): https://github.com/edx/frontend-app-ora-grading
 
 Settings and Toggles
---------------------
+====================
 
 New settings and toggles added since the Nutmeg release:
 
@@ -240,18 +244,20 @@ The following settings were removed:
 .. _deprecations-and-removals:
 
 Deprecations & Removals
-=======================
+***********************
 
 Legacy learner experience
--------------------------
+=========================
+
 A few pieces of the legacy/deprecated learner experience have been removed entirely in favor of the Learning MFE experience, specifically, the outline, dates, and courseware tabs. Instead, you must run the Learning MFE, and its tabs will be used. Along with the legacy code, a few old waffle flags have been removed: :code:`course_experience.latest_update`, :code:`course_experience.show_upgrade_msg_on_course_home`, :code:`course_experience.upgrade_deadline_message`, :code:`course_home.course_home_use_legacy_frontend`, :code:`courseware.microfrontend_course_team_preview`, and :code:`courseware.use_legacy_frontend`.
 
 Legacy OLX attributes translations removed
-------------------------------------------
+==========================================
+
 Support for importing courses that use obsolete XML attributes has been removed. Courses with attributes :code:`slug`, :code:`name` in course tags, :code:`display_name` and :code:`id` in discussion tags and :code:`attempts` in problem tags, will no longer import properly. A simple import and export before upgrading will update the XML attributes. See https://github.com/openedx/public-engineering/issues/74 for more details.
 
 Other removals/deprecations
----------------------------
+===========================
 
 - The `Molecular Structure Problem type`_ was removed.
 - `Removed the last vestiges of the save option from anonymous_id_for_user`_.
@@ -267,17 +273,17 @@ Other removals/deprecations
 
 
 Developer Experience
-====================
+********************
 
 Open edX Test Course
---------------------
+====================
 
 In order to make testing your Open edX installation easier, `this course and its associated libraries`_ aim to expose as many Open edX Studio & courseware features as possible. It does so by providing example usages of various block types and by enabling various features through Advanced Settings.
 
 .. _this course and its associated libraries: https://github.com/openedx/openedx-test-course
 
 Hooks Extension Framework
--------------------------
+=========================
 
 As part of `OEP-50`_, the following filters were added in Olive:
 
@@ -291,7 +297,7 @@ As part of `OEP-50`_, the following filters were added in Olive:
 
 
 Researcher & Data Experiences
-=============================
+*****************************
 
 * Added analytics event on recommendation course click, :code:`edx.bi.user.recommended.course.click`
 * Added many new discussion events, including
@@ -310,7 +316,7 @@ Researcher & Data Experiences
   * :code:`edx.forum.searched`
 
 Known Issues
-============
+************
 
 - The Authentication MFE contains some hard-coded mentioned of edX. We expect these will be fixed by the time Olive.2 is released.
 - The Zoom tool is not working. There is currently no plan for when this may be fixed.


### PR DESCRIPTION
This PR is to clean up heading symbols, also delete some trailing whitespaces.

Is linked and solves https://github.com/openedx/docs.openedx.org/issues/307

