### PR TITLE
docs: Add a maintainers homepage.

### DIFF
--- a/source/developers/how-tos/ongoing-maintainers-tasks.rst
+++ b/source/developers/how-tos/ongoing-maintainers-tasks.rst
@@ -90,7 +90,7 @@ The current process for this is to:
 
    a. In the event of a questionable or malicious looking change, please notify #maintainers-pilot in Slack to warn other maintainers and allow us to take appropriate action.
 
-2. Any maintainer or tCRIL employee with write permissions on the repository can approve the PR after step 1 has been completed. This should only need to be done once per contributor per repository. 
+2. Any maintainer or Axim employee with write permissions on the repository can approve the PR after step 1 has been completed. This should only need to be done once per contributor per repository. 
 
 3. Once the PR is unblocked, the rest of the approval process should work as normal.
 

--- a/source/developers/how-tos/ongoing-maintainers-tasks.rst
+++ b/source/developers/how-tos/ongoing-maintainers-tasks.rst
@@ -73,6 +73,27 @@ As a part of bringing your repository into alignment with the standards of the p
 
 Keeping your dependencies up-to-date on a regular basis is both lest costly and more secure than waiting a long time between package updates.  It is recommended that you **apply all security fix on packages you depend on within weekly**.  For automated PRs that don't contain security updates to dependent packages it is still recommended that you triage them on a weekly basis. Schedule any complex upgrades in a timely manner - you don't want to be in a situation where it becomes an emergency to land them (whether to get new features or apply a major security fix).
 
+Approving GitHub Actions for new committer PRs
+**********************************************
+
+.. note::
+
+   This process is only for contributors that already have passed the CLA check, for those that haven’t please follow the normal process for helping the contributor onboard.
+
+When a user opens their first PR in a repository you maintain it is likely that they will need to be approved before some Github Actions, such as tests, will run. This is to protect us all from having malicious code run in our account as part of our test suite. 
+
+When this occurs the orange “Approve and run“ will appear for the PR.
+
+The current process for this is to:
+
+1. Look over the PR to make sure that it is legitimate and there are no malicious changes.
+
+   a. In the event of a questionable or malicious looking change, please notify #maintainers-pilot in Slack to warn other maintainers and allow us to take appropriate action.
+
+2. Any maintainer or tCRIL employee with write permissions on the repository can approve the PR after step 1 has been completed. This should only need to be done once per contributor per repository. 
+
+3. Once the PR is unblocked, the rest of the approval process should work as normal.
+
 Participating in Forum Discussions
 **********************************
 

--- a/source/developers/index.rst
+++ b/source/developers/index.rst
@@ -29,7 +29,6 @@ Open edX Developers
       :class-card: sd-shadow-md sd-p-2
       :class-footer: sd-border-0
       
-      * :doc:`how-tos/maintain-a-repo`
       * :doc:`how-tos/enable-python-upgrade-automation`
       * :doc:`how-tos/enable-javascript-upgrade-automation`
       +++
@@ -59,7 +58,6 @@ Open edX Developers
       :class-card: sd-shadow-md sd-p-2
       :class-footer: sd-border-0
       
-      * :doc:`references/tools_for_maintainers`
       * :doc:`references/internal_data_formats/index`
       * `edx-platform <https://github.com/openedx/edx-platform>`_
       * `frontend-platform <https://openedx.github.io/frontend-platform>`_
@@ -70,3 +68,24 @@ Open edX Developers
          :expand:
 
          More References
+
+   .. grid-item-card:: Maintainers Home
+      :class-card: sd-shadow-md sd-p-2
+      :class-footer: sd-border-0
+      
+      * :doc:`how-tos/maintain-a-repo`
+      * :doc:`how-tos/ongoing-maintainers-tasks`
+      * :doc:`references/tools_for_maintainers`
+
+      +++
+      .. button-ref:: maintainers_home
+         :color: primary
+         :outline:
+         :expand:
+
+         Maintainers Home
+
+.. toctree::
+   :hidden:
+
+   maintainers_home

