### PR TITLE
build: Add XBlock docs references

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -83,6 +83,10 @@ intersphinx_mapping = {
         f"https://docs.openedx.org/projects/edx-platform/{rtd_language}/{rtd_version}",
         None,
     ),
+    "xblock": (
+        f"https://docs.openedx.org/projects/xblock/{rtd_language}/{rtd_version}",
+        None,
+    ),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/source/developers/references/glossary.rst
+++ b/source/developers/references/glossary.rst
@@ -810,7 +810,7 @@ Glossary
       the components that deliver course content to learners.
     
       Third parties can create components as web applications that can run within
-      the Open edX learning management system. For more information, see
-      `xblocktutorial:Open edX XBlock Tutorial`.
-    
+      the Open edX learning management system. For more information, see the
+      :doc:`xblock:xblock-tutorial/index`.
+
    

--- a/source/developers/references/index.rst
+++ b/source/developers/references/index.rst
@@ -11,6 +11,7 @@ Per Repo Documentation
 * :doc:`DoneXBlock:index`
 * :doc:`openedx-aspects:index`
 * :doc:`edx-platform:index`
+* :doc:`xblock:index`
 
 Other References
 ****************


### PR DESCRIPTION
Add pointers to the XBlock repo docs in the References section as well as a reference in the glossary