### PR TITLE
Add link to Dev Guide within Dev Quickstart for additional info

### DIFF
--- a/source/developers/quickstarts/index.rst
+++ b/source/developers/quickstarts/index.rst
@@ -6,3 +6,7 @@ Developer Quickstarts
    :maxdepth: 1
 
    *
+
+.. seealso::
+
+   :doc:`/developers/references/developer_guide/process/index`


### PR DESCRIPTION
The Developer Guide is a reference that contains a ton of information about making your first PR, running PR tests, etc. Providing a link to this guide in a "See Also" at the end of the Quickstart index will help route people to the right place for additional digging and info.

Honestly part of the reason I added this is because https://docs.openedx.org/en/latest/developers/quickstarts/index.html looks like an empty page - until I looked ath the rst, I thought it was a blank page