### PR TITLE
docs: Add links to Aspects documentation

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -80,6 +80,12 @@ intersphinx_mapping = {
         f"/{rtd_version}",
         None,
     ),
+    "platform-plugin-aspects": (
+        f"https://docs.openedx.org/projects/platform-plugin-aspects/{rtd_language}/{rtd_version}", None
+    ),
+    "event-routing-backends": (
+        f"https://event-routing-backends.readthedocs.io/{rtd_language}/{rtd_version}", None
+    ),
     "edx-installing-configuring-and-running": (
         f"https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/{rtd_language}/{rtd_version}",
         None,

--- a/source/developers/index.rst
+++ b/source/developers/index.rst
@@ -62,6 +62,7 @@ Open edX Developers
       * :doc:`references/developer_guide/index`
       * :doc:`edx-platform:index`
       * `frontend-platform <https://openedx.github.io/frontend-platform>`_
+      * :doc:`references/aspects_home`
       +++
       .. button-ref:: references/index
          :color: primary

--- a/source/developers/references/aspects_home.rst
+++ b/source/developers/references/aspects_home.rst
@@ -1,0 +1,13 @@
+################
+Aspects
+################
+
+Aspects Homepage
+    :doc:`openedx-aspects:index`
+
+LMS Events
+    :doc:`event-routing-backends:index`
+
+Tutor plugin
+    * `<https://github.com/openedx/tutor-contrib-aspects?tab=readme-ov-file#installation>`_
+    * :doc:`platform-plugin-aspects:index`

--- a/source/developers/references/index.rst
+++ b/source/developers/references/index.rst
@@ -9,7 +9,7 @@ Per Repo Documentation
    relevant mapping to the ``intersphinx_mapping`` setting in conf.py
 
 * :doc:`DoneXBlock:index`
-* :doc:`openedx-aspects:index`
+* :doc:`aspects_home`
 * :doc:`edx-platform:index`
 * :doc:`xblock:index`
 * :doc:`wordpress-ecommerce-plugin:index`
@@ -26,3 +26,8 @@ Other References
    internal_data_formats/index
    developer_guide/index
    glossary
+
+.. toctree::
+   :hidden:
+   
+   aspects_home

--- a/source/educators/index.rst
+++ b/source/educators/index.rst
@@ -61,6 +61,7 @@ Open edX Educators
       * :doc:`references/simple_problem_types`
 
       * :doc:`references/instructional_design/index`
+      * :doc:`/developers/references/aspects_home`
       +++
       .. button-ref:: references/index
          :color: primary

--- a/source/educators/references/index.rst
+++ b/source/educators/references/index.rst
@@ -33,6 +33,7 @@ General References
    :caption: References
    :glob:
 
+   /developers/references/aspects_home
    *
    instructional_design/index
    course_development/index

--- a/source/index.rst
+++ b/source/index.rst
@@ -162,3 +162,4 @@ Open edX Documentation
          other/feedback
          other/getting_help
          Technical Decisions About This Site <documentors/decisions/index>
+         developers/references/aspects_home


### PR DESCRIPTION
- New landing page for Aspects with links to repo documentation
- Include link in Developer Resources, Other Topics, and Educator Resources