### PR TITLE
Fix for quickstart missing as command

### DIFF
--- a/source/developers/quickstarts/first_openedx_pr.rst
+++ b/source/developers/quickstarts/first_openedx_pr.rst
@@ -127,6 +127,19 @@ Depending on your system and your Internet connection speed,
 this could take anywhere from five minutes to over an hour,
 so go get a coffee and come back for the next part.
 
+If quickstart doesn't work you can use
+
+.. code-block:: bash
+
+  tutor dev start
+
+to download the files then
+
+.. code-block:: bash
+
+  tutor dev lauch
+
+to setup edx
 
 Working with a fork
 *******************


### PR DESCRIPTION
I was setting it up when I found that `quickstart` doesn't exist

```
(ibl) sam@sam:~/Documents/code/ibl$ tutor local quickstart
Usage: tutor local [OPTIONS] COMMAND [ARGS]...
Try 'tutor local -h' for help.

Error: No such command 'quickstart'.
```

this commands did however work for me and I got the site to run, the first to download

`tutor local start`

and then this to setup edx

`tutor local launch`

i also checked to see if `dev` was the only one with `quickstart` it doesn't have it

```
(ibl) sam@sam:~/Documents/code/ibl$ tutor dev quickstart
Usage: tutor dev [OPTIONS] COMMAND [ARGS]...
Try 'tutor dev -h' for help.

Error: No such command 'quickstart'.
```