### PR TITLE
docs: add Quince.2 to list of releases

### DIFF
--- a/source/community/release_notes/named_release_branches_and_tags.rst
+++ b/source/community/release_notes/named_release_branches_and_tags.rst
@@ -53,6 +53,10 @@ Quince
      - 2023-12-11
      - open-release/quince.1
 
+   * - Quince.2
+     - 2024-02-09
+     - open-release/quince.2
+
 Palm
 ====
 


### PR DESCRIPTION
Adds the new Quince.2 release that was tagged 2024-02-09 to the list of releases.