### PR TITLE
docs: Reorganize release notes display

### DIFF
--- a/source/community/release_notes/index.rst
+++ b/source/community/release_notes/index.rst
@@ -10,12 +10,14 @@ migrations, and other changes and updates to the Open edX platform.
    un-supported release to the toctree in the old_releases.rst file.
 
 .. toctree::
-    :maxdepth: 1
+    :maxdepth: 2
 
     Redwood: The Current Release <redwood>
-    Redwood Release Notes <redwood/feature_release_notes>
-    Redwood Developer & Operator Release Notes <redwood/dev_op_release_notes>
     Sumac: The Next Release <sumac>
+
+.. toctree::
+    :maxdepth: 1
+
     old_releases
     named_release_branches_and_tags
 

--- a/source/community/release_notes/redwood.rst
+++ b/source/community/release_notes/redwood.rst
@@ -19,4 +19,10 @@ about :doc:`index` or learn more about the `Open edX Platform`_.
    
    :doc:`redwood/dev_op_release_notes`.
 
+.. toctree::
+    :maxdepth: 2
+
+    Redwood Release Notes <redwood/feature_release_notes>
+    Redwood Developer & Operator Release Notes <redwood/dev_op_release_notes>
+
 .. _Open edX Platform: https://openedx.org

--- a/source/community/release_notes/sumac.rst
+++ b/source/community/release_notes/sumac.rst
@@ -1,48 +1,29 @@
-Open edX Sumac Release
-######################
+Open edX Sumac - The Next Release
+#################################
 
-These are the release notes for the Sumac release, the 19th community release of the Open edX Platform, spanning changes from May 10, 2024 to October 09, 2024.  You can also review details about `earlier releases`_ or learn more about the `Open edX Platform`_.
+These are the release notes for the Sumac release, the 19th community release
+of the Open edX Platform, which will be released in December 2024. You can also review details
+about :doc:`index` or learn more about the `Open edX Platform`_.
 
-.. _earlier releases: https://edx.readthedocs.io/projects/edx-developer-docs/en/latest/named_releases.html
+.. highlights::
+
+   What's new in Sumac? Click to read about new features:
+
+   :doc:`sumac/feature_release_notes`.
+
+
+.. highlights::
+
+   What's new in Sumac? Operators and developers, click to read about new
+   updates, patches, and configuration options.
+   
+   :doc:`sumac/dev_op_release_notes`.
+
+.. toctree::
+    :maxdepth: 2
+
+    Sumac Release Notes <sumac/feature_release_notes>
+    Sumac Developer & Operator Release Notes <sumac/dev_op_release_notes>
+
 .. _Open edX Platform: https://openedx.org
 
-.. contents::
- :depth: 1
- :local:
-
-Breaking Changes
-****************
-
-
-Learner Experiences
-*******************
-
-
-Instructor Experiences
-**********************
-
-
-Administrators & Operators
-**************************
-
-Settings and Toggles
-====================
-
-
-Other Operator Changes
-======================
-
-
-Deprecations & Removals
-***********************
-
-
-Developer Experience
-********************
-
-Researcher & Data Experiences
-*****************************
-
-
-Known Issues
-************

--- a/source/community/release_notes/sumac/dev_op_release_notes.rst
+++ b/source/community/release_notes/sumac/dev_op_release_notes.rst
@@ -1,0 +1,52 @@
+Open edX Sumac Release
+######################
+
+These are the release notes for the Sumac release, the 19th community release of
+the Open edX Platform, spanning changes from May 10, 2024 to October 09, 2024.
+You can also review details about :doc:`../index` or learn more about the `Open edX
+Platform`_.
+
+To view the end-user facing docs, see the :doc:`feature_release_notes`.
+
+.. _Open edX Platform: https://openedx.org
+
+.. contents::
+ :depth: 1
+ :local:
+
+Breaking Changes
+****************
+
+
+Learner Experiences
+*******************
+
+
+Instructor Experiences
+**********************
+
+
+Administrators & Operators
+**************************
+
+Settings and Toggles
+====================
+
+
+Other Operator Changes
+======================
+
+
+Deprecations & Removals
+***********************
+
+
+Developer Experience
+********************
+
+Researcher & Data Experiences
+*****************************
+
+
+Known Issues
+************

--- a/source/community/release_notes/sumac/feature_release_notes.rst
+++ b/source/community/release_notes/sumac/feature_release_notes.rst
@@ -1,0 +1,10 @@
+Open edX Redwood Release - Feature-Based Notes
+##############################################
+
+.. toctree::
+   :maxdepth: 1
+
+
+Information for site operators and developers, including information on how to
+enable and/or configure new features that require additional work, can be found
+in the :doc:`dev_op_release_notes`.


### PR DESCRIPTION
As per [mocks from early 2024](https://docs.google.com/presentation/d/1hnot8lO5AmL4biW7UPMvxQVEWEk5-aiVCsqIsvViL3w/edit#slide=id.g2dfcad1c961_0_20), arrange the release notes such that
the differences between the Dev/Operator RNs and the Product or
Feature-based RNs is clear for the current and upcoming releases.

## Acceptance Criteria

The implementation should match the mock.

## Mocks

Mock ("Teak" should be "Sumac"):

<img width="841" alt="image" src="https://github.com/openedx/docs.openedx.org/assets/1985317/86110bf6-d2bb-4351-94a9-820224f7802d">

## Implemented

Implemented (see [sandbox](https://docsopenedxorg--531.org.readthedocs.build/en/531/community/release_notes/index.html)):

<img width="855" alt="image" src="https://github.com/openedx/docs.openedx.org/assets/1985317/94dd2aa3-b6b5-4060-85bb-4fd599407aa7">


