### PR TITLE
build: Deal with RTD Deprecation

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -20,6 +20,11 @@ import sys
 import urllib
 from datetime import datetime
 
+# -- Project Base URL --------------------------------------------------------
+
+# Set canonical URL from the Read the Docs Domain
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
 # -- Project information -----------------------------------------------------
 
 project = ""


### PR DESCRIPTION
More info here: https://about.readthedocs.com/blog/2024/07/addons-by-default/

tl;dr  RTD used to inject data into conf.py but it's going to stop doing
that so we need to read RTD environment variables and pull in that data
ourselves to not break builds.
