### PR TITLE
docs: Update 'install tutor nightly' command.

### DIFF
--- a/source/developers/quickstarts/first_openedx_pr.rst
+++ b/source/developers/quickstarts/first_openedx_pr.rst
@@ -121,7 +121,7 @@ Answer them however you like, although the default answers will work fine.
 
 .. code-block:: bash
 
-  tutor dev quickstart
+  tutor dev launch
 
 Depending on your system and your Internet connection speed,
 this could take anywhere from five minutes to over an hour,


### PR DESCRIPTION
Under the section, `Install Tutor Nightly` update the command `tutor dev quickstart` to `tutor dev launch` to configure and provision an Open edX instance. `quickstart` is not listed as one of the options commands for `tutor dev`.

### Update to the tutorial: **Quick Start: First Open edX Pull Request**

**Navigation:**
```
|--- Quickstarts
     |--- Developers: Contribute to Open edX
           |--- Quick Start: First Open edX Pull Request
                 |--- #Section: Installing Tutor Nightly

```
Here is the documentation [link](https://docs.openedx.org/en/latest/developers/quickstarts/first_openedx_pr.html#installing-tutor-nightly). 

**Problem:**
When following the tutorial I encountered a blocker in executing one of the provided commands: `tutor dev quickstart`.
**Expected:**
An interactive session to configure and provision an Open edX instance. 
**Actual:**
The following terminal output error message:
```
Usage: tutor dev [OPTIONS] COMMAND [ARGS]...
Try 'tutor dev -h' for help.

Error: No such command 'quickstart'.
```
**Additional:**
`quickstart` does not appear as one of the commands for `tutor dev`.
List usage commands with the following command, `tutor dev -h`.
Output from executing the command:
```
Usage: tutor dev [OPTIONS] COMMAND [ARGS]...

  Run Open edX locally with development settings

Options:
  -h, --help  Show this message and exit.

Commands:
  copyfrom  Copy files/folders from a container directory to the local...
  dc        Direct interface to docker-compose.
  do        Run a custom job in the right container(s).
  exec      Run a command in a running container
  launch    Configure and run Open edX from scratch
  logs      View output from containers
  reboot    Reboot an existing platform
  restart   Restart some components from a running platform.
  run       Run a command in a new container
  start     Run all or a selection of services.
  status    Print status information for containers
  stop      Stop a running platform
  upgrade   Perform release-specific upgrade tasks.
```

**Context:**
The host machine runs Ubuntu Focal. Python version: `3.8.10`. The only configuration run by the user was the instructions specified in the tutorial, **Quick Start: First Open edX Pull Request**. Prior to this, nothing concerning Open edX or Tutor was installed or set up on the user's host machine.
 
**Fix:**
Suggest an edit to update the provided command from `tutor dev quickstart` to `tutor dev launch` to configure and provision an Open edX instance.