### PR TITLE
docs: Update documentation links in release note

### DIFF
--- a/source/community/release_notes/redwood/aspects.rst
+++ b/source/community/release_notes/redwood/aspects.rst
@@ -20,8 +20,7 @@ How can I find Aspects Reports?
 Accessing course-level dashboards from the LMS
 ==============================================
 
-Once Aspects has been installed, users can easily `access Aspects Reports
-<https://openedx.atlassian.net/wiki/x/CIBJ-Q>`_ for a
+Once Aspects has been installed, users can easily `access Aspects Reports <https://docs.openedx.org/projects/openedx-aspects/en/latest/course_team/how-tos/access_aspects.html>`_ for a
 course directly from the Open edX LMS by clicking on a new Reports link on the
 Instructor Dashboard. There's no need to navigate elsewhere to gain valuable
 insight into exactly what's going on in a course:
@@ -29,9 +28,7 @@ insight into exactly what's going on in a course:
    .. image:: /_images/release_notes/redwood/aspects_screenshot2.png
 
 On the Reports tab in the LMS, users can navigate between three new dashboards:
-a `course dashboard <https://openedx.atlassian.net/wiki/x/FIBI-Q>`_, `at-risk
-learners dashboard <https://openedx.atlassian.net/wiki/x/EQBD-Q>`_, and `individual learner
-dashboard <https://openedx.atlassian.net/wiki/x/CoBE-Q>`_. These dashboards were
+a `course dashboard <https://docs.openedx.org/projects/openedx-aspects/en/latest/reference/course_overview_dashboard.html>`_, `at risk learners dashboard <https://docs.openedx.org/projects/openedx-aspects/en/latest/reference/learner_groups_dashboard.html>`_, and `individual learner dashboard <https://docs.openedx.org/projects/openedx-aspects/en/latest/reference/individual_learner_dashboard.html>`_. These dashboards were
 designed specifically for course authors and course teams looking to access
 quick and easy-to-glean engagement, enrollment, and performance data from their
 courses:
@@ -42,17 +39,13 @@ Accessing all Aspects has to offer from Superset
 ================================================
 
 Course delivery team members who plan to view information for one course and
-then another may chose to `navigate to Superset
-<https://openedx.atlassian.net/l/cp/c1n0h2AD>`_, a third-party data
+then another may chose to `navigate to Superset <https://docs.openedx.org/projects/openedx-aspects/en/latest/course_team/how-tos/access_aspects.html>`_, a third-party data
 visualization tool used to create and display Aspects dashboards and charts.
 This will allow these users to easily view the three out-of-the-box course-level
 dashboards for one of their courses and followed by another and another.
 
 Site operators and superusers can view data about any course on their Open edX
-instance or their whole Open edX instance in Superset. `Users can access Superset
-directly via a link from the Aspects Reports in the LMS
-<https://openedx.atlassian.net/wiki/spaces/OEPM/pages/4248666119/How-to+Navigate+to+Superset>`_
-using single sign-on authorization via their LMS account credentials:
+instance or their whole Open edX instance in Superset. `Users can access Superset directly via a link from the Aspects Reports in the LMS <https://docs.openedx.org/projects/openedx-aspects/en/latest/course_team/how-tos/access_aspects.html>`_ using single sign-on authorization via their LMS account credentials:
 
    .. image:: /_images/release_notes/redwood/aspects_screenshot4.png
 
@@ -95,7 +88,7 @@ course where learner engagement drops off:
 
    .. image:: /_images/release_notes/redwood/aspects_screenshot8.png
 
-When `cross-filtered <https://openedx.atlassian.net/wiki/x/KABN-Q>`_ by a single
+When `cross filtered <https://docs.openedx.org/projects/openedx-aspects/en/latest/course_team/how-tos/cross_filter.html>`_ by a single
 course video, the Watched Video Segment graphs can help course authors and teams
 pinpoint potentially unclear video timestamp ranges:
 
@@ -112,9 +105,8 @@ Individual and At-Risk Learner Dashboards
 =========================================
 
 In addition to course-wide data, Aspects Reports surface course activity data
-for `individual learners <https://openedx.atlassian.net/wiki/x/CoBE-Q>`_ and
-`learners that may be at-risk of not completing the course
-<https://openedx.atlassian.net/wiki/x/EQBD-Q>`_ based on a set of predefined
+for `individual learners <https://docs.openedx.org/projects/openedx-aspects/en/latest/reference/individual_learner_dashboard.html>`_ and
+`learners that may be at risk of not completing the course <https://docs.openedx.org/projects/openedx-aspects/en/latest/reference/learner_groups_dashboard.html>`_ based on a set of predefined
 risk factors. The at-risk learner group is made up of learners that have
 enrolled in the course, done something in the course other than visit the course
 outline page, have not yet passed the course, and have not visited the course in
@@ -123,8 +115,7 @@ seven or more days.
 When installing the plugin, site operators can choose whether or not to show
 limited personally identifiable information (PII) to course delivery teams. On
 Open edX instances that show limited PII to course delivery teams, staff and
-admin users can see and `download
-<https://openedx.atlassian.net/wiki/x/GwBI-Q>`_ the names, usernames, and email
+admin users can see and `download <https://docs.openedx.org/projects/openedx-aspects/en/latest/course_team/how-tos/download_reports.html>`_ the names, usernames, and email
 addresses of individual and at-risk learners making targeted communication and
 learner intervention possible.
 
@@ -142,7 +133,7 @@ view detailed information:
 Add filters to a dashboard
 ==========================
 
-Users can `add filters <https://openedx.atlassian.net/wiki/x/G4BC-Q>`_ to an
+Users can `add filters <https://docs.openedx.org/projects/openedx-aspects/en/latest/course_team/how-tos/apply_filters_lms.html#>`_ to an
 Aspects dashboard using the filters panel on the side of each dashboard. Hover
 over the filter icon on the upper corner of a table or chart to view what
 filters were applied to create the data visualization on any dashboard:
@@ -153,7 +144,7 @@ Dive deeper into the data with interactive charts that can be cross-filtered
 ============================================================================
 
 All Aspects Dashboards allow users to dig deeper into their data through
-`cross-filters <https://openedx.atlassian.net/wiki/x/KABN-Q>`_. With
+`cross filters <https://docs.openedx.org/projects/openedx-aspects/en/latest/course_team/how-tos/cross_filter.html>`_. With
 cross-filters, a user can apply the same filter to multiple charts and tables in
 a dashboard at once. For example, if a user adds a cross-filter for a single
 video on the Video Engagement tab of the Course Dashboard, all applicable video
@@ -164,10 +155,7 @@ tables and charts will update to show data only for that video:
 Download tables and images from Aspects dashboards
 ==================================================
 
-Users can easily `download the data used to create any chart or table in an
-Aspects dashboard in tabular format as a CSV or Excel file
-<https://openedx.atlassian.net/wiki/x/GwBI-Q>`_ or `download the table or chart
-as an image <https://openedx.atlassian.net/wiki/x/JQBJ-Q>`_ for use in their own
+Users can easily `download the data used to create any chart or table in an Aspects dashboard in tabular format as a CSV or Excel file <https://docs.openedx.org/projects/openedx-aspects/en/latest/administator/how_to/export_tabular_data.html>`_ or `download the table or chart as an image <https://docs.openedx.org/projects/openedx-aspects/en/latest/course_team/how-tos/download_reports.html>`_ for use in their own
 documents, presentations, or reports:
 
    .. image:: /_images/release_notes/redwood/aspects_screenshot14.png


### PR DESCRIPTION
This PR updates different links in the release notes to direct them to the Aspects documentation.