### PR TITLE
docs: start the Quince release listing

### DIFF
--- a/source/community/release_notes/index.rst
+++ b/source/community/release_notes/index.rst
@@ -11,6 +11,7 @@ The *Open edX Platform Release Notes* provide information about releases, migrat
 .. toctree::
     :maxdepth: 2
 
+    Quince: The next release <quince>
     Palm: The current release <palm>
     named_release_branches_and_tags
     old_releases

--- a/source/community/release_notes/named_release_branches_and_tags.rst
+++ b/source/community/release_notes/named_release_branches_and_tags.rst
@@ -31,6 +31,13 @@ Every release line (Ginkgo, Hawthorn, etc) has a branch that accumulates changes
 
 If an installation of a tag fails, try the corresponding release line master branch, it may have a fix.
 
+Quince
+~~~~~~
+
+* **Code cut date:** 2023-10-10
+* **Status:** upcoming
+* :doc:`Release Notes <./quince>`
+
 Palm
 ~~~~
 
@@ -52,6 +59,10 @@ Palm
    * - Palm.2
      - 2023-08-09
      - open-release/palm.2
+
+   * - Palm.3
+     - 2023-10-13
+     - open-release/palm.3
 
 Olive
 =====

--- a/source/community/release_notes/quince.rst
+++ b/source/community/release_notes/quince.rst
@@ -1,0 +1,44 @@
+.. _Open edX Quince Release:
+
+Open edX Quince Release
+#######################
+
+These are the release notes for the Quince release, the 17th community release of the Open edX Platform, spanning changes from April 11 2023 to October 10 2023.  You can also review details about `earlier releases`_ or learn more about the `Open edX Platform`_.
+
+.. _earlier releases: https://edx.readthedocs.io/projects/edx-developer-docs/en/latest/named_releases.html
+.. _Open edX Platform: https://openedx.org
+
+.. contents::
+ :depth: 1
+ :local:
+
+Breaking Changes
+****************
+
+
+Learner Experiences
+*******************
+
+
+Instructor Experiences
+**********************
+
+
+Administrators & Operators
+**************************
+
+
+Deprecations & Removals
+***********************
+
+
+Developer Experience
+********************
+
+
+Researcher & Data Experiences
+*****************************
+
+
+Known Issues
+************


### PR DESCRIPTION
Adding Quince to docs regarding the [Release process](https://openedx.atlassian.net/wiki/spaces/COMM/pages/19662426/Process+to+Create+an+Open+edX+Release#5c.-Add-the-latest-release-to-the-main-docs-site).