### PR TITLE
docs: Add redwood.2 release notes.

### DIFF
--- a/source/community/release_notes/redwood/dev_op_release_notes.rst
+++ b/source/community/release_notes/redwood/dev_op_release_notes.rst
@@ -288,6 +288,9 @@ Other Operator Changes
       - If you're running Tutor and your Mongo/Ruby are in Tutor, they will get automatically upgraded.
       - `chore: add mongo 7 to testing matrix <https://github.com/openedx/edx-platform/pull/34213>`_.
       - `build: Build with newer ruby and mongo versions. <https://github.com/openedx/cs_comments_service/pull/426>`_.
+- django-social-auth-django application
+      - The 'django-social-auth-django application has been upgraded with a security fix. Operators should update to this version of the edx-platform if they are using auth via social media sites eg. "Login with Google, Facebook, etc." features.
+      - `Feanil/backport django social auth <https://github.com/openedx/edx-platform/pull/35166>`_.
 
 
 Deprecations & Removals

--- a/source/community/release_notes/redwood/dev_op_release_notes.rst
+++ b/source/community/release_notes/redwood/dev_op_release_notes.rst
@@ -289,7 +289,7 @@ Other Operator Changes
       - `chore: add mongo 7 to testing matrix <https://github.com/openedx/edx-platform/pull/34213>`_.
       - `build: Build with newer ruby and mongo versions. <https://github.com/openedx/cs_comments_service/pull/426>`_.
 - django-social-auth-django application
-      - The 'django-social-auth-django application has been upgraded with a security fix. Operators should update to this version of the edx-platform if they are using auth via social media sites eg. "Login with Google, Facebook, etc." features.
+      - In redwood.2 and later, the 'django-social-auth-django application has been upgraded with a security fix. Operators should update to this version of the edx-platform if they are using auth via social media sites eg. "Login with Google, Facebook, etc." features.
       - `Feanil/backport django social auth <https://github.com/openedx/edx-platform/pull/35166>`_.
 
 


### PR DESCRIPTION
Add a note about the django-social app upgrade for redwood.2 to release notes.