### PR TITLE
docs: Update configuration for the oars repo name changes

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -70,8 +70,9 @@ intersphinx_mapping = {
         f"https://docs.openedx.org/projects/openedx-proposals/{rtd_language}/latest",
         None,
     ),
-    "openedx-oars": (
-        f"https://docs.openedx.org/projects/openedx-oars/{rtd_language}/{rtd_version}",
+    "openedx-aspects": (
+        f"https://docs.openedx.org/projects/openedx-aspects/{rtd_language}"
+        f"/{rtd_version}",
         None,
     ),
     "edx-installing-configuring-and-running": (

--- a/source/developers/references/index.rst
+++ b/source/developers/references/index.rst
@@ -9,7 +9,7 @@ Per Repo Documentation
    relevant mapping to the ``intersphinx_mapping`` setting in conf.py
 
 * :doc:`DoneXBlock:index`
-* :doc:`openedx-oars:index`
+* :doc:`openedx-aspects:index`
 
 Other References
 ****************


### PR DESCRIPTION
Relies on changes here: https://github.com/openedx/openedx-oars/pull/55 and the subsequent renaming of that repo.