### PR TITLE
docs: [FC-0074] centralize docs for the hooks extension framework

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -100,6 +100,14 @@ intersphinx_mapping = {
         f"https://docs.openedx.org/projects/wordpress-ecommerce-plugin/{rtd_language}/{rtd_version}",
         None,
     ),
+    "openedx-events": (
+        f"https://docs.openedx.org/projects/openedx-events/{rtd_language}/latest",
+        None,
+    ),
+    "openedx-filters": (
+        f"https://docs.openedx.org/projects/openedx-filters/{rtd_language}/latest",
+        None,
+    ),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/source/developers/concepts/hooks_extension_framework.rst
+++ b/source/developers/concepts/hooks_extension_framework.rst
@@ -19,8 +19,8 @@ The main goal of the framework is that developers can use it to change the platf
 A longer description of the framework and its history can be found in `OEP 50`_.
 
 .. _OEP 50: https://open-edx-proposals.readthedocs.io/en/latest/oep-0050-hooks-extension-framework.html
-.. _openedx-filters: https://github.com/eduNEXT/openedx-filters
-.. _openedx-events: https://github.com/eduNEXT/openedx-events
+.. _openedx-filters: https://github.com/openedx/openedx-filters
+.. _openedx-events: https://github.com/openedx/openedx-events
 .. _open-closed principle: https://docs.openedx.org/projects/edx-platform/en/open-release-quince.master/concepts/extension_points.html
 
 Why adopt the Hooks Extension Framework?

--- a/source/developers/concepts/hooks_extension_framework.rst
+++ b/source/developers/concepts/hooks_extension_framework.rst
@@ -109,7 +109,7 @@ A developer might use an Open edX Event in order to perform the following action
 - Communicate, synchronize, or coordinate with other components or services based on specific events or actions, e.g., send certificate data from LMS to credentials service to keep models up to date.
 - Integrate with external systems or services based on specific events or actions, e.g., send user data to third-party services upon registration for marketing purposes.
 
-Fore more detailed use cases, please visit :doc:`openedx-events:references/real-life-use-cases`.
+Fore more detailed use cases, please visit :doc:`openedx-events:reference/real-life-use-cases`.
 
 In summary, events can be used to integrate application components with each other or with external services, allowing them to communicate, synchronize, and perform additional actions when specific triggers occur.
 
@@ -124,7 +124,7 @@ A developer might use an Open edX Filter in order to perform the following actio
 - Enforce specific constraints or business rules of a specific component, e.g., don't allow registration for non-authorized email domains.
 - Implement additional features or behavior in a specific component, e.g., add registration extra fields to the user registration form.
 
-Fore more detailed use cases, please visit :doc:`openedx-filters:references/real-life-use-cases`.
+Fore more detailed use cases, please visit :doc:`openedx-filters:reference/real-life-use-cases`.
 
 In summary, filters can be used when implementing application flow control that modifies the application's behavior, navigation, or user interaction flow during runtime.
 

--- a/source/developers/concepts/hooks_extension_framework.rst
+++ b/source/developers/concepts/hooks_extension_framework.rst
@@ -5,9 +5,9 @@ Hooks Extension Framework
 What is the Hooks Extension Framework?
 =======================================
 
-Based on the `open-closed principle`_, this framework aims to extend the Open edX platform in a maintainable way without modifying its core. The main goal is to leverage the existing extension capabilities provided by the plugin architecture, allowing developers to implement new features to fit customer needs while reducing the need for core modifications and minimizing maintenance efforts.
+Based on the `open-closed principle`_, this framework aims to extend the Open edX platform in a maintainable way without modifying its core. The main goal is to leverage the existing extension capabilities provided by the `Open edX Django plugins`_ architecture, allowing developers to implement new features to fit customer needs while reducing the need for core modifications and minimizing maintenance efforts.
 
-Hooks are a list of places in the Open edX platform where externally defined functions can take place. These functions may alter what the user sees or experiences on the platform, while in other cases, they act as notifications. All hooks are designed to be extended through `Open edX Django plugins`_ and configurations.
+Hooks are a list of places in the Open edX platform where externally defined functions can take place. These functions may alter what the user sees or experiences on the platform, while in other cases, they are informative only. All hooks are designed to be extended through `Open edX Django plugins`_ and configurations.
 
 Hooks can be of two types: events and filters. Events are signals sent in specific places whose receivers can extend functionality, while filters are functions that can modify the application's behavior. To allow extension developers to use these definitions in their implementations, both kinds of hooks are defined in lightweight external libraries:
 
@@ -44,7 +44,7 @@ The framework allows developers to implement custom business logic and integrati
 Standardization
 ---------------
 
-Both filters and events implementations implement an approach for adding additional features, such as communication between services or backend flow control. With these standards in place, it’s easy to identify when and how to use the framework as a solution, ensuring a consistent and predictable approach to extending the platform.
+Both filters and events implement approaches for adding additional features, such as communication between services or backend flow control. With these standards in place, it's easy to identify when and how to use the framework as a solution, ensuring a consistent and predictable approach to extending the platform.
 
 Reduce Fork Modifications
 -------------------------
@@ -93,7 +93,7 @@ Here are some key differences between Open edX Events and Filters:
 | **Purpose**        | Notify when an action occurs in a specific part of the                 | Alter the application flow control.                         |
 |                    | application.                                                           |                                                             |
 +--------------------+------------------------------------------------------------------------+-------------------------------------------------------------+
-|  **Usage**         | Used to **extend** functionality via signal handlers when an event is  |  Used to intercept and **modify** the data used within a    |
+|  **Usage**         | Used to **extend** functionality via signal receivers when an event is |  Used to intercept and **modify** the data used within a    |
 |                    | triggered.                                                             |  component without directly modifying the application       |
 |                    |                                                                        |  itself.                                                    |
 +--------------------+------------------------------------------------------------------------+-------------------------------------------------------------+
@@ -107,7 +107,6 @@ Here are some key differences between Open edX Events and Filters:
 |                    |                                                                        |  processing.                                                |
 +--------------------+------------------------------------------------------------------------+-------------------------------------------------------------+
 | **Use cases**      |  Send an email notification when a user enrolls in a course.           |  Include additional information in an API endpoint response.|
