### PR TITLE
Clarify how to use :ref: vs :doc: in our templates

### DIFF
--- a/source/documentors/references/doc_templates.rst
+++ b/source/documentors/references/doc_templates.rst
@@ -139,7 +139,11 @@ Copy this codeblock to start a new how-to topic.
 
    .. seealso::
 
-     :ref:`title to link to`
+     # To cross-reference a label use :ref:
+     :ref:`reference to link to`
+
+     # To point to another document in the docs.openedx.org filetree, use :doc:
+     :doc:`/relative/path/to_the_document`
 
 
 Add an Ordered List


### PR DESCRIPTION
In https://docs.openedx.org/en/latest/documentors/references/doc_templates.html#create-a-how-to the seealso directive says to use :ref:, however, :doc: is the way to reference a whole document. Added an example and comments to clarify when to use which.