### PR TITLE
Add solution for missing mount info

### DIFF
--- a/source/developers/quickstarts/first_openedx_pr.rst
+++ b/source/developers/quickstarts/first_openedx_pr.rst
@@ -202,6 +202,35 @@ mounted:
 From this point on, whatever changes you make to the code in your clone should
 be visible in your local LMS instance immediately.
 
+Mounting other directories
+--------------------------
+You should be able to mount any repository by running:
+::
+   tutor mounts add /my/workspace/edx-ora2
+
+Verify that your repository is properly bind-mounted by running tutor mounts list:
+::
+   $ tutor mounts list
+   - name: /my/workspace/edx-ora2
+   build_mounts:
+   - image: openedx
+       context: mnt-edx-ora2
+   - image: openedx-dev
+       context: mnt-edx-ora2
+   compose_mounts:
+   - service: lms
+       container_path: /mnt/edx-ora2
+   - service: cms
+       container_path: /mnt/edx-ora2
+
+You should then re-build the “openedx” Docker image to pick up your changes.
+
+If your repository does not match a certain regex, you'll need to tell Tutor directly.
+In your tutor plugin repo (tutor-contrib-[something]), add the following under # CONFIGURATION:
+::
+   hooks.Filters.MOUNTED_DIRECTORIES.add_item(("openedx", "my-package"))
+Re-build the image and check the mounts list to verify it worked.
+
 Exercise: Update the Learner Dashboard
 **************************************
 


### PR DESCRIPTION
Similar to the info in https://docs.tutor.edly.io/tutorials/edx-platform.html#what-if-my-edx-platform-package-is-not-automatically-bind-mounted but more specifically for axim/edx set up