### PR TITLE
Update name on Concepts index page

### DIFF
--- a/source/educators/concepts/open_edx_platform/index.rst
+++ b/source/educators/concepts/open_edx_platform/index.rst
@@ -1,5 +1,5 @@
-Instructional Design Concepts
-#############################
+LMS & Studio Concepts
+#####################
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
I think this was just a copy-paste error, but this page has the wrong title:

<img width="454" alt="image" src="https://github.com/user-attachments/assets/598fe8d3-650d-49ef-8188-44a33b71abc0">

<img width="566" alt="image" src="https://github.com/user-attachments/assets/8ac840a7-a36b-4ee7-b4f7-229374ee28ac">


I retitled it to the best of my ability but would love feedback.