### PR TITLE
fix: headings on named releases page

### DIFF
--- a/source/community/release_notes/named_release_branches_and_tags.rst
+++ b/source/community/release_notes/named_release_branches_and_tags.rst
@@ -32,14 +32,14 @@ Every release line (Ginkgo, Hawthorn, etc) has a branch that accumulates changes
 If an installation of a tag fails, try the corresponding release line master branch, it may have a fix.
 
 Quince
-~~~~~~
+======
 
 * **Code cut date:** 2023-10-10
 * **Status:** upcoming
 * :doc:`Release Notes <./quince>`
 
 Palm
-~~~~
+====
 
 * **Code cut date:** 2023-04-11
 * **Status:** supported


### PR DESCRIPTION
Quince and Palm had the wrong heading underline
(~ instead of =) so they were rending a level above the named releases.

## Before

![image](https://github.com/openedx/docs.openedx.org/assets/3628148/b1ded2d8-8d67-47ca-8e4a-692e993d0442)

## After

![image](https://github.com/openedx/docs.openedx.org/assets/3628148/597d7988-1ad4-45cc-a890-d85341376ca5)