-|                    |  an email notification.                                                |                                                             |
 +--------------------+------------------------------------------------------------------------+-------------------------------------------------------------+
 
 .. _Django signals: https://docs.djangoproject.com/en/4.2/topics/signals/
@@ -138,9 +137,9 @@ When to use an Open edX Filter?
 
 Use an Open edX Filter when but not limited to:
 
-- Enrich the data or parameters passed to a specific component, e.g., fetch reusable LTI configurations from external plugins.
-- Intercept and modify the input of a specific component, e.g., include "Edit" link to an HTML block if certain conditions are met.
-- Enforce specific constraints or business rules on the input or output of a specific function or method, e.g., prevent enrollment for non-authorized users.
+- Enrich the data or parameters used to a specific component, e.g., fetch reusable LTI configurations from external plugins.
+- Intercept and modify runtime data of a specific component, e.g., include "Edit" link to an HTML block if certain conditions are met.
+- Enforce specific constraints or business rules of a specific component, e.g., prevent enrollment for non-authorized users.
 - Implement additional features or behavior in a specific component, e.g., add custom logic to the user profile update process.
 
 In summary, filters can be used when implementing application flow control that modifies the application's behavior, navigation, or user interaction flow during runtime.

--- a/source/developers/concepts/hooks_extension_framework.rst
+++ b/source/developers/concepts/hooks_extension_framework.rst
@@ -17,7 +17,7 @@ The framework's main goal is to empower developers to change the platform's func
 
 A longer description of the framework and its history can be found in :doc:`openedx-proposals:architectural-decisions/oep-0050-hooks-extension-framework`.
 
-Why adopt the Hooks Extension Framework?
+Why Adopt the Hooks Extension Framework?
 ****************************************
 
 Stable and Maintainable Extensions
@@ -70,7 +70,7 @@ Filters are functions that can modify the application's behavior by altering inp
 
 To start using Open edX Filters in your project, see the :doc:`Open edX Filters <openedx-filters:index>` documentation.
 
-Differences between Events and Filters
+Differences Between Events and Filters
 =======================================
 
 Here are some key differences between Open edX Events and Filters:
@@ -97,10 +97,10 @@ Here are some key differences between Open edX Events and Filters:
 | **Use cases**      |  Send an email notification when a user enrolls in a course.           |  Prevent the enrollment of non-authorized users.            |
 +--------------------+------------------------------------------------------------------------+-------------------------------------------------------------+
 
-How to know when to use an Event or a Filter?
+How to Know When to Use an Event or a Filter?
 =============================================
 
-When to use an Open edX Event?
+When to Use an Open edX Event?
 ------------------------------
 
 A developer might use an Open edX Event in order to perform the following actions. Note that this is not an exhaustive list.
@@ -115,7 +115,7 @@ In summary, events can be used to integrate application components with each oth
 
 You can review the :doc:`Open edX Events <openedx-events:index>` documentation for more information on :doc:`openedx-events:how-tos/using-events` in your project. This documentation includes a list of :doc:`openedx-events:reference/events` and much more.
 
-When to use an Open edX Filter?
+When to Use an Open edX Filter?
 -------------------------------
 
 A developer might use an Open edX Filter in order to perform the following actions. Note that this is not an exhaustive list.

--- a/source/developers/concepts/hooks_extension_framework.rst
+++ b/source/developers/concepts/hooks_extension_framework.rst
@@ -1,9 +1,8 @@
-=========================
 Hooks Extension Framework
-=========================
+#########################
 
 What is the Hooks Extension Framework?
-=======================================
+**************************************
 
 Based on the `open-closed principle`_, this framework aims to extend the Open edX platform in a maintainable way without modifying its core. The main goal is to leverage the existing extension capabilities provided by the `Open edX Django plugins`_ architecture, allowing developers to implement new features to fit customer needs while reducing the need for core modifications and minimizing maintenance efforts.
 
@@ -24,48 +23,48 @@ A longer description of the framework and its history can be found in `OEP 50`_.
 .. _open-closed principle: https://docs.openedx.org/projects/edx-platform/en/open-release-quince.master/concepts/extension_points.html
 
 Why adopt the Hooks Extension Framework?
-========================================
+****************************************
 
 Stable and Maintainable Extensions
-----------------------------------
+==================================
 
 The Hooks Extension Framework allows developers to extend the platform's functionality in a stable, maintainable, and decoupled way ensuring easier upgrades and long-term stability by removing the need to modify the core in an significant way.
 
 Contained Solution Implementation
----------------------------------
+=================================
 
 By avoiding core modifications, the framework promotes self-contained solutions, eliminating the need for custom code to coexist with core logic which lowers maintenance costs for extension developers.
 
 Leveraging the Open edX Plugin Extension Mechanism
---------------------------------------------------
+==================================================
 
 The framework allows developers to implement custom business logic and integrations directly in plugins. This keeps core modifications minimal, focusing maintenance and development efforts on plugins, where solutions can be built and maintained independently of the core platform.
 
 Standardization
----------------
+===============
 
 Both filters and events implement approaches for adding additional features, such as communication between services or backend flow control. With these standards in place, it's easy to identify when and how to use the framework as a solution, ensuring a consistent and predictable approach to extending the platform.
 
 Reduce Fork Modifications
--------------------------
+=========================
 
 The need to modify logic in forks is minimized, as most extensions can now be implementing using the framework, keeping forks closer to the core and easier to manage.
 
 Community Compatibility
-------------------------
+=======================
 
 The framework allows for shorter and more agile contribution cycles. By adding standardized extension points, contributors avoid creating customer-specific logic, making development more community-friendly.
 
 Backward Compatibility
------------------------
+======================
 
 Hooks are designed to be backward compatible, guaranteeing stability across releases and making it easier to upgrade without breaking existing functionality.
 
 Open edX Events and Filters
-============================
+***************************
 
 Open edX Events
-----------------
+===============
 
 Events are Open edX-specific Django signals sent in specific places on the Open edX platform. They allow developers to listen to these signals and perform additional processing based on the event data.
 
@@ -74,7 +73,7 @@ To start using Open edX Events in your project, see the `Open edX Events`_ docum
 .. _Open edX Events: https://docs.openedx.org/projects/openedx-events/en/latest/
 
 Open edX Filters
------------------
+================
 
 Filters are functions that can modify the application's behavior by altering input data or halting execution based on specific conditions. They allow developers to implement application flow control based on their business logic or requirements without directly modifying the application code.
 
@@ -83,7 +82,7 @@ To start using Open edX Filters in your project, see the `Open edX Filters`_ doc
 .. _Open edX Filters: https://docs.openedx.org/projects/openedx-filters/en/latest/
 
 Differences between Events and Filters
----------------------------------------
+=======================================
 
 Here are some key differences between Open edX Events and Filters:
 
@@ -112,10 +111,10 @@ Here are some key differences between Open edX Events and Filters:
 .. _Django signals: https://docs.djangoproject.com/en/4.2/topics/signals/
 
 How to know when to use an Event or a Filter?
-----------------------------------------------
+=============================================
 
 When to use an Open edX Event?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------
 
 Use an Open edX Event when but not limited to:
 
@@ -133,7 +132,7 @@ You can review the `Open edX Events`_ documentation for more information on `how
 .. _how to implement event receivers: https://docs.openedx.org/projects/openedx-events/en/latest/how-tos/using-events.html#receiving-events
 
 When to use an Open edX Filter?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 
 Use an Open edX Filter when but not limited to:
 

--- a/source/developers/concepts/hooks_extension_framework.rst
+++ b/source/developers/concepts/hooks_extension_framework.rst
@@ -26,31 +26,38 @@ A longer description of the framework and its history can be found in `OEP 50`_.
 Why adopt the Hooks Extension Framework?
 ========================================
 
-#. Stable and Maintainable Extensions
+Stable and Maintainable Extensions
+----------------------------------
 
 The Hooks Extension Framework allows developers to extend the platform's functionality in a stable, maintainable, and decoupled way ensuring easier upgrades and long-term stability by removing the need to modify the core in an significant way.
 
-#. Contained Solution Implementation
+Contained Solution Implementation
+---------------------------------
 
 By avoiding core modifications, the framework promotes self-contained solutions, eliminating the need for custom code to coexist with core logic which lowers maintenance costs for extension developers.
 
-#. Leveraging the Open edX Plugin Extension Mechanism
+Leveraging the Open edX Plugin Extension Mechanism
+--------------------------------------------------
 
 The framework allows developers to implement custom business logic and integrations directly in plugins. This keeps core modifications minimal, focusing maintenance and development efforts on plugins, where solutions can be built and maintained independently of the core platform.
 
-#. Standardization
+Standardization
+---------------
 
 Both filters and events implementations implement an approach for adding additional features, such as communication between services or backend flow control. With these standards in place, it’s easy to identify when and how to use the framework as a solution, ensuring a consistent and predictable approach to extending the platform.
 
-#. Reduce Fork Modifications
+Reduce Fork Modifications
+-------------------------
 
 The need to modify logic in forks is minimized, as most extensions can now be implementing using the framework, keeping forks closer to the core and easier to manage.
 
-#. Community Compatibility
+Community Compatibility
+------------------------
 
 The framework allows for shorter and more agile contribution cycles. By adding standardized extension points, contributors avoid creating customer-specific logic, making development more community-friendly.
 
-#. Backward Compatibility
+Backward Compatibility
+-----------------------
 
 Hooks are designed to be backward compatible, guaranteeing stability across releases and making it easier to upgrade without breaking existing functionality.
 

--- a/source/developers/concepts/hooks_extension_framework.rst
+++ b/source/developers/concepts/hooks_extension_framework.rst
@@ -109,7 +109,7 @@ A developer might use an Open edX Event in order to perform the following action
 - Communicate, synchronize, or coordinate with other components or services based on specific events or actions, e.g., send certificate data from LMS to credentials service to keep models up to date.
 - Integrate with external systems or services based on specific events or actions, e.g., send user data to third-party services upon registration for marketing purposes.
 
-.. For more detailed use cases, see the TODO: ADD REFERENCE TO REAL LIFE USE CASES documentation.
+Fore more detailed use cases, please visit :doc:`openedx-events:references/real-life-use-cases`.
 
 In summary, events can be used to integrate application components with each other or with external services, allowing them to communicate, synchronize, and perform additional actions when specific triggers occur.
 
@@ -124,7 +124,7 @@ A developer might use an Open edX Filter in order to perform the following actio
 - Enforce specific constraints or business rules of a specific component, e.g., don't allow registration for non-authorized email domains.
 - Implement additional features or behavior in a specific component, e.g., add registration extra fields to the user registration form.
 
-.. For more detailed use cases, see the TODO: ADD REFERENCE TO REAL LIFE USE CASES documentation.
+Fore more detailed use cases, please visit :doc:`openedx-filters:references/real-life-use-cases`.
 
 In summary, filters can be used when implementing application flow control that modifies the application's behavior, navigation, or user interaction flow during runtime.
 

--- a/source/developers/concepts/hooks_extension_framework.rst
+++ b/source/developers/concepts/hooks_extension_framework.rst
@@ -7,11 +7,9 @@ What is the Hooks Extension Framework?
 
 Based on the `open-closed principle`_, this framework aims to extend the Open edX platform in a maintainable way without modifying its core. The main goal is to leverage the existing extension capabilities provided by the plugin architecture, allowing developers to implement new features to fit customer needs while reducing the need for core modifications and minimizing maintenance efforts.
 
-Hooks are a list of places in the Open edX platform where externally defined functions can take place. These functions may alter what the user sees or experiences on the platform, while in other cases, they act as notifications. All hooks are designed to be extended through Open edX plugins and configurations.
+Hooks are a list of places in the Open edX platform where externally defined functions can take place. These functions may alter what the user sees or experiences on the platform, while in other cases, they act as notifications. All hooks are designed to be extended through `Open edX Django plugins`_ and configurations.
 
-Hooks can be of two types: events and filters. Events are signals sent in specific places whose receivers can extend functionality, while filters are functions that can modify the application's behavior.
-
-To allow extension developers to use the framework's definitions in their implementations, both kinds of hooks are defined in lightweight external libraries:
+Hooks can be of two types: events and filters. Events are signals sent in specific places whose receivers can extend functionality, while filters are functions that can modify the application's behavior. To allow extension developers to use these definitions in their implementations, both kinds of hooks are defined in lightweight external libraries:
 
 * `openedx-filters`_
 * `openedx-events`_
@@ -28,31 +26,31 @@ A longer description of the framework and its history can be found in `OEP 50`_.
 Why adopt the Hooks Extension Framework?
 ========================================
 
-1. Stable and Maintainable Extensions
+#. Stable and Maintainable Extensions
 
 The Hooks Extension Framework allows developers to extend the platform's functionality in a stable, maintainable, and decoupled way ensuring easier upgrades and long-term stability by removing the need to modify the core in an significant way.
 
-2. Contained Solution Implementation
+#. Contained Solution Implementation
 
-By avoiding core modifications, the framework promotes self-contained solutions, eliminating the need  for custom code to coexist with core logic which lowers maintenance costs for extension developers.
+By avoiding core modifications, the framework promotes self-contained solutions, eliminating the need for custom code to coexist with core logic which lowers maintenance costs for extension developers.
 
-3. Leveraging the Open edX Plugin Extension Mechanism
+#. Leveraging the Open edX Plugin Extension Mechanism
 
 The framework allows developers to implement custom business logic and integrations directly in plugins. This keeps core modifications minimal, focusing maintenance and development efforts on plugins, where solutions can be built and maintained independently of the core platform.
 
-4. Standardization
+#. Standardization
 
 Both filters and events implementations implement an approach for adding additional features, such as communication between services or backend flow control. With these standards in place, it’s easy to identify when and how to use the framework as a solution, ensuring a consistent and predictable approach to extending the platform.
 
-5. Reduce Fork Modifications
+#. Reduce Fork Modifications
 
 The need to modify logic in forks is minimized, as most extensions can now be implementing using the framework, keeping forks closer to the core and easier to manage.
 
-6. Community Compatibility
+#. Community Compatibility
 
 The framework allows for shorter and more agile contribution cycles. By adding standardized extension points, contributors avoid creating customer-specific logic, making development more community-friendly.
 
-7. Backward Compatibility
+#. Backward Compatibility
 
 Hooks are designed to be backward compatible, guaranteeing stability across releases and making it easier to upgrade without breaking existing functionality.
 
@@ -92,7 +90,7 @@ Here are some key differences between Open edX Events and Filters:
 |                    | triggered.                                                             |  component without directly modifying the application       |
 |                    |                                                                        |  itself.                                                    |
 +--------------------+------------------------------------------------------------------------+-------------------------------------------------------------+
-|  **Definition**    |  Defined using the `OpenEdxPublicSignal` class, which                  |  Defined using the ``OpenEdxPublicFilter`` class,           |
+|  **Definition**    |  Defined using the ``OpenEdxPublicSignal``` class, which               |  Defined using the ``OpenEdxPublicFilter`` class,           |
 |                    |  provides a structured way to define the data and                      |  which provides a way to define the filter function         |
 |                    |  metadata associated with the event.                                   |  and the parameters it should receive.                      |
 +--------------------+------------------------------------------------------------------------+-------------------------------------------------------------+
@@ -113,7 +111,7 @@ How to know when to use an Event or a Filter?
 When to use an Open edX Event?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use an Open edX Event when you need to:
+Use an Open edX Event when but not limited to:
 
 - Trigger custom logic or processing in response to specific actions within the platform, e.g., updating a search index after a course block is modified.
 - Communicate, synchronize, or coordinate with other components or services based on specific events or actions, e.g., send certificate data from LMS to credentials service to keep models up to date.
@@ -131,11 +129,12 @@ You can review the `Open edX Events`_ documentation for more information on `how
 When to use an Open edX Filter?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use an Open edX Filter when:
+Use an Open edX Filter when but not limited to:
 
 - Enrich the data or parameters passed to a specific component, e.g., fetch reusable LTI configurations from external plugins.
 - Intercept and modify the input of a specific component, e.g., include "Edit" link to an HTML block if certain conditions are met.
 - Enforce specific constraints or business rules on the input or output of a specific function or method, e.g., prevent enrollment for non-authorized users.
+- Implement additional features or behavior in a specific component, e.g., add custom logic to the user profile update process.
 
 In summary, filters can be used when implementing application flow control that modifies the application's behavior, navigation, or user interaction flow during runtime.
 
@@ -146,3 +145,4 @@ You can review the `Open edX Filters`_ documentation for more information on `ho
 .. _list of available filters: https://docs.openedx.org/projects/openedx-filters/en/latest/reference/filters.html
 .. _how to implement filter pipelines: https://docs.openedx.org/projects/openedx-filters/en/latest/how-tos/using-filters.html#implement-pipeline-steps
 .. _create new filters: https://docs.openedx.org/projects/openedx-filters/en/latest/how-tos/create-new-filters.html
+.. _Open edX Django plugins: https://edx.readthedocs.io/projects/edx-django-utils/en/latest/plugins/readme.html

--- a/source/developers/concepts/hooks_extension_framework.rst
+++ b/source/developers/concepts/hooks_extension_framework.rst
@@ -4,23 +4,18 @@ Hooks Extension Framework
 What is the Hooks Extension Framework?
 **************************************
 
-Based on the `open-closed principle`_, this framework aims to extend the Open edX platform in a maintainable way without modifying its core. The main goal is to leverage the existing extension capabilities provided by the `Open edX Django plugins`_ architecture, allowing developers to implement new features to fit customer needs while reducing the need for core modifications and minimizing maintenance efforts.
+Based on the :doc:`edx-platform:concepts/extension_points`, this framework aims to extend the Open edX platform in a maintainable way without modifying its core. The main goal is to leverage the existing extension capabilities provided by the `Open edX Django plugins`_ architecture, allowing developers to implement new features to fit customer needs while reducing the need for core modifications and minimizing maintenance efforts.
 
-Hooks are a list of places in the Open edX platform where externally defined functions can take place. These functions may alter what the user sees or experiences on the platform, while in other cases, they are informative only. All hooks are designed to be extended through `Open edX Django plugins`_ and configurations.
+Hooks are places in the Open edX platform where externally defined functions can take place. These functions may alter what the user sees or experiences on the platform, while in other cases, they are informative only. All hooks are designed to be used along with `Open edX Django plugins`_.
 
 Hooks can be of two types: events and filters. Events are signals sent in specific places whose receivers can extend functionality, while filters are functions that can modify the application's behavior. To allow extension developers to use these definitions in their implementations, both kinds of hooks are defined in lightweight external libraries:
 
 * `openedx-filters`_
 * `openedx-events`_
 
-The main goal of the framework is that developers can use it to change the platform's functionality as needed and still migrate to newer Open edX releases with little to no development effort. So, the framework is designed with stability in mind, meaning it is versioned and backward compatible as much as possible.
+The framework's main goal is to empower developers to change the platform's functionality as needed while allowing them to migrate to newer Open edX releases with little to no development effort. The framework is designed with stability in mind, meaning it is versioned and backward compatible as much as possible.
 
-A longer description of the framework and its history can be found in `OEP 50`_.
-
-.. _OEP 50: https://open-edx-proposals.readthedocs.io/en/latest/oep-0050-hooks-extension-framework.html
-.. _openedx-filters: https://github.com/openedx/openedx-filters
-.. _openedx-events: https://github.com/openedx/openedx-events
-.. _open-closed principle: https://docs.openedx.org/projects/edx-platform/en/open-release-quince.master/concepts/extension_points.html
+A longer description of the framework and its history can be found in :doc:`openedx-proposals:architectural-decisions/oep-0050-hooks-extension-framework`.
 
 Why adopt the Hooks Extension Framework?
 ****************************************
@@ -28,12 +23,12 @@ Why adopt the Hooks Extension Framework?
 Stable and Maintainable Extensions
 ==================================
 
-The Hooks Extension Framework allows developers to extend the platform's functionality in a stable, maintainable, and decoupled way ensuring easier upgrades and long-term stability by removing the need to modify the core in an significant way.
+The Hooks Extension Framework allows developers to extend the platform's functionality in a stable, maintainable, and decoupled way ensuring easier upgrades and long-term stability by removing the need to modify the core in a significant way.
 
 Contained Solution Implementation
 =================================
 
-By avoiding core modifications, the framework promotes self-contained solutions, eliminating the need for custom code to coexist with core logic which lowers maintenance costs for extension developers.
+By avoiding core modifications, the framework promotes self-contained solutions, eliminating the need for custom code to coexist with core logic which lowers maintenance costs for extension developers. As most extensions can now be implementing using the framework, forks are closer to the core and easier to manage.
 
 Leveraging the Open edX Plugin Extension Mechanism
 ==================================================
@@ -45,11 +40,6 @@ Standardization
 
 Both filters and events implement approaches for adding additional features, such as communication between services or backend flow control. With these standards in place, it's easy to identify when and how to use the framework as a solution, ensuring a consistent and predictable approach to extending the platform.
 
-Reduce Fork Modifications
-=========================
-
-The need to modify logic in forks is minimized, as most extensions can now be implementing using the framework, keeping forks closer to the core and easier to manage.
-
 Community Compatibility
 =======================
 
@@ -58,7 +48,10 @@ The framework allows for shorter and more agile contribution cycles. By adding s
 Backward Compatibility
 ======================
 
-Hooks are designed to be backward compatible, guaranteeing stability across releases and making it easier to upgrade without breaking existing functionality.
+Hooks are designed to be backwards compatible, guaranteeing stability across releases and making it easier to upgrade without breaking existing functionality. This ensures that extensions built on the framework will continue to work as expected across different Open edX versions. See the Architectural Decision Records (ADRs) about versioning for Open edX Events and Filters for more information:
+
+* :doc:`openedx-events:decisions/0002-events-naming-and-versioning`
+* :doc:`openedx-filters:decisions/0004-filters-naming-and-versioning`
 
 Open edX Events and Filters
 ***************************
@@ -66,20 +59,16 @@ Open edX Events and Filters
 Open edX Events
 ===============
 
-Events are Open edX-specific Django signals sent in specific places on the Open edX platform. They allow developers to listen to these signals and perform additional processing based on the event data.
+Events are Open edX-specific Django signals sent in specific places on the Open edX platform. Developers write code that listens to these signals and performs additional processing based on the event data.
 
-To start using Open edX Events in your project, see the `Open edX Events`_ documentation.
-
-.. _Open edX Events: https://docs.openedx.org/projects/openedx-events/en/latest/
+To start using Open edX Events in your project, see the :doc:`Open edX Events <openedx-events:index>` documentation.
 
 Open edX Filters
 ================
 
 Filters are functions that can modify the application's behavior by altering input data or halting execution based on specific conditions. They allow developers to implement application flow control based on their business logic or requirements without directly modifying the application code.
 
-To start using Open edX Filters in your project, see the `Open edX Filters`_ documentation.
-
-.. _Open edX Filters: https://docs.openedx.org/projects/openedx-filters/en/latest/
+To start using Open edX Filters in your project, see the :doc:`Open edX Filters <openedx-filters:index>` documentation.
 
 Differences between Events and Filters
 =======================================
@@ -96,7 +85,7 @@ Here are some key differences between Open edX Events and Filters:
 |                    | triggered.                                                             |  component without directly modifying the application       |
 |                    |                                                                        |  itself.                                                    |
 +--------------------+------------------------------------------------------------------------+-------------------------------------------------------------+
