### PR TITLE
docs: add security policy to community section

### DIFF
--- a/source/_templates/primary_sidebar_end.html
+++ b/source/_templates/primary_sidebar_end.html
@@ -3,4 +3,5 @@
 <a class='external' href='https://openedx.atlassian.net/wiki/spaces' target='_blank'>Open edX Wiki</a><br/>
 <a class='external' href='https://openedx.org' target='_blank'>Open edX website</a><br/>
 <a class='external' href='https://openedx.org/cookie-policy/' target='_blank'>Cookie Policy</a>
+<a class='external' href='https://docs.openedx.org/en/latest/community/security_policy/index.html' target='_blank'>Security Policy</a>
 

--- a/source/_templates/primary_sidebar_end.html
+++ b/source/_templates/primary_sidebar_end.html
@@ -2,6 +2,6 @@
 
 <a class='external' href='https://openedx.atlassian.net/wiki/spaces' target='_blank'>Open edX Wiki</a><br/>
 <a class='external' href='https://openedx.org' target='_blank'>Open edX website</a><br/>
-<a class='external' href='https://openedx.org/cookie-policy/' target='_blank'>Cookie Policy</a>
+<a class='external' href='https://openedx.org/cookie-policy/' target='_blank'>Cookie Policy</a><br/>
 <a class='external' href='https://docs.openedx.org/en/latest/community/security_policy/index.html' target='_blank'>Security Policy</a>
 

--- a/source/community/index.rst
+++ b/source/community/index.rst
@@ -5,3 +5,4 @@ Community Home
    :maxdepth: 1
 
    release_notes/index
+   security_policy/index

--- a/source/community/security_policy/index.rst
+++ b/source/community/security_policy/index.rst
@@ -1,0 +1,30 @@
+########################
+Open edX Security Policy
+########################
+
+===================================
+Disclosing a Security Vulnerability
+===================================
+
+If you believe that you have discovered a security vulnerability or other suspicious activity relating to the Open edX platform code base, please:
+
+* report it to the Open edX project by emailing the Open edX Security Working Group at security@openedx.org;
+* describe the nature of the vulnerability; and
+* provide sufficient detail in your report to enable the Open edX Security Working Group to respond quickly reproduce and understand the vulnerability and respond effectively, including the following (as applicable):
+    * a textual description of the steps necessary to reproduce the issue;
+    * proof-of-concept code; and
+    * links to vulnerable code.
+
+Upon receipt of your email, the Open edX Security Working Group will acknowledge the receipt of your email, review and triage your security vulnerability, and act accordingly. If necessary, the group will reach out to you for more information. The group will not provide communication on the status of the security vulnerability after it has been reviewed and triaged.
+
+==========
+Bug Bounty
+==========
+
+The Open edX project does not offer bug bounties for security vulnerability disclosures.
+
+============
+Out of Scope
+============
+
+There are many sites powered by the Open edX platform. If you have found a vulnerability that is specific to an Open edX deployment please contact the operators of that site directly.


### PR DESCRIPTION
The Open edX security policy was updated as part of https://github.com/openedx/.github/pull/82. The policy should also be part of the documentation to ensure that any users of the Open edX platform are aware of where to disclose security vulnerabilities.