### PR TITLE
docs: add Quince.3 to list of releases

### DIFF
--- a/source/community/release_notes/named_release_branches_and_tags.rst
+++ b/source/community/release_notes/named_release_branches_and_tags.rst
@@ -57,6 +57,10 @@ Quince
      - 2024-02-09
      - open-release/quince.2
 
+   * - Quince.3
+     - 2024-04-09
+     - open-release/quince.3
+
 Palm
 ====
 


### PR DESCRIPTION
Adds the new Quince.3 release that was tagged 2024-04-09 to the list of releases.

Localtion: `docs.openedx.org/build/html/community/release_notes/named_release_branches_and_tags.html`

<img width="852" alt="image" src="https://github.com/openedx/docs.openedx.org/assets/877401/c4b10021-b71f-4524-a086-608802fa136c">
