### PR TITLE
docs: add Palm.2 to list of releases

### DIFF
--- a/source/community/release_notes/named_release_branches_and_tags.rst
+++ b/source/community/release_notes/named_release_branches_and_tags.rst
@@ -49,6 +49,10 @@ Palm
      - 2023-06-14
      - open-release/palm.1
 
+   * - Palm.2
+     - 2023-08-09
+     - open-release/palm.2
+
 Olive
 =====
 
@@ -74,6 +78,10 @@ Olive
    * - Olive.3
      - 2023-04-11
      - open-release/olive.3
+
+   * - Olive.4
+     - 2023-05-22
+     - open-release/olive.4
 
 Nutmeg
 ======


### PR DESCRIPTION
This adds the new Palm.2 release that was tagged today to the list of releases.

It also adds Olive.4, which we forgot to add at the time it was tagged.