### PR TITLE
chore: update docs for new Quince.1 release

### DIFF
--- a/source/community/release_notes/index.rst
+++ b/source/community/release_notes/index.rst
@@ -11,8 +11,7 @@ The *Open edX Platform Release Notes* provide information about releases, migrat
 .. toctree::
     :maxdepth: 2
 
-    Quince: The next release <quince>
-    Palm: The current release <palm>
+    Quince: The current release <quince>
     named_release_branches_and_tags
     old_releases
 

--- a/source/community/release_notes/named_release_branches_and_tags.rst
+++ b/source/community/release_notes/named_release_branches_and_tags.rst
@@ -9,11 +9,11 @@ Open edX releases are named alphabetically with botanical tree names.
 Latest Open edX Release
 ***********************
 
-The latest supported release line is Palm_, based on code from 2023-04-11.
+The latest supported release line is Quince_, based on code from 2023-10-10.
 
-The next release will be Quince__.
+The next release will be Redwood__.
 
-__ https://openedx.atlassian.net/wiki/spaces/COMM/pages/3726802953/Quince
+__ https://openedx.atlassian.net/wiki/spaces/COMM/pages/3890380898/Redwood
 
 
 All Open edX Releases
@@ -35,14 +35,25 @@ Quince
 ======
 
 * **Code cut date:** 2023-10-10
-* **Status:** upcoming
+* **Status:** supported
 * :doc:`Release Notes <./quince>`
+
+.. list-table::
+   :header-rows: 1
+
+   * - Release Name
+     - Release Date
+     - Git Tag
+
+   * - Quince.1
+     - 2023-12-11
+     - open-release/quince.1
 
 Palm
 ====
 
 * **Code cut date:** 2023-04-11
-* **Status:** supported
+* **Status:** unsupported
 * :doc:`Release Notes <./palm>`
 
 .. list-table::

--- a/source/community/release_notes/old_releases.rst
+++ b/source/community/release_notes/old_releases.rst
@@ -11,6 +11,7 @@ fixes and features. These older releases will not recieve any of those.
 .. toctree::
    :maxdepth: 2
 
+   palm
    olive
    nutmeg
    maple

--- a/source/conf.py
+++ b/source/conf.py
@@ -48,7 +48,7 @@ extensions = [
 graphviz_output_format = "svg"
 
 rediraffe_redirects = {
-    "community/release_notes/latest.rst": "community/release_notes/palm.rst",
+    "community/release_notes/latest.rst": "community/release_notes/quince.rst",
 }
 
 # Intersphinx Extension Configuration

--- a/source/index.rst
+++ b/source/index.rst
@@ -43,7 +43,7 @@ Open edX Documentation
          :maxdepth: 1
          :caption: Open Source Community
 
-         Current Release: Palm <community/release_notes/palm>
+         Current Release: Quince <community/release_notes/quince>
          All Release Notes <community/release_notes/index>
          How to Contribute <https://openedx.atlassian.net/wiki/spaces/COMM/pages/941457737/How+to+start+contributing+to+the+Open+edX+code+base>
          OEPs (Open edX Proposals): Community Decision Documents <https://docs.openedx.org/projects/openedx-proposals/en/latest/>


### PR DESCRIPTION
Quince.1 release update. This points latest release to Quince.

See: https://openedx.atlassian.net/wiki/spaces/COMM/pages/19662426/Process+to+Create+an+Open+edX+Release#4b.-Make-the-new-release-notes-the-%E2%80%9Clatest%E2%80%9D