### PR TITLE
Fix/Add links to Aspects Course Comparison Dashboard Release Notes

### DIFF
--- a/source/community/release_notes/sumac/aspects_comp_dashboard.rst
+++ b/source/community/release_notes/sumac/aspects_comp_dashboard.rst
@@ -3,7 +3,7 @@ Aspects Course Comparison Dashboard
 
 The Product and Engineering Teams from eduNEXT and Axim Collaborative are excited to introduce the `Aspects Course Comparison Dashboards </en/latest/documentors/references/quick_reference_rst.html>`_ for course administrators! We’ve also made improvements to existing course-level dashboards to make them easier to use. 
 
-Operators can learn more about enabling or updating Aspects on their installations by reviewing the Operator Release Notes.
+Operators can learn more about enabling or updating Aspects on their installations by reviewing the `Operator Release Notes </en/latest/community/release_notes/sumac/dev_op_release_notes.html#researcher-data-experiences>`_.
 
 Compare courses and course runs with Aspects
 ********************************************

--- a/source/community/release_notes/sumac/aspects_comp_dashboard.rst
+++ b/source/community/release_notes/sumac/aspects_comp_dashboard.rst
@@ -1,7 +1,7 @@
 Aspects Course Comparison Dashboard
 ###################################
 
-The Product and Engineering Teams from eduNEXT and Axim Collaborative are excited to introduce the `Aspects Course Comparison Dashboards </en/latest/documentors/references/quick_reference_rst.html>`_ for course administrators! We’ve also made improvements to existing course-level dashboards to make them easier to use. 
+The Product and Engineering Teams from eduNEXT and Axim Collaborative are excited to introduce the `Aspects Course Comparison Dashboards </projects/openedx-aspects/en/latest/reference/course_comparison_dashboard.html>`_ for course administrators! We’ve also made improvements to existing course-level dashboards to make them easier to use. 
 
 Operators can learn more about enabling or updating Aspects on their installations by reviewing the `Operator Release Notes </en/latest/community/release_notes/sumac/dev_op_release_notes.html#researcher-data-experiences>`_.
 


### PR DESCRIPTION
Update Aspects Product Release Notes by: fixing an existing link and adding a link to Operator Release Notes