### PR TITLE
docs: describe number-of-lines mnemonic for heading levels

### DIFF
--- a/source/documentors/references/quick_reference_rst.rst
+++ b/source/documentors/references/quick_reference_rst.rst
@@ -9,6 +9,11 @@ Headings
 
 .. include:: ../references/rst_samples/headings.txt
 
+.. tip::
+   :class: dropdown
+   
+   Here's a way to remember the symbols for heading levels: ``#`` has four lines, ``*`` has three lines, ``=`` has two lines, ``-`` has one line, and ``~`` has zero lines.
+
 .. note::
    :class: dropdown
 


### PR DESCRIPTION
This trick helped me remember the heading levels,
so maybe it'll help others too?

### Rendered

From: https://docsopenedxorg--318.org.readthedocs.build/en/318/documentors/references/quick_reference_rst.html#headings
![image](https://user-images.githubusercontent.com/3628148/233713749-4c4af321-7a22-4e83-9467-97830df5ec05.png)