### PR TITLE
docs: Update add-sphinx-docs-to-a-repo.rst

### DIFF
--- a/source/developers/how-tos/add-sphinx-docs-to-a-repo.rst
+++ b/source/developers/how-tos/add-sphinx-docs-to-a-repo.rst
@@ -150,8 +150,8 @@ Steps
    .. code::
 
       cd docs/
-      mkdir -p {concepts,how-tos,quickstarts,reference,decisions}
-      touch {concepts,how-tos,quickstarts,reference,decisions}/index.rst
+      mkdir -p {concepts,how-tos,quickstarts,references,decisions}
+      touch {concepts,how-tos,quickstarts,references,decisions}/index.rst
 
 #. Add a title to each index.rst
 


### PR DESCRIPTION
`reference` -> `references` - Everything else is plural, and we use `references` in this repo, so the fact that it wasn't plural here was probably an oversight.