### PR TITLE
Add (Quince) to titles of Quince blog posts

### DIFF
--- a/source/community/release_notes/quince/copy_paste_a.rst
+++ b/source/community/release_notes/quince/copy_paste_a.rst
@@ -1,5 +1,5 @@
-Introducing Copy & Paste for Course Components!
-###############################################
+Introducing Copy & Paste for Course Components! (Quince)
+########################################################
 
 The Open edX Product Team is thrilled to announce the launch of a new Copy &
 Paste feature for course authors!

--- a/source/community/release_notes/quince/copy_paste_b.rst
+++ b/source/community/release_notes/quince/copy_paste_b.rst
@@ -1,5 +1,5 @@
-Copy & Paste - Second Phase Release
-###################################
+Copy & Paste - Second Phase Release (Quince)
+############################################
 
 The Open edX Community Product Team is excited to announce the release of the
 second phase of Copy & Paste!

--- a/source/community/release_notes/quince/demox_course.rst
+++ b/source/community/release_notes/quince/demox_course.rst
@@ -1,5 +1,5 @@
-Introducing the New DemoX Course
-################################
+Introducing the New DemoX Course (Quince)
+#########################################
 
 In 2013, just as the Open edX® platform was starting to take off, the “edX
 Demonstration Course”, or DemoX, was created and bundled with each new Open edX®

--- a/source/community/release_notes/quince/feature_roundup.rst
+++ b/source/community/release_notes/quince/feature_roundup.rst
@@ -2,9 +2,11 @@ Quince Feature Roundup
 ######################
 
 The latest Open edX release, Quince, includes a number of improvements for
-learners and course teams. In this post, we'll highlight some of the biggest
+learners and course teams. In this post we'll highlight some of the biggest
 changes that the Open edX community engineering and product teams have
-contributed to this release.
+contributed to this release. See also features previously discussed:
+:doc:`copy_paste_b`, :doc:`demox_course`, :doc:`woocommerce`, and
+:doc:`copy_paste_a`.
 
 .. contents::
   :local:

--- a/source/community/release_notes/quince/woocommerce.rst
+++ b/source/community/release_notes/quince/woocommerce.rst
@@ -1,5 +1,5 @@
-Integrating WooCommerce WordPress Plugin
-########################################
+Integrating WooCommerce WordPress Plugin (Quince)
+#################################################
 
 Earlier this year, we began discovery work on the possibility of integrating the
 Open edX platform directly with a 3rd party ecommerce platform that we would not


### PR DESCRIPTION
In order to match the way we did Redwood posts, append (Quince) to the title of Quince blog posts.
