### PR TITLE
chore: update docs for new Redwood.1 release

### DIFF
--- a/source/community/release_notes/named_release_branches_and_tags.rst
+++ b/source/community/release_notes/named_release_branches_and_tags.rst
@@ -42,6 +42,17 @@ Redwood
 * **Status:** supported
 * :doc:`Release Notes <./redwood>`
 
+.. list-table::
+   :header-rows: 1
+
+   * - Release Name
+     - Release Date
+     - Git Tag
+
+   * - Redwood.1
+     - 2024-06-19
+     - open-release/redwood.1
+
 Quince
 ======
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -48,7 +48,7 @@ extensions = [
 graphviz_output_format = "svg"
 
 rediraffe_redirects = {
-    "community/release_notes/latest.rst": "community/release_notes/quince.rst",
+    "community/release_notes/latest.rst": "community/release_notes/redwood.rst",
 }
 
 # Intersphinx Extension Configuration


### PR DESCRIPTION
Redwood.1 release update. This points latest release to Redwood.

See: https://openedx.atlassian.net/wiki/spaces/COMM/pages/19662426/Process+to+Create+an+Open+edX+Release#4b.-Make-the-new-release-notes-the-%E2%80%9Clatest%E2%80%9D