### PR TITLE
Use :titlesonly: instead of :maxdepth: 0 on CT How-Tos index

### DIFF
--- a/source/educators/how-tos/content-tagging-how-tos/index.rst
+++ b/source/educators/how-tos/content-tagging-how-tos/index.rst
@@ -10,7 +10,7 @@ Content Tagging: How-tos
       :class-footer: sd-border-0
 
       .. toctree::
-         :maxdepth: 0
+         :titlesonly:
          :caption: Content Tagging Management
 
          add_delete_course_tags
@@ -20,7 +20,7 @@ Content Tagging: How-tos
       :class-footer: sd-border-0
 
       .. toctree::
-         :maxdepth: 0
+         :titlesonly:
          :caption: Taxonomies
 
          Create_flat_taxonomy_by_uploading_CSV


### PR DESCRIPTION
With `:maxdepth: 0`, subheadings were unexpectedly showing:

<img width="886" alt="image" src="https://github.com/user-attachments/assets/65071b0c-c7ce-4c11-a65e-aa4f429b9e9c">

However with `:titlesonly:`, only the titles show.

<img width="846" alt="image" src="https://github.com/user-attachments/assets/bd546fd6-1b97-45cd-8330-fa0da1d91cd8">

We want this because as the content tagging how-tos grow, this will become a tricky list to navigate. We only want to show the title of each article.