### PR TITLE
Link from "Developer Guide" to OEP-67 frontend info

### DIFF
--- a/source/developers/references/developer_guide/conventions/frontend.rst
+++ b/source/developers/references/developer_guide/conventions/frontend.rst
@@ -1,0 +1,10 @@
+.. _Frontend Good Practices:
+
+#######################
+Frontend Good Practices
+#######################
+
+For best practices and standards related to frontend development for the Open edX platform, please see:
+
+* OEP-67: Standard Tools and Technologies: `Frontend Technology Selection <https://docs.openedx.org/projects/openedx-proposals/en/latest/best-practices/oep-0067-bp-tools-and-technology.html#frontend-technology-selection>`_
+* :ref:`Open edX JavaScript Style Guide <javascript_style_guide>`

--- a/source/developers/references/developer_guide/conventions/index.rst
+++ b/source/developers/references/developer_guide/conventions/index.rst
@@ -8,4 +8,4 @@ Writing Good Code
     :maxdepth: 2
 
     django
-
+    frontend


### PR DESCRIPTION
Following up from https://github.com/openedx/open-edx-proposals/pull/616 as suggested by @sarina, to link to it from our Developer Guide.

Preview at:
* https://docsopenedxorg--550.org.readthedocs.build/en/550/developers/references/developer_guide/index.html
* https://docsopenedxorg--550.org.readthedocs.build/en/550/developers/references/developer_guide/conventions/frontend.html