### PR TITLE
docs: Add links to the index for concepts and how-tos.

### DIFF
--- a/source/translators/index.rst
+++ b/source/translators/index.rst
@@ -32,6 +32,13 @@ Translators Home
          :caption: How-Tos
 
          how-tos/how-to*
+      +++
+      .. button-ref:: how-tos/index
+         :color: primary
+         :outline:
+         :expand:
+
+         More How-Tos
 
    .. grid-item-card::
       :class-card: sd-shadow-md sd-p-2
@@ -43,6 +50,14 @@ Translators Home
          :caption: Concepts
 
          concepts/working*
+      +++
+      .. button-ref:: concepts/index
+         :color: primary
+         :outline:
+         :expand:
+
+         More Concepts
+
 
    .. grid-item-card::
       :class-card: sd-shadow-md sd-p-2


### PR DESCRIPTION
These two sections have more articles that aren't listed in the small
tiles. So add a link to the index page for these sections.
