### PR TITLE
docs: recommend tilde (`~~~~`) for heading 5 underline

### DIFF
--- a/source/documentors/references/rst_samples/headings.txt
+++ b/source/documentors/references/rst_samples/headings.txt
@@ -15,9 +15,15 @@
    Heading 3
    =========
 
-   Heading 3s denote subsections under Heading 2s
+   Heading 3s denote subsections under Heading 2s.
 
    Heading 4
    ---------
 
-   Heading 4s denote subsections under Heading 3s
+   Heading 4s denote subsections under Heading 3s.
+   
+   Heading 5
+   ~~~~~~~~~
+   
+   Heading 5s denote subsections under Heading 4s.
+   If you are this deep, consider splitting your document into multiple topics.


### PR DESCRIPTION
It's not ideal to be nested this deeply, but it's already the case in some of the release notes
(https://github.com/openedx/docs.openedx.org/pull/311) so we should have a recommendation for it.

I chose `~` because it works with the mneumonic:
four lines (`#`), three lines (`*`), two lines (`=`), one line (`-`) if you consider a tilde to have "zero" lines.