### PR TITLE
docs: start the Redwood release listing

### DIFF
--- a/source/community/release_notes/index.rst
+++ b/source/community/release_notes/index.rst
@@ -11,7 +11,7 @@ The *Open edX Platform Release Notes* provide information about releases, migrat
 .. toctree::
     :maxdepth: 2
 
+    Redwood: The next release <redwood>
     Quince: The current release <quince>
     named_release_branches_and_tags
     old_releases
-

--- a/source/community/release_notes/named_release_branches_and_tags.rst
+++ b/source/community/release_notes/named_release_branches_and_tags.rst
@@ -35,6 +35,13 @@ Every release line (Ginkgo, Hawthorn, etc) has a branch that accumulates changes
 
 If an installation of a tag fails, try the corresponding release line master branch, it may have a fix.
 
+Redwood
+=======
+
+* **Code cut date:** 2024-05-09
+* **Status:** upcoming
+* :doc:`Release Notes <./redwood>`
+
 Quince
 ======
 

--- a/source/community/release_notes/redwood.rst
+++ b/source/community/release_notes/redwood.rst
@@ -1,0 +1,41 @@
+Open edX Redwood Release
+########################
+
+These are the release notes for the Redwood release, the 18th community release of the Open edX Platform, spanning changes from October 10 2023 to May 09 2024.  You can also review details about `earlier releases`_ or learn more about the `Open edX Platform`_.
+
+.. _earlier releases: https://edx.readthedocs.io/projects/edx-developer-docs/en/latest/named_releases.html
+.. _Open edX Platform: https://openedx.org
+
+.. contents::
+ :depth: 1
+ :local:
+
+Breaking Changes
+****************
+
+
+Learner Experiences
+*******************
+
+
+Instructor Experiences
+**********************
+
+
+Administrators & Operators
+**************************
+
+
+Deprecations & Removals
+***********************
+
+
+Developer Experience
+********************
+
+Researcher & Data Experiences
+*****************************
+
+
+Known Issues
+************


### PR DESCRIPTION
Adding Redwood to docs regarding the [Release process](https://openedx.atlassian.net/wiki/spaces/COMM/pages/19662426/Process+to+Create+an+Open+edX+Release#5c.-Add-the-latest-release-to-the-main-docs-site).