### PR TITLE
FC-0068: Reference cleaning by edunext #4

### DIFF
--- a/source/educators/how-tos/advanced_features/lti_blackboard_example.rst
+++ b/source/educators/how-tos/advanced_features/lti_blackboard_example.rst
@@ -1,17 +1,13 @@
-.. _edX as an LTI Provider to Blackboard:
+.. _Open edX as an LTI Provider to Blackboard:
 
-###############################################
-Example: edX as an LTI Provider to Blackboard
-###############################################
+Example: Open edX Platform as an LTI Provider to Blackboard
+###########################################################
 
-.. tags:: educator, reference
+.. tags:: educator, how-to
 
-.. only:: Partners
+.. warning:: This feature was a closed pilot experiment. This feature is poorly documented and may not work properly.
 
-.. note:: This feature was a closed pilot experiment. This feature is not
- supported for new users.
-
-To use edX course content in the Blackboard LMS, you add a new app to the course and then add external tool module items.
+To use Open edX course content in the Blackboard LMS, you add a new app to the course and then add external tool module items.
 
 .. note:: This example relies on the use of a third-party tool. Because this
   tool is subject to change by its owner, the steps and illustrations provided
@@ -32,8 +28,8 @@ To use edX course content in the Blackboard LMS, you add a new app to the course
 #. On the **Create Web Link** page, enter an identifying name and the URL for
    the edX content you want to include.
 
-   The **URL** is the LTI URL that you determined for the edX course content,
-   such as ``https://edx-lti.org/lti_provider/courses/course-v1:edX+DemoX+2014/block-1:edX+DemoX+Demo_Course+type@problem+block@d2e35c1d294b4ba0b3b1048615605d2a``.
+   The **URL** is the LTI URL that you determined for the course content.
+   
 
    .. image:: /_images/educator_references/lti_blackboard_create_link.png
      :alt: The Blackboard Create Web Link page with example name and URL
@@ -44,7 +40,7 @@ To use edX course content in the Blackboard LMS, you add a new app to the course
 #. Review the content to verify that it appears as you expect.
 
    .. image:: /_images/educator_references/lti_blackboard_example.png
-     :alt: An edX drag and drop problem shown as part of a course running on a
+     :alt: An Open edX drag and drop problem shown as part of a course running on a
       Blackboard system.
 
 .. seealso::

--- a/source/educators/how-tos/advanced_features/lti_canvas_example.rst
+++ b/source/educators/how-tos/advanced_features/lti_canvas_example.rst
@@ -1,15 +1,13 @@
-.. _edX as an LTI Provider to Canvas:
+.. _Open edX as an LTI Provider to Canvas:
 
-##########################################
-Example: edX as an LTI Provider to Canvas
-##########################################
+Example: Open edX Platform as an LTI Provider to Canvas
+#######################################################
 
-.. tags:: educator, reference
+.. tags:: educator, how-to
 
-.. note:: This feature was a closed pilot experiment. This feature is not
- supported for new users.
+.. warning:: This feature was a closed pilot experiment. This feature is poorly documented and may not work properly.
 
-To use edX course content in the Canvas LMS, you add a new app to the course and then add external tool module items.
+To use Open edX course content in the Canvas LMS, you add a new app to the course and then add external tool module items.
 
 .. note:: This example relies on the use of a third-party tool. Because this
   tool is subject to change by its owner, the steps and illustrations provided
@@ -22,8 +20,7 @@ To use edX course content in the Canvas LMS, you add a new app to the course and
          site as a LTI tool provider.
 
 #. In **Modules**, add a new **External Tool** item. The **URL** is the LTI
-   URL that you determined for the edX course content, such as
-   ``https://edx-lti.org/lti_provider/courses/course-v1:edX+DemoX+2014/block-v1:edX+DemoX+Demo_Course+type@problem+block@d2e35c1d294b4ba0b3b1048615605d2a``.
+   URL that you determined for the your course content.
 
    .. image:: /_images/educator_references/lti_edit_problem_Canvas.png
      :alt: The Canvas page where you add an external tool and supply the LTI
@@ -34,7 +31,7 @@ To use edX course content in the Canvas LMS, you add a new app to the course and
 #. Review the content to verify that it appears as you expect.
 
    .. image:: /_images/educator_references/lti_canvas_example2.png
-     :alt: An edX drag and drop problem shown as part of a course running on a
+     :alt: An Open edX drag and drop problem shown as part of a course running on a
       Canvas system.
 
 .. seealso::
@@ -48,4 +45,4 @@ To use edX course content in the Canvas LMS, you add a new app to the course and
 
  :ref:`Planning for Content Reuse (LTI)<Planning for Content Reuse>` (reference)
 
- :ref:`Example: edX as an LTI Provider to Blackboard<edX as an LTI Provider to Blackboard>` (reference)
+ :ref:`Example: edX as an LTI Provider to Blackboard<edX as an LTI Provider to Blackboard>` (how-to)

--- a/source/educators/navigation/advanced_features.rst
+++ b/source/educators/navigation/advanced_features.rst
@@ -68,8 +68,8 @@ Use Open edX as an LTI Tool Provider
    ../references/advanced_features/planning_content_reuse.rst
    ../how-tos/advanced_features/lti_prepare_content.rst
    ../how-tos/advanced_features/lti_determine_content_address.rst
-   ../references/advanced_features/lti_canvas_example.rst
-   ../references/advanced_features/lti_blackboard_example.rst  
+   ../how-tos/advanced_features/lti_canvas_example.rst
+   ../how-tos/advanced_features/lti_blackboard_example.rst  
 
 Course Tags and Taxonomies
 *******************************************************

--- a/source/educators/references/course_development/Section_adding_tooltip.rst
+++ b/source/educators/references/course_development/Section_adding_tooltip.rst
@@ -16,7 +16,7 @@ a definition for "ROI" is being shown.
  :width: 500
 
 .. note::
-  For learners using screen reader, the tooltip expands to make its
+  For learners using a screen reader, the tooltip expands to make its
   associated text accessible when the screen reader focuses on the tooltip
   icon.
 

--- a/source/educators/references/course_development/Section_adding_tooltip.rst
+++ b/source/educators/references/course_development/Section_adding_tooltip.rst
@@ -1,13 +1,11 @@
 .. _Adding Tooltips:
 
-==============================
 Adding Tooltips to a Problem
-==============================
+############################
 
 .. tags:: educator, reference
 
-To help learners understand terminology or other aspects of a problem, you can
-add inline tooltips. Tooltips show text to learners when they move their
+You can add inline tooltips to help learners understand terminology or other aspects of a problem. Tooltips display text to learners when they move their
 cursors over a tooltip icon.
 
 The following example problem includes two tooltips. The tooltip that provides
@@ -18,7 +16,7 @@ a definition for "ROI" is being shown.
  :width: 500
 
 .. note::
-  For learners using a screen reader, the tooltip expands to make its
+  For learners using screen reader, the tooltip expands to make its
   associated text accessible when the screen reader focuses on the tooltip
   icon.
 
@@ -36,3 +34,10 @@ tooltips.
             Investment</clarification> over 20 years.
           </p>
        . . .
+
+.. seealso::
+ :class: dropdown
+
+ :ref:`Adding Feedback and Hints to a Problem` (reference)
+
+ :ref:`Accessibility Best Practices for Course Content Development` (concept)

--- a/source/educators/references/course_development/Section_partial_credit.rst
+++ b/source/educators/references/course_development/Section_partial_credit.rst
@@ -6,7 +6,7 @@ Awarding Partial Credit for a Problem
 .. tags:: educator, reference
 
 You can configure the following problem types so that learners can receive
-partial credit for a problem if they submit a partly correct answer.
+partial credit for a problem if they submit a partially correct answer.
 
 * :ref:`Single Select <Awarding Partial Credit in a Multiple Choice Problem>`
 * :ref:`Multi-select <Awarding Partial Credit in a Multi select Problem>`

--- a/source/educators/references/course_development/Section_partial_credit.rst
+++ b/source/educators/references/course_development/Section_partial_credit.rst
@@ -6,15 +6,15 @@ Awarding Partial Credit for a Problem
 .. tags:: educator, reference
 
 You can configure the following problem types so that learners can receive
-partial credit for a problem if they submit an answer that is partly correct.
+partial credit for a problem if they submit a partly correct answer.
 
 * :ref:`Single Select <Awarding Partial Credit in a Multiple Choice Problem>`
-* :ref:`Multi-select <Awarding Partial Credit in a Multi select Problem:>`
+* :ref:`Multi-select <Awarding Partial Credit in a Multi select Problem>`
 * :ref:`Numerical Input <Awarding Partial Credit in a Numerical Input Problem>`
 * :ref:`Custom Python-evaluated Input Problem (Write-Your-Own Grader) <Award Half Credit>`
 
 By awarding partial credit for problems, you can motivate learners who have
-mastered some of the course content and provide a score that accurately
+mastered some of the course content and provided a score that accurately
 demonstrates their progress.
 
 For more information about configuring partial credit, see the topic for each
@@ -27,8 +27,8 @@ How Learners Receive Partial Credit
 Learners receive partial credit when they submit an answer in the LMS.
 
 In the following example, the course team configured a single select problem
-to award 25% of the possible points (instead of 0 points) for one of the
-incorrect answer options. The learner selected this incorrect option, and
+to award 25% of the possible points (instead of 0) for one of the
+incorrect answer options. The learner selected this incorrect option and
 received 25% of the possible points.
 
 .. image:: /_images/educator_references/partial_credit_multiple_choice.png
@@ -42,7 +42,7 @@ Partial Credit and Reporting on Learner Performance
 ***************************************************
 
 When a learner receives partial credit for a problem, the LMS only adds the
-points that the learner earned to the grade. However, the LMS reports any
+points earned to the grade. However, the LMS reports any
 problem for which a learner receives credit, in full or in part, as correct in
 the following ways.
 
@@ -57,7 +57,7 @@ the following ways.
 
 Course teams can see that a learner received partial credit for a problem in
 the learner's submission history. The submission history shows the score that
-the learner received out of the total available score, and the value in the
+the learner received out of the total available score and the value in the
 ``correctness`` field is ``partially-correct``.  For more information, see
 :ref:`Student_Answer_Submission`.
 
@@ -69,4 +69,4 @@ the learner received out of the total available score, and the value in the
 
  :ref:`Awarding Partial Credit in a Numerical Input Problem` (how-to)
 
- :ref:`Award Partial Credit for a Custom Python-Evaluated Input Problem <Award Partial Credit>` (how-to)
+ :ref:`Award Partial Credit` (how-to)

--- a/source/educators/references/course_development/Section_partial_credit.rst
+++ b/source/educators/references/course_development/Section_partial_credit.rst
@@ -1,8 +1,7 @@
 .. _Partial Credit:
 
-==========================================
 Awarding Partial Credit for a Problem
-==========================================
+#####################################
 
 .. tags:: educator, reference
 
@@ -10,7 +9,7 @@ You can configure the following problem types so that learners can receive
 partial credit for a problem if they submit an answer that is partly correct.
 
 * :ref:`Single Select <Awarding Partial Credit in a Multiple Choice Problem>`
-* :ref:`Multi-select <Awarding Partial Credit in a Multi-select Problem>`
+* :ref:`Multi-select <Awarding Partial Credit in a Multi select Problem:>`
 * :ref:`Numerical Input <Awarding Partial Credit in a Numerical Input Problem>`
 * :ref:`Custom Python-evaluated Input Problem (Write-Your-Own Grader) <Award Half Credit>`
 
@@ -21,9 +20,9 @@ demonstrates their progress.
 For more information about configuring partial credit, see the topic for each
 problem type.
 
-------------------------------------------
+
 How Learners Receive Partial Credit
-------------------------------------------
+************************************
 
 Learners receive partial credit when they submit an answer in the LMS.
 
@@ -38,9 +37,9 @@ received 25% of the possible points.
  :width: 500
 
 
------------------------------------------------------
+
 Partial Credit and Reporting on Learner Performance
------------------------------------------------------
+***************************************************
 
 When a learner receives partial credit for a problem, the LMS only adds the
 points that the learner earned to the grade. However, the LMS reports any
@@ -61,3 +60,13 @@ the learner's submission history. The submission history shows the score that
 the learner received out of the total available score, and the value in the
 ``correctness`` field is ``partially-correct``.  For more information, see
 :ref:`Student_Answer_Submission`.
+
+.. seealso::
+
+ :ref:`Awarding Partial Credit in a Multiple Choice Problem` (how-to)
+ 
+ :ref:`Awarding Partial Credit in a Multi select Problem` (how-to)
+
+ :ref:`Awarding Partial Credit in a Numerical Input Problem` (how-to)
+
+ :ref:`Award Partial Credit for a Custom Python-Evaluated Input Problem <Award Partial Credit>` (how-to)

--- a/source/educators/references/course_development/advanced_problem_editor.rst
+++ b/source/educators/references/course_development/advanced_problem_editor.rst
@@ -1,14 +1,14 @@
 .. _Advanced Editor:
 
-***************************************************
+
 The Advanced Editor
-***************************************************
+####################
 
 .. tags:: educator, reference
 
 If the simple editor cannot fulfill your needs, you might turn your attention
 to the Advanced Editor. This editor will allow you to directly edit the open
-learning XML (OLX) of your problem. The Advanced Editor can be accessed one of
+learning XML (OLX) of your problem. The Advanced Editor can be accessed in one of
 two ways.
 
 If you are creating a new problem, on the **Select problem type** screen,
@@ -28,7 +28,7 @@ While the other settings are not shown on the collapsible panes to the right of
 the problem editor, they can be added via editing the OLX.
 
 OLX specifications can be found under each problem type in
-:ref:`Exercises and Tools Index`.
+:ref:`Components and Activities TOC`.
 
 .. note::
    If you have turned your problem into an advanced problem, it is possible to
@@ -43,8 +43,7 @@ Advanced Editor Features
 ***************************************************
 
 Since the Advanced Editor allows you to edit the problem directly using the OLX,
-there are many more ways to write a problem. Below are several features the
-Advanced Editor is capable of:
+there are many more ways to write a problem. Below are several features that the Advanced Editor is capable of:
 
 .. contents::
  :local:
@@ -64,7 +63,7 @@ Randomization
    versions to different learners. For more information, see
    :ref:`Problem Randomization`.
 
-This setting can be found on the collapsible settings to the right of the
+This setting can be found in the collapsible settings to the right of the
 problem editor. For problems that include a Python script to generate numbers
 randomly, this setting specifies how frequently the values in the problem
 change: each time a different learner accesses the problem, each time a single
@@ -82,7 +81,7 @@ learner submits an answer to the problem.
    values that change.
  :width: 800
 
-If you want to randomize numeric values in a problem, you complete both of
+If you want to randomize numeric values in a problem, you must complete both of
 these steps.
 
 * Make sure that you edit your problem to include a Python script that randomly
@@ -90,7 +89,7 @@ these steps.
 
 * Select an option other than **Never** for the **Randomization** setting.
 
-The edX Platform has a 20-seed maximum for randomization. This means that
+The Open edX Platform has a 20-seed maximum for randomization. This means that
 learners see up to 20 different problem variants for every problem that has
 **Randomization** set to an option other than **Never**. It also means that
 every answer for the 20 different variants is reported by the Answer
@@ -181,7 +180,7 @@ all of the other required elements for each question.
 * You can provide a different explanation for each question with the
   OLX ``<solution>`` element.
 
-As a best practice, edX recommends that you avoid including unformatted
+As a best practice, avoid including unformatted
 paragraph text between the questions. Screen readers can skip over text that is
 inserted among multiple questions.
 
@@ -227,13 +226,6 @@ numerical input question follows.
     </numericalresponse>
   </problem>
 
-.. seealso::
- :class: dropdown
-
- :ref:`Partial Credit` (reference)
-
- :ref:`Adding Tooltips` (reference)
-
 
 .. _Problem Randomization:
 
@@ -277,3 +269,4 @@ course's XML files is no longer supported.
  :ref:`Partial Credit` (reference)
 
  :ref:`Adding Tooltips` (reference)
+

--- a/source/educators/references/course_development/exercise_tools/Section_adding_hints.rst
+++ b/source/educators/references/course_development/exercise_tools/Section_adding_hints.rst
@@ -1,8 +1,7 @@
 .. _Adding Feedback and Hints to a Problem:
 
-=======================================
 Adding Feedback and Hints to a Problem
-=======================================
+######################################
 
 .. tags:: educator, reference
 
@@ -11,9 +10,8 @@ You can add feedback, hints, or both to the simple problem types.
 By using hints and feedback, you can provide learners with guidance and help as
 they work on problems.
 
-------------------------------------------
 Feedback in Response to Attempted Answers
-------------------------------------------
+*****************************************
 
 You can add feedback that displays to learners after they submit an answer.
 
@@ -25,9 +23,9 @@ case, feedback is given for an incorrect answer.
  :alt: Image of a single select problem with feedback.
  :width: 600
 
-------------------------------------------
+
 Best Practices for Providing Feedback
-------------------------------------------
+**************************************
 
 The immediacy of the feedback available to learners is a key advantage of
 online instruction and difficult to do in a traditional classroom environment.
@@ -46,9 +44,9 @@ answer is correct. Especially in questions where learners are able to guess,
 such as single select and dropdown problems, the feedback should provide a
 reason why the selection is correct.
 
-------------------------------------------
+
 Providing Hints for Problems
-------------------------------------------
+*****************************
 
 You can add one or more hints that are displayed to learners. When you add
 hints, the **Hint** button is automatically displayed to learners. Learners can
@@ -56,7 +54,7 @@ access the hints by selecting **Hint** beneath the problem.  A learner can view
 multiple hints by selecting **Hint** multiple times.
 
 For example, in the following single select problem, the learner selects
-**Hint** after having made one incorrect attempt.
+**Hint** after an incorrect attempt.
 
 .. image:: /_images/educator_references/multiple_choice_hint.png
  :alt: Image of a single select problem with the first hint.
@@ -70,9 +68,8 @@ been used, the **Hint** or **Next Hint** option is no longer available.
  :alt: Image of a single select problem with the second hint.
  :width: 600
 
-------------------------------------------
 Best Practices for Providing Hints
-------------------------------------------
+**********************************
 
 To ensure that your hints can assist learners with varying backgrounds and
 levels of understanding, you should provide multiple hints with different
@@ -86,9 +83,9 @@ The second hint can then take the learner further towards the answer.
 In problems that are not graded, the third and final hint can explain the
 solution for learners who are still confused.
 
-------------------------------------------
+
 Create Problems with Feedback and Hints
-------------------------------------------
+***************************************
 
 While editing a problem block, you can apply **Answer-specific feedback**
 for all problem types. **Group feedback** can only be applied to
@@ -96,9 +93,9 @@ for all problem types. **Group feedback** can only be applied to
 
 Any number of **hints** can be added for all simple problem types.
 
-------------------------------------------
+
 Adding Answer-specific Feedback
-------------------------------------------
+*********************************
 
 **Answer-specific feedback** can be added under each answer by pressing
 the feedback icon to the right of the answer text. Feedback entered in
@@ -113,9 +110,9 @@ learner does not select that answer.
    The “is not selected” feedback field shown above is only available
    for the **multi-select** problem type.
 
-------------------------------------------------
+
 Adding Group Feedback for Multi-Select Problems
-------------------------------------------------
+************************************************
 
 This setting can be found on the collapsible settings to the right of
 the problem editor. Feedback entered in this field will display if and
@@ -128,9 +125,8 @@ the **multi-select** problem type.
  :alt: Image of the group feedback settings.
  :width: 300
 
-------------------------------------------
 Adding Hints
-------------------------------------------
+**************
 
 This setting can be found on the collapsible settings to the right of
 the problem editor. Click the **Add hint** button to add additional
@@ -140,3 +136,11 @@ hints for learners.
  :alt: Image of the hints settings.
  :width: 300
 
+.. seealso::
+ :class: dropdown
+
+ :ref:`Adding Hints via the Advanced Editor` (how-to)
+ 
+ :ref:`Use Hints in a Dropdown Problem` (how-to)
+
+ :ref:`Defining Settings for Problem Components` (reference)

--- a/source/educators/references/course_development/exercise_tools/Section_adding_hints.rst
+++ b/source/educators/references/course_development/exercise_tools/Section_adding_hints.rst
@@ -54,7 +54,7 @@ access the hints by selecting **Hint** beneath the problem.  A learner can view
 multiple hints by selecting **Hint** multiple times.
 
 For example, in the following single select problem, the learner selects
-**Hint** after an incorrect attempt.
+**Hint** after having made an incorrect attempt.
 
 .. image:: /_images/educator_references/multiple_choice_hint.png
  :alt: Image of a single select problem with the first hint.

--- a/source/educators/references/course_development/exercise_tools/Section_adding_hints.rst
+++ b/source/educators/references/course_development/exercise_tools/Section_adding_hints.rst
@@ -143,4 +143,4 @@ hints for learners.
  
  :ref:`Use Hints in a Dropdown Problem` (how-to)
 
- :ref:`Defining Settings for Problem Components` (reference)
+ :ref:`Problem Settings` (reference)

--- a/source/educators/references/course_development/exercise_tools/drag_and_drop.rst
+++ b/source/educators/references/course_development/exercise_tools/drag_and_drop.rst
@@ -2,9 +2,8 @@
 
 .. _drag_and_drop_background_images:
 
-===============================
 Understanding Background Images
-===============================
+###############################
 
 .. tags:: educator, reference
 
@@ -33,7 +32,7 @@ between the top of the background image and the top of the target zone.
 
 The following image shows a background image and target zones in the drag and
 drop problem editing dialog box. For more information about editing drag and
-drop problems, see :ref:`creating_a_drag_and_drop_problem`.
+drop problems, see :ref:`Creating a Drag and Drop Problem`.
 
 .. image:: /_images/educator_references/dnd-zone-borders.png
   :width: 600
@@ -48,9 +47,8 @@ drop problems, see :ref:`creating_a_drag_and_drop_problem`.
 
 .. _drag_and_drop_draggable_items:
 
-=============================
 Understanding Draggable Items
-=============================
+*****************************
 
 A draggable item is a rectangle that contains either a label or an image.
 Learners grab draggable items from the top of a drag and drop problem and drag
@@ -69,9 +67,9 @@ If you include only a text label, that label appears in the draggable item. If
 you include both a text label and an image for an item, the image appears as
 its label.
 
-=================================
+
 Using Draggable Items with Images
-=================================
+*********************************
 
 The following image shows draggable items with images. For examples of items
 with text, see :ref:`overview_of_drag_and_drop_problems`.
@@ -96,9 +94,9 @@ draggable item, you should consider how that image appears after scaling.
 
 .. _choosing_a_dnd_mode:
 
-=====================================
+
 Choosing a Drag and Drop Problem Mode
-=====================================
+*************************************
 
 You can configure drag and drop problems to allow learners to experiment with
 matching draggable items to target zones until all items are matched correctly,
@@ -159,7 +157,6 @@ unlimited attempts.
 
 .. _drag_and_drop_editor_fields:
 
-************************************************
 Understanding the Drag and Drop Editing Controls
 ************************************************
 

--- a/source/educators/references/course_development/exercise_tools/numerical_input.rst
+++ b/source/educators/references/course_development/exercise_tools/numerical_input.rst
@@ -1,6 +1,5 @@
 .. _Numerical Input:
 
-########################
 Numerical Input Problem
 ########################
 
@@ -18,7 +17,6 @@ both, you can give learners guidance and help when they work on a problem.
 For more information about the simple problem types, see
 :ref:`Working with Problem Components`.
 
-**********
 Overview
 **********
 
@@ -68,7 +66,7 @@ numerical input problem. An example of a completed numerical input problem follo
 
  :ref:`Editing Numerical Input Problems using the Advanced Editor` (how to)
 
- :ref:`Use Feedback in a Numerical Input Problems` (how-to)
+ :ref:`Use Feedback in a Numerical Input Problems` (how to)
 
  :ref:`Adding Numerical Input Problem` (how to)
 

--- a/source/educators/references/course_development/exercise_tools/numerical_input_xml.rst
+++ b/source/educators/references/course_development/exercise_tools/numerical_input_xml.rst
@@ -1,20 +1,17 @@
 .. _Numerical Input Problem XML:
 
-*************************************
 Numerical Input Problem OLX Reference
-*************************************
+#####################################
 
 .. tags:: educator, reference
 
-=========
 Templates
-=========
+*********
 
 The following templates represent problems without, and with, a Python script.
 
---------------------------
 Problem with No Tolerance
---------------------------
+=========================
 
 .. code-block:: xml
 
@@ -33,9 +30,9 @@ Problem with No Tolerance
     </numericalresponse>
   </problem>
 
-------------------------------
+
 Answer Created Using a Script
-------------------------------
+=============================
 
 .. note:: The following example includes a Python script. When you add a
   script to a problem component, make sure that it is not indented. A "jailed
@@ -63,9 +60,8 @@ Answer Created Using a Script
     </numericalresponse>
   </problem>
 
-=========
 Elements
-=========
+********
 
 For numerical input problems, the ``<problem>`` element can include this
 hierarchy of child elements.
@@ -86,9 +82,9 @@ hierarchy of child elements.
 
 In addition, standard HTML tags can be used to format text.
 
-------------------------
+
 ``<numericalresponse>``
-------------------------
+=======================
 
 Required. Indicates that the problem is a numerical input problem.
 
@@ -97,9 +93,9 @@ element used by the :ref:`math expression input<Math Expression Input>` problem
 type, but the ``<numericalresponse>`` element does not allow unspecified
 variables.
 
-^^^^^^^^^^^^^^^^^^^^
+
 Attributes
-^^^^^^^^^^^^^^^^^^^^
+----------
 
 .. list-table::
   :widths: 20 80
@@ -124,9 +120,9 @@ expressions that you or a learner provides. Answers can include simple
 expressions such as "0.3" and "42", or more complex expressions such as
 "1/3" and "sin(pi/5)".
 
-^^^^^^^^^^^^^^^^^^^^
+
 Children
-^^^^^^^^^^^^^^^^^^^^
+--------
 
 * ``<label>``
 * ``<description>``
@@ -137,47 +133,47 @@ Children
 * ``<script>``
 * ``<solution>``
 
-------------------------
+
 ``<label>``
-------------------------
+===========
 
 Required. Identifies the question or prompt. You can include HTML tags within
 this element.
 
-^^^^^^^^^^^^^^^^^^^^
+
 Attributes
-^^^^^^^^^^^^^^^^^^^^
+-----------
 
 None.
 
-^^^^^^^^^^^^^^^^^^^^
+
 Children
-^^^^^^^^^^^^^^^^^^^^
+--------
 
 None.
 
-------------------------
+
 ``<description>``
-------------------------
+=================
 
 Optional. Provides clarifying information about how to answer the question. You
 can include HTML tags within this element.
 
-^^^^^^^^^^^^^^^^^^^^
+
 Attributes
-^^^^^^^^^^^^^^^^^^^^
+----------
 
 None.
 
-^^^^^^^^^^^^^^^^^^^^
+
 Children
-^^^^^^^^^^^^^^^^^^^^
+---------
 
 None.
 
---------------------------
+
 ``<formulaequationinput>``
---------------------------
+==========================
 
 Required. Creates a response field in the LMS where learners enter a response.
 
@@ -187,9 +183,9 @@ Required. Creates a response field in the LMS where learners enter a response.
     element has been deprecated. All new problems should use the
     ``<formulaequationinput>`` element.
 
-^^^^^^^^^^^^^^^^^^^^
+
 Attributes
-^^^^^^^^^^^^^^^^^^^^
+----------
 
 .. list-table::
    :widths: 20 80
@@ -203,22 +199,22 @@ Attributes
    * - ``trailing_text``
      - Optional. Specified text to appear immediately after the response field.
 
-^^^^^^^^^^^^^^^^^^^^
+
 Children
-^^^^^^^^^^^^^^^^^^^^
+--------
 
 None.
 
---------------------------
+
 ``<additional_answer>``
---------------------------
+=======================
 
 Optional. Specifies an additional correct answer for the problem. A problem can
 contain an unlimited number of additional answers.
 
-^^^^^^^^^^^^^^^^^^^^
+
 Attributes
-^^^^^^^^^^^^^^^^^^^^
+----------
 
 .. list-table::
    :widths: 20 80
@@ -229,21 +225,21 @@ Attributes
    * - ``answer``
      - Required. The alternative correct answer.
 
-^^^^^^^^^^^^^^^^^^^^
+
 Children
-^^^^^^^^^^^^^^^^^^^^
+---------
 
 ``correcthint``
 
---------------------------
+
 ``<responseparam>``
---------------------------
+===================
 
 Specifies a tolerance, or margin of error, for an answer.
 
-^^^^^^^^^^^^^^^^^^^^
+
 Attributes
-^^^^^^^^^^^^^^^^^^^^
+-----------
 
 .. list-table::
    :widths: 20 80
@@ -263,22 +259,21 @@ Attributes
      - Optional. For partial credit problems of ``type="list"``, a comma-
          separated list of values that are to receive 50% credit.
 
-^^^^^^^^^^^^^^^^^^^^
 Children
-^^^^^^^^^^^^^^^^^^^^
+--------
 
 None.
 
---------------------------
+
 ``<correcthint>``
---------------------------
+=================
 
 Optional. Specifies feedback to appear after the learner submits the correct
 answer.
 
-^^^^^^^^^^^^^^^^^^^^
+
 Attributes
-^^^^^^^^^^^^^^^^^^^^
+----------
 
 .. list-table::
    :widths: 20 80
@@ -288,15 +283,15 @@ Attributes
    * - ``label``
      - Optional. The text of the custom feedback label.
 
-^^^^^^^^^^^^^^^^^^^^
+
 Children
-^^^^^^^^^^^^^^^^^^^^
+--------
 
 None.
 
---------------------------
+
 ``<script>``
---------------------------
+=============
 
 Optional. Specifies a script that the grader uses to evaluate a learner's
 response. A problem behaves as if all of the code in all of the ``<script>``
@@ -307,9 +302,9 @@ overridden.
 As with all Python, indentation matters, even though the code is embedded in
 XML.
 
-^^^^^^^^^^^^^^^^^^^^
+
 Attributes
-^^^^^^^^^^^^^^^^^^^^
+-----------
 
 .. list-table::
    :widths: 20 80
@@ -320,15 +315,15 @@ Attributes
    * - ``type``
      - Required. Must be set to ``loncapa/python``.
 
-^^^^^^^^^^^^^^^^^^^^
+
 Children
-^^^^^^^^^^^^^^^^^^^^
+---------
 
 None.
 
---------------------------
+
 ``<solution>``
---------------------------
+===============
 
 Optional. Identifies the explanation or solution for the problem, or for one of
 the questions in a problem that contains more than one question.
@@ -336,40 +331,39 @@ the questions in a problem that contains more than one question.
 This element contains an HTML division ``<div>``. The division contains one or
 more paragraphs ``<p>`` of explanatory text.
 
---------------------------
+
 ``<demandhint>``
---------------------------
+================
 
 Optional. Specifies hints for the learner. For problems that include multiple
 questions, the hints apply to the entire problem.
 
-^^^^^^^^^^^^^^^^^^^^
+
 Attributes
-^^^^^^^^^^^^^^^^^^^^
+----------
 
 None.
 
-^^^^^^^^^^^^^^^^^^^^
 Children
-^^^^^^^^^^^^^^^^^^^^
+---------
 
 ``<hint>``
 
---------------------------
+
 ``<hint>``
---------------------------
+==========
 
 Required. Specifies additional information that learners can access if needed.
 
-^^^^^^^^^^^^^^^^^^^^
+
 Attributes
-^^^^^^^^^^^^^^^^^^^^
+-----------
 
 None.
 
-^^^^^^^^^^^^^^^^^^^^
+
 Children
-^^^^^^^^^^^^^^^^^^^^
+---------
 
 None.
 
@@ -379,8 +373,6 @@ None.
  :ref:`Numerical Input` (reference)
 
  :ref:`Adding Numerical Input Problem` (how to)
-
- :ref:`Use Feedback in a Numerical Input Problems` (how-to)
 
  :ref:`Editing Numerical Input Problems using the Advanced Editor` (how to)
 


### PR DESCRIPTION
This PR modifies a series of reference documents migrated from the legacy repositories to the educators' documentation. The principal changes in the lti_canvas_example and lti_blackboard_example were converted into how-tos. An issue will be created for each document for an extended review.

In the case of drag_and_drop and numerical_input, there is one reference to edX legacy repositories in each document that I could not erase or replace with another link.