### PR TITLE
Expose docs concepts articles on documentor's home page

### DIFF
--- a/source/documentors/index.rst
+++ b/source/documentors/index.rst
@@ -20,21 +20,19 @@ Open edX Documentors
 
          All Quick Starts
 
-   .. grid-item-card:: References
+   .. grid-item-card:: Concepts
       :class-card: sd-shadow-md sd-p-2
       :class-footer: sd-border-0
 
-      * :doc:`references/doc_guidelines`
-      * :doc:`references/quick_reference_rst`
-      * :doc:`references/doc_templates`
-      * :doc:`references/doc_checklist`
+      * :doc:`concepts/doc_audiences`
+      * :doc:`concepts/content_types`
       +++
-      .. button-ref:: references/index
+      .. button-ref:: concepts/index
          :color: primary
          :outline:
          :expand:
 
-         All References
+         All Concepts
 
    .. grid-item-card:: How-tos
       :class-card: sd-shadow-md sd-p-2
@@ -50,6 +48,22 @@ Open edX Documentors
          :expand:
 
          All How-tos
+
+   .. grid-item-card:: References
+      :class-card: sd-shadow-md sd-p-2
+      :class-footer: sd-border-0
+
+      * :doc:`references/doc_guidelines`
+      * :doc:`references/quick_reference_rst`
+      * :doc:`references/doc_templates`
+      * :doc:`references/doc_checklist`
+      +++
+      .. button-ref:: references/index
+         :color: primary
+         :outline:
+         :expand:
+
+         All References
 
    .. grid-item-card:: Decisions
       :class-card: sd-shadow-md sd-p-2


### PR DESCRIPTION
## Page:

https://docs.openedx.org/en/latest/documentors/

## Before:

<img width="837" alt="image" src="https://github.com/user-attachments/assets/7b9abb3f-2122-4d93-af5e-ebf863a4fe7f">

## After:

https://docsopenedxorg--571.org.readthedocs.build/en/571/documentors/index.html

<img width="850" alt="image" src="https://github.com/user-attachments/assets/07f99a7c-5f88-4104-b81f-bf4090d4d1df">
