### PR TITLE
Fix codeblock syntax in Redwood tagging notes

### DIFF
--- a/source/community/release_notes/redwood/content_tagging.rst
+++ b/source/community/release_notes/redwood/content_tagging.rst
@@ -193,9 +193,8 @@ the Taxonomy Dashboard.
 The platform supports both flat and hierarchical taxonomies. Flat taxonomies are
 the simplest types of taxonomies, consisting of simple lists of tags. For
 example, a Taxonomy for tagging the "difficulty" of problems might contain tags
-like these:
+like these::
 
-.. code block:: text
 
     Taxonomy: Problem Difficulty
 
@@ -206,9 +205,8 @@ like these:
 Hierarchical taxonomies are more complex, consisting of one or more levels of
 hierarchical, or nested, tags. These tags are often called Parent Tags, Children
 Tags, Grandchildren Tags, etc. For example, a hierarchical taxonomy of locations
-might contain tags like these:
+might contain tags like these::
 
-.. code block:: text
 
     Taxonomy: Cities
        United States


### PR DESCRIPTION
Currently the codeblock syntax is wrong resulting in non-rendering of tag hierarchy example:

<img width="812" alt="image" src="https://github.com/user-attachments/assets/d6208816-ff93-4948-a2ac-dab71c1568fc" />

Fixed:

<img width="861" alt="image" src="https://github.com/user-attachments/assets/36ebf764-47ad-4500-ae46-a5ac6bd5590a" />