--- a/source/developers/maintainers_home.rst
+++ b/source/developers/maintainers_home.rst
@@ -1,0 +1,49 @@
+Maintainers Home
+################
+
+.. grid:: 1 2 2 2
+   :gutter: 3
+   :padding: 0
+
+   .. grid-item-card:: How-tos
+      :class-card: sd-shadow-md sd-p-2
+      :class-footer: sd-border-0
+
+      * :doc:`how-tos/maintain-a-repo`
+      * :doc:`how-tos/ongoing-maintainers-tasks`
+
+   .. grid-item-card:: References
+      :class-card: sd-shadow-md sd-p-2
+      :class-footer: sd-border-0
+
+      * :doc:`references/tools_for_maintainers`
+      * `Maintainers Slack Channel`_
+      
+   .. grid-item-card:: Process Documentation 
+      :class-card: sd-shadow-md sd-p-2
+      :class-footer: sd-border-0
+
+      * `Maintainership Wiki Space`_
+      * `Maintainer Scrum of Scrums Notes`_
+      * `Office Hours Notes`_
+
+Concepts Documentation
+**********************
+
+* :doc:`openedx-proposals:processes/oep-0055-proc-project-maintainers` - The
+  OEP that kicked off the maintainership program.
+
+* `Community Contributions Project Manager`_ - The role definition for the
+  Community Project Managers.  They help triage PRs and coordinate reviews from
+  subject matter experts.
+
+.. _Maintainers Slack Channel: https://openedx.slack.com/archives/C03R320AFJP
+
+.. _Office Hours Notes:  https://openedx.atlassian.net/wiki/spaces/COMM/pages/3603791889/Office+Hours+Notes
+
+.. _Maintainer Scrum of Scrums Notes: https://openedx.atlassian.net/wiki/spaces/COMM/pages/3507027983/Maintainers+Scrum+of+Scrums
+
+.. _Maintainership Wiki Space: https://openedx.atlassian.net/wiki/spaces/COMM/pages/3426844690/Maintainership+Pilot
+
+.. _Community Contributions Project Manager: https://openedx.atlassian.net/wiki/spaces/COMM/pages/3548807177/Community+Contributions+Project+Manager
+

--- a/source/developers/maintainers_home.rst
+++ b/source/developers/maintainers_home.rst
@@ -24,8 +24,8 @@ Maintainers Home
       :class-footer: sd-border-0
 
       * `Maintainership Wiki Space`_
-      * `Maintainer Scrum of Scrums Notes`_
-      * `Office Hours Notes`_
+      * `Maintainers Scrum of Scrums Notes`_
+      * `Maintainers Office Hours Notes`_
 
 Concepts Documentation
 **********************
@@ -34,14 +34,14 @@ Concepts Documentation
   OEP that kicked off the maintainership program.
 
 * `Community Contributions Project Manager`_ - The role definition for the
-  Community Project Managers.  They help triage PRs and coordinate reviews from
-  subject matter experts.
+  Community Project Managers.  They help triage community PRs and coordinate
+  reviews from subject matter experts.
 
 .. _Maintainers Slack Channel: https://openedx.slack.com/archives/C03R320AFJP
 
-.. _Office Hours Notes:  https://openedx.atlassian.net/wiki/spaces/COMM/pages/3603791889/Office+Hours+Notes
+.. _Maintainers Office Hours Notes:  https://openedx.atlassian.net/wiki/spaces/COMM/pages/3603791889/Office+Hours+Notes
 
-.. _Maintainer Scrum of Scrums Notes: https://openedx.atlassian.net/wiki/spaces/COMM/pages/3507027983/Maintainers+Scrum+of+Scrums
+.. _Maintainers Scrum of Scrums Notes: https://openedx.atlassian.net/wiki/spaces/COMM/pages/3507027983/Maintainers+Scrum+of+Scrums
 
 .. _Maintainership Wiki Space: https://openedx.atlassian.net/wiki/spaces/COMM/pages/3426844690/Maintainership+Pilot
 


### PR DESCRIPTION
Hade a single page that can serve as a hub for resources for
maintainers.  The content is still a part of the general developer space
but we're using a new special home page to collect the items that are
specifically relevant to maintainers so it's easier to find.
