### PR TITLE
Add local table of contents to Redwood Product Notes

### DIFF
--- a/source/community/release_notes/redwood/aspects.rst
+++ b/source/community/release_notes/redwood/aspects.rst
@@ -6,6 +6,10 @@ thrilled to introduce Aspects Reports for course delivery teams and site
 operators! Operators can learn more about enabling Aspects on their
 installations by reviewing the :doc:`dev_op_release_notes`.
 
+.. contents::
+  :local:
+  :depth: 1
+
 What are Aspects Reports?
 *************************
 

--- a/source/community/release_notes/redwood/content_tagging.rst
+++ b/source/community/release_notes/redwood/content_tagging.rst
@@ -2,7 +2,11 @@ Content Tagging Release Notes (Redwood)
 #######################################
 
 The Product and Engineering Teams at OpenCraft and Axim are thrilled to announce
-the release of Content Tagging! 
+the release of Content Tagging!
+
+.. contents::
+  :local:
+  :depth: 1
 
 What is Content Tagging?
 ************************

--- a/source/community/release_notes/redwood/course_search.rst
+++ b/source/community/release_notes/redwood/course_search.rst
@@ -26,6 +26,10 @@ the :ref:`redwood-enable-search` for details about how to enable.
 .. _in the discussion forums: https://discuss.openedx.org/t/feedback-thread-new-course-search/13076
 .. _#wg-product-core: https://openedx.slack.com/archives/C057J2D1WU9
 
+.. contents::
+  :local:
+  :depth: 2
+
 What is Course Search?
 **********************
 

--- a/source/community/release_notes/redwood/potpourri.rst
+++ b/source/community/release_notes/redwood/potpourri.rst
@@ -4,6 +4,10 @@ Additional Redwood Features
 Redwood contains numerous features and feature enhancements that affect quality
 of life for both authors and learners.
 
+.. contents::
+  :local:
+  :depth: 1
+
 Make Sections available independently of the course outline
 ***********************************************************
 

--- a/source/community/release_notes/redwood/sidebar_nav.rst
+++ b/source/community/release_notes/redwood/sidebar_nav.rst
@@ -33,6 +33,9 @@ experience it can be.
       the sidebar navigation in sections that include content that has yet to be
       published.
 
+.. contents::
+  :local:
+  :depth: 2
 
 What is sidebar navigation?
 ***************************

--- a/source/community/release_notes/redwood/sidebar_nav.rst
+++ b/source/community/release_notes/redwood/sidebar_nav.rst
@@ -35,13 +35,10 @@ experience it can be.
 
 .. contents::
   :local:
-  :depth: 2
-
-What is sidebar navigation?
-***************************
+  :depth: 1
 
 Overview
-========
+********
 
 The new navigation experience allows learners to navigate through course
 material linearly or non-linearly via a new UI element on the side of the page
@@ -113,7 +110,7 @@ still able to view its contents.
 See :doc:`/educators/how-tos/sidebar_view_course_section` for details.
 
 Collapsing and expanding the sidebar navigation
-===============================================
+***********************************************
 
 The learner can easily collapse the sidebar navigation at any time to view the
 course content in a full page format by clicking the collapse button in the
@@ -133,7 +130,7 @@ the sidebar remains the same until the learner changes it. See
 :doc:`/educators/how-tos/sidebar_collapse_expand`.
 
 Viewing completed and in-progress items
-=======================================
+***************************************
 
 When a learner completes a course unit, the icon next to the unit name in the
 sidebar navigation updates to indicate that it was completed.

--- a/source/community/release_notes/redwood/studio_facelift.rst
+++ b/source/community/release_notes/redwood/studio_facelift.rst
@@ -23,8 +23,9 @@ disabling specific pages, site operators should see :ref:`course-authoring-flags
 
 *¹ excluding the Unit Page, which will be live in Sumac*
 
-.. toctree::
-   :maxdepth: 1
+.. contents::
+  :local:
+  :depth: 1
 
 Studio Home Page
 ****************


### PR DESCRIPTION
## Acceptance Criteria

Local table of contents should appear in the Redwood product notes pages, matching specs in [wiki](https://openedx.atlassian.net/wiki/spaces/OEPM/pages/4247257093/BETA+Course+Search+-+Product+Release+Notes) - I just forgot how to do it initially 😬 