### PR TITLE
Add big blank issue to custom config

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank-issue.md
+++ b/.github/ISSUE_TEMPLATE/blank-issue.md
@@ -1,0 +1,10 @@
+---
+name: 📝 Blank Issue (Reponse not guaranteed!)
+about: Record an established issue relating to this repository. In order to increase the likelihood of getting a reponse, we highly recommend cross-posting the issue to the community forum (linked below).
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: 💬 Open edX Community Support
     url: https://discuss.openedx.org/


### PR DESCRIPTION
currently:
<img width="1296" alt="image" src="https://github.com/user-attachments/assets/d6ce8a04-e1e1-4cce-9264-61277c45bb34">

wish to make it more like the default:
<img width="1187" alt="image" src="https://github.com/user-attachments/assets/0a1f6ab6-a793-49fc-9472-6fcb77bab8ac">
