### PR TITLE
docs: Add a link to the new edx-platform docs.

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -79,6 +79,10 @@ intersphinx_mapping = {
         f"https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/{rtd_language}/{rtd_version}",
         None,
     ),
+    "edx-platform": (
+        f"https://docs.openedx.org/projects/edx-platform/{rtd_language}/{rtd_version}",
+        None,
+    ),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/source/developers/references/index.rst
+++ b/source/developers/references/index.rst
@@ -10,6 +10,7 @@ Per Repo Documentation
 
 * :doc:`DoneXBlock:index`
 * :doc:`openedx-aspects:index`
+* :doc:`edx-platform:index`
 
 Other References
 ****************


### PR DESCRIPTION
Now that we're publishing the edx-platform docs, cross link them
from the developer section of docs.openedx.org
