### PR TITLE
chore: update docs for new Redwood.3 release

### DIFF
--- a/source/community/release_notes/named_release_branches_and_tags.rst
+++ b/source/community/release_notes/named_release_branches_and_tags.rst
@@ -53,6 +53,14 @@ Redwood
      - 2024-06-19
      - open-release/redwood.1
 
+   * - Redwood.2
+     - 2024-08-09
+     - open-release/redwood.2
+
+   * - Redwood.3
+     - 2024-10-23
+     - open-release/redwood.3
+
 Quince
 ======
 


### PR DESCRIPTION
Redwood.3 release update. This points latest release to Redwood.

See: https://openedx.atlassian.net/wiki/spaces/COMM/pages/19662426/Process+to+Create+an+Open+edX+Release#4b.-Make-the-new-release-notes-the-%E2%80%9Clatest%E2%80%9D