-|  **Definition**    |  Defined using the ``OpenEdxPublicSignal``` class, which               |  Defined using the ``OpenEdxPublicFilter`` class,           |
+|  **Definition**    |  Defined using the ``OpenEdxPublicSignal`` class, which                |  Defined using the ``OpenEdxPublicFilter`` class,           |
 |                    |  provides a structured way to define the data and                      |  which provides a way to define the filter function         |
 |                    |  metadata associated with the event.                                   |  and the parameters it should receive.                      |
 +--------------------+------------------------------------------------------------------------+-------------------------------------------------------------+
@@ -105,10 +94,8 @@ Here are some key differences between Open edX Events and Filters:
 |                    |  within a Django application.                                          |  to the caller or raises exceptions during                  |
 |                    |                                                                        |  processing.                                                |
 +--------------------+------------------------------------------------------------------------+-------------------------------------------------------------+
-| **Use cases**      |  Send an email notification when a user enrolls in a course.           |  Include additional information in an API endpoint response.|
+| **Use cases**      |  Send an email notification when a user enrolls in a course.           |  Prevent the enrollment of non-authorized users.            |
 +--------------------+------------------------------------------------------------------------+-------------------------------------------------------------+
-
-.. _Django signals: https://docs.djangoproject.com/en/4.2/topics/signals/
 
 How to know when to use an Event or a Filter?
 =============================================
@@ -116,38 +103,34 @@ How to know when to use an Event or a Filter?
 When to use an Open edX Event?
 ------------------------------
 
-Use an Open edX Event when but not limited to:
+A developer might use an Open edX Event in order to perform the following actions. Note that this is not an exhaustive list.
 
 - Trigger custom logic or processing in response to specific actions within the platform, e.g., updating a search index after a course block is modified.
 - Communicate, synchronize, or coordinate with other components or services based on specific events or actions, e.g., send certificate data from LMS to credentials service to keep models up to date.
-- Integrate with external systems or services based on specific events or actions within the platform, e.g., send user data to third-party services upon registration for marketing purposes.
+- Integrate with external systems or services based on specific events or actions, e.g., send user data to third-party services upon registration for marketing purposes.
+
+For more detailed use cases, see the :doc:`openedx-filters:references/real-life-use-cases` documentation.
 
 In summary, events can be used to integrate application components with each other or with external services, allowing them to communicate, synchronize, and perform additional actions when specific triggers occur.
 
-You can review the `Open edX Events`_ documentation for more information on `how to use events`_ in your project. This documentation includes a `list of available events`_ and `how to implement event receivers`_.
-
-.. _Open edX Events: https://docs.openedx.org/projects/openedx-events/en/latest/
-.. _how to use events: https://docs.openedx.org/projects/openedx-events/en/latest/how-tos/using-events.html
-.. _list of available events: https://docs.openedx.org/projects/openedx-events/en/latest/reference/events.html
-.. _how to implement event receivers: https://docs.openedx.org/projects/openedx-events/en/latest/how-tos/using-events.html#receiving-events
+You can review the :doc:`Open edX Events <openedx-events:index>` documentation for more information on :doc:`openedx-events:how-tos/using-events` in your project. This documentation includes a list of :doc:`openedx-events:reference/events` and much more.
 
 When to use an Open edX Filter?
 -------------------------------
 
-Use an Open edX Filter when but not limited to:
+A developer might use an Open edX Filter in order to perform the following actions. Note that this is not an exhaustive list.
 
 - Enrich the data or parameters used to a specific component, e.g., fetch reusable LTI configurations from external plugins.
-- Intercept and modify runtime data of a specific component, e.g., include "Edit" link to an HTML block if certain conditions are met.
-- Enforce specific constraints or business rules of a specific component, e.g., prevent enrollment for non-authorized users.
-- Implement additional features or behavior in a specific component, e.g., add custom logic to the user profile update process.
+- Enforce specific constraints or business rules of a specific component, e.g., don't allow registration for non-authorized email domains.
+- Implement additional features or behavior in a specific component, e.g., add registration extra fields to the user registration form.
+
+For more detailed use cases, see the :doc:`openedx-filters:references/real-life-use-cases` documentation.
 
 In summary, filters can be used when implementing application flow control that modifies the application's behavior, navigation, or user interaction flow during runtime.
 
-You can review the `Open edX Filters`_ documentation for more information on `how to use filters`_ in your project or `create new filters`_. This documentation includes a `list of available filters`_ and `how to implement filter pipelines`_.
+You can review the :doc:`Open edX Filters <openedx-filters:index>` documentation for more information on :doc:`openedx-filters:how-tos/using-filters` in your project. This documentation includes a list of :doc:`openedx-filters:reference/filters` and much more.
 
-.. _Open edX Filters: https://docs.openedx.org/projects/openedx-filters/en/latest/
-.. _how to use filters: https://docs.openedx.org/projects/openedx-filters/en/latest/how-tos/using-filters.html
-.. _list of available filters: https://docs.openedx.org/projects/openedx-filters/en/latest/reference/filters.html
-.. _how to implement filter pipelines: https://docs.openedx.org/projects/openedx-filters/en/latest/how-tos/using-filters.html#implement-pipeline-steps
-.. _create new filters: https://docs.openedx.org/projects/openedx-filters/en/latest/how-tos/create-new-filters.html
 .. _Open edX Django plugins: https://edx.readthedocs.io/projects/edx-django-utils/en/latest/plugins/readme.html
+.. _openedx-filters: https://github.com/openedx/openedx-filters
+.. _openedx-events: https://github.com/openedx/openedx-events
+.. _Django signals: https://docs.djangoproject.com/en/4.2/topics/signals/

--- a/source/developers/concepts/hooks_extension_framework.rst
+++ b/source/developers/concepts/hooks_extension_framework.rst
@@ -1,0 +1,148 @@
+=========================
+Hooks Extension Framework
+=========================
+
+What is the Hooks Extension Framework?
+=======================================
+
+Based on the `open-closed principle`_, this framework aims to extend the Open edX platform in a maintainable way without modifying its core. The main goal is to leverage the existing extension capabilities provided by the plugin architecture, allowing developers to implement new features to fit customer needs while reducing the need for core modifications and minimizing maintenance efforts.
+
+Hooks are a list of places in the Open edX platform where externally defined functions can take place. These functions may alter what the user sees or experiences on the platform, while in other cases, they act as notifications. All hooks are designed to be extended through Open edX plugins and configurations.
+
+Hooks can be of two types: events and filters. Events are signals sent in specific places whose receivers can extend functionality, while filters are functions that can modify the application's behavior.
+
+To allow extension developers to use the framework's definitions in their implementations, both kinds of hooks are defined in lightweight external libraries:
+
+* `openedx-filters`_
+* `openedx-events`_
+
+The main goal of the framework is that developers can use it to change the platform's functionality as needed and still migrate to newer Open edX releases with little to no development effort. So, the framework is designed with stability in mind, meaning it is versioned and backward compatible as much as possible.
+
+A longer description of the framework and its history can be found in `OEP 50`_.
+
+.. _OEP 50: https://open-edx-proposals.readthedocs.io/en/latest/oep-0050-hooks-extension-framework.html
+.. _openedx-filters: https://github.com/eduNEXT/openedx-filters
+.. _openedx-events: https://github.com/eduNEXT/openedx-events
+.. _open-closed principle: https://docs.openedx.org/projects/edx-platform/en/open-release-quince.master/concepts/extension_points.html
+
+Why adopt the Hooks Extension Framework?
+========================================
+
+1. Stable and Maintainable Extensions
+
+The Hooks Extension Framework allows developers to extend the platform's functionality in a stable, maintainable, and decoupled way ensuring easier upgrades and long-term stability by removing the need to modify the core in an significant way.
+
+2. Contained Solution Implementation
+
+By avoiding core modifications, the framework promotes self-contained solutions, eliminating the need  for custom code to coexist with core logic which lowers maintenance costs for extension developers.
+
+3. Leveraging the Open edX Plugin Extension Mechanism
+
+The framework allows developers to implement custom business logic and integrations directly in plugins. This keeps core modifications minimal, focusing maintenance and development efforts on plugins, where solutions can be built and maintained independently of the core platform.
+
+4. Standardization
+
+Both filters and events implementations implement an approach for adding additional features, such as communication between services or backend flow control. With these standards in place, it’s easy to identify when and how to use the framework as a solution, ensuring a consistent and predictable approach to extending the platform.
+
+5. Reduce Fork Modifications
+
+The need to modify logic in forks is minimized, as most extensions can now be implementing using the framework, keeping forks closer to the core and easier to manage.
+
+6. Community Compatibility
+
+The framework allows for shorter and more agile contribution cycles. By adding standardized extension points, contributors avoid creating customer-specific logic, making development more community-friendly.
+
+7. Backward Compatibility
+
+Hooks are designed to be backward compatible, guaranteeing stability across releases and making it easier to upgrade without breaking existing functionality.
+
+Open edX Events and Filters
+============================
+
+Open edX Events
+----------------
+
+Events are Open edX-specific Django signals sent in specific places on the Open edX platform. They allow developers to listen to these signals and perform additional processing based on the event data.
+
+To start using Open edX Events in your project, see the `Open edX Events`_ documentation.
+
+.. _Open edX Events: https://docs.openedx.org/projects/openedx-events/en/latest/
+
+Open edX Filters
+-----------------
+
+Filters are functions that can modify the application's behavior by altering input data or halting execution based on specific conditions. They allow developers to implement application flow control based on their business logic or requirements without directly modifying the application code.
+
+To start using Open edX Filters in your project, see the `Open edX Filters`_ documentation.
+
+.. _Open edX Filters: https://docs.openedx.org/projects/openedx-filters/en/latest/
+
+Differences between Events and Filters
+---------------------------------------
+
+Here are some key differences between Open edX Events and Filters:
+
++--------------------+------------------------------------------------------------------------+-------------------------------------------------------------+
+|                    | Events                                                                 | Filters                                                     |
++====================+========================================================================+=============================================================+
+| **Purpose**        | Notify when an action occurs in a specific part of the                 | Alter the application flow control.                         |
+|                    | application.                                                           |                                                             |
++--------------------+------------------------------------------------------------------------+-------------------------------------------------------------+
+|  **Usage**         | Used to **extend** functionality via signal handlers when an event is  |  Used to intercept and **modify** the data used within a    |
+|                    | triggered.                                                             |  component without directly modifying the application       |
+|                    |                                                                        |  itself.                                                    |
++--------------------+------------------------------------------------------------------------+-------------------------------------------------------------+
+|  **Definition**    |  Defined using the `OpenEdxPublicSignal` class, which                  |  Defined using the ``OpenEdxPublicFilter`` class,           |
+|                    |  provides a structured way to define the data and                      |  which provides a way to define the filter function         |
+|                    |  metadata associated with the event.                                   |  and the parameters it should receive.                      |
++--------------------+------------------------------------------------------------------------+-------------------------------------------------------------+
+| **Implementation** |  Implemented using `Django signals`_, which allow                      |  Implemented using an accumulative pipeline mechanism which |
+|                    |  developers to send and receive notifications that an action happened  |  takes a set of arguments and returns a modified set        |
+|                    |  within a Django application.                                          |  to the caller or raises exceptions during                  |
+|                    |                                                                        |  processing.                                                |
++--------------------+------------------------------------------------------------------------+-------------------------------------------------------------+
+| **Use cases**      |  Send an email notification when a user enrolls in a course.           |  Include additional information in an API endpoint response.|
+|                    |  an email notification.                                                |                                                             |
++--------------------+------------------------------------------------------------------------+-------------------------------------------------------------+
+
+.. _Django signals: https://docs.djangoproject.com/en/4.2/topics/signals/
+
+How to know when to use an Event or a Filter?
+----------------------------------------------
+
+When to use an Open edX Event?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use an Open edX Event when you need to:
+
+- Trigger custom logic or processing in response to specific actions within the platform, e.g., updating a search index after a course block is modified.
+- Communicate, synchronize, or coordinate with other components or services based on specific events or actions, e.g., send certificate data from LMS to credentials service to keep models up to date.
+- Integrate with external systems or services based on specific events or actions within the platform, e.g., send user data to third-party services upon registration for marketing purposes.
+
+In summary, events can be used to integrate application components with each other or with external services, allowing them to communicate, synchronize, and perform additional actions when specific triggers occur.
+
+You can review the `Open edX Events`_ documentation for more information on `how to use events`_ in your project. This documentation includes a `list of available events`_ and `how to implement event receivers`_.
+
+.. _Open edX Events: https://docs.openedx.org/projects/openedx-events/en/latest/
+.. _how to use events: https://docs.openedx.org/projects/openedx-events/en/latest/how-tos/using-events.html
+.. _list of available events: https://docs.openedx.org/projects/openedx-events/en/latest/reference/events.html
+.. _how to implement event receivers: https://docs.openedx.org/projects/openedx-events/en/latest/how-tos/using-events.html#receiving-events
+
+When to use an Open edX Filter?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use an Open edX Filter when:
+
+- Enrich the data or parameters passed to a specific component, e.g., fetch reusable LTI configurations from external plugins.
+- Intercept and modify the input of a specific component, e.g., include "Edit" link to an HTML block if certain conditions are met.
+- Enforce specific constraints or business rules on the input or output of a specific function or method, e.g., prevent enrollment for non-authorized users.
+
+In summary, filters can be used when implementing application flow control that modifies the application's behavior, navigation, or user interaction flow during runtime.
+
+You can review the `Open edX Filters`_ documentation for more information on `how to use filters`_ in your project or `create new filters`_. This documentation includes a `list of available filters`_ and `how to implement filter pipelines`_.
+
+.. _Open edX Filters: https://docs.openedx.org/projects/openedx-filters/en/latest/
+.. _how to use filters: https://docs.openedx.org/projects/openedx-filters/en/latest/how-tos/using-filters.html
+.. _list of available filters: https://docs.openedx.org/projects/openedx-filters/en/latest/reference/filters.html
+.. _how to implement filter pipelines: https://docs.openedx.org/projects/openedx-filters/en/latest/how-tos/using-filters.html#implement-pipeline-steps
+.. _create new filters: https://docs.openedx.org/projects/openedx-filters/en/latest/how-tos/create-new-filters.html

--- a/source/developers/concepts/hooks_extension_framework.rst
+++ b/source/developers/concepts/hooks_extension_framework.rst
@@ -4,7 +4,7 @@ Hooks Extension Framework
 What is the Hooks Extension Framework?
 **************************************
 
-Based on the :doc:`edx-platform:concepts/extension_points`, this framework aims to extend the Open edX platform in a maintainable way without modifying its core. The main goal is to leverage the existing extension capabilities provided by the `Open edX Django plugins`_ architecture, allowing developers to implement new features to fit customer needs while reducing the need for core modifications and minimizing maintenance efforts.
+Based on the :doc:`edx-platform:concepts/extension_points`, this framework aims to extend the Open edX platform in a maintainable way without modifying its core. The main goal is to leverage the existing extension capabilities provided by the `Open edX Django plugins`_ architecture, allowing developers to implement new features while reducing the need for core modifications and minimizing maintenance efforts.
 
 Hooks are places in the Open edX platform where externally defined functions can take place. These functions may alter what the user sees or experiences on the platform, while in other cases, they are informative only. All hooks are designed to be used along with `Open edX Django plugins`_.
 

--- a/source/developers/concepts/hooks_extension_framework.rst
+++ b/source/developers/concepts/hooks_extension_framework.rst
@@ -109,7 +109,7 @@ A developer might use an Open edX Event in order to perform the following action
 - Communicate, synchronize, or coordinate with other components or services based on specific events or actions, e.g., send certificate data from LMS to credentials service to keep models up to date.
 - Integrate with external systems or services based on specific events or actions, e.g., send user data to third-party services upon registration for marketing purposes.
 
-For more detailed use cases, see the :doc:`openedx-filters:references/real-life-use-cases` documentation.
+.. For more detailed use cases, see the TODO: ADD REFERENCE TO REAL LIFE USE CASES documentation.
 
 In summary, events can be used to integrate application components with each other or with external services, allowing them to communicate, synchronize, and perform additional actions when specific triggers occur.
 
@@ -124,7 +124,7 @@ A developer might use an Open edX Filter in order to perform the following actio
 - Enforce specific constraints or business rules of a specific component, e.g., don't allow registration for non-authorized email domains.
 - Implement additional features or behavior in a specific component, e.g., add registration extra fields to the user registration form.
 
-For more detailed use cases, see the :doc:`openedx-filters:references/real-life-use-cases` documentation.
+.. For more detailed use cases, see the TODO: ADD REFERENCE TO REAL LIFE USE CASES documentation.
 
 In summary, filters can be used when implementing application flow control that modifies the application's behavior, navigation, or user interaction flow during runtime.
 

--- a/source/developers/index.rst
+++ b/source/developers/index.rst
@@ -24,7 +24,7 @@ Open edX Developers
 
       * :doc:`references/running_pr_tests`
       * :doc:`references/internal_data_formats/index`
-      * :doc: `contents/hooks_extension_framework`
+      * :doc: `concepts/hooks_extension_framework`
 
    .. grid-item-card:: How-tos
       :class-card: sd-shadow-md sd-p-2
@@ -47,7 +47,7 @@ Open edX Developers
       * :doc:`concepts/platform_overview`
       * :doc:`concepts/backend_layout_and_approach`
       * :doc:`concepts/accessibility`
-      * :doc: `contents/hooks_extension_framework`
+      * :doc: `concepts/hooks_extension_framework`
       +++
       .. button-ref:: concepts/index
          :color: primary

--- a/source/developers/index.rst
+++ b/source/developers/index.rst
@@ -24,7 +24,7 @@ Open edX Developers
 
       * :doc:`references/running_pr_tests`
       * :doc:`references/internal_data_formats/index`
-      * :doc: `concepts/hooks_extension_framework`
+      * :doc:`concepts/hooks_extension_framework`
 
    .. grid-item-card:: How-tos
       :class-card: sd-shadow-md sd-p-2
@@ -47,7 +47,7 @@ Open edX Developers
       * :doc:`concepts/platform_overview`
       * :doc:`concepts/backend_layout_and_approach`
       * :doc:`concepts/accessibility`
-      * :doc: `concepts/hooks_extension_framework`
+      * :doc:`concepts/hooks_extension_framework`
       +++
       .. button-ref:: concepts/index
          :color: primary

--- a/source/developers/index.rst
+++ b/source/developers/index.rst
@@ -24,6 +24,7 @@ Open edX Developers
 
       * :doc:`references/running_pr_tests`
       * :doc:`references/internal_data_formats/index`
+      * :doc: `contents/hooks_extension_framework`
 
    .. grid-item-card:: How-tos
       :class-card: sd-shadow-md sd-p-2
@@ -46,6 +47,7 @@ Open edX Developers
       * :doc:`concepts/platform_overview`
       * :doc:`concepts/backend_layout_and_approach`
       * :doc:`concepts/accessibility`
+      * :doc: `contents/hooks_extension_framework`
       +++
       .. button-ref:: concepts/index
          :color: primary


### PR DESCRIPTION
## Description

This PR adds documentation about the Hooks Extension Framework under the developers section to centralize common concepts between Open edX Events and filters, such as framework overview, differences, comparisons, etc.

You can see the docs rendered here: https://docsopenedxorg--599.org.readthedocs.build/en/599/developers/concepts/index.html

The documentation in https://github.com/openedx/edx-platform/tree/master/docs/hooks should be removed after this gets merged. What this docs is missing from edx-platform guides, it's the index of filters and events within edx-platform:

https://github.com/openedx/edx-platform/blob/master/docs/hooks/filters.rst#index-of-filters
https://github.com/openedx/edx-platform/blob/master/docs/hooks/events.rst#index-of-events

This PR will not replace those indexes since they need extra effort to keep up to date, making the contribution process more cumbersome since we will need to update them here each time a new event/filter is added to a service. I prefer enhancing the current list of events and filters in each repo to reference in some way where they're being used instead.