### PR TITLE
docs: add Palm.4 to list of releases

### DIFF
--- a/source/community/release_notes/named_release_branches_and_tags.rst
+++ b/source/community/release_notes/named_release_branches_and_tags.rst
@@ -64,6 +64,10 @@ Palm
      - 2023-10-13
      - open-release/palm.3
 
+   * - Palm.4
+     - 2023-11-16
+     - open-release/palm.4
+
 Olive
 =====
 


### PR DESCRIPTION
Adds the new Palm.4 release that was tagged 16/11 to the list of releases.