### PR TITLE
Modify Accessibility guidelines from legacy to Open edX

### DIFF
--- a/source/developers/references/developer_guide/process/code-considerations.rst
+++ b/source/developers/references/developer_guide/process/code-considerations.rst
@@ -19,7 +19,7 @@ analytics.
 
 * `Internationalization Coding Guidelines`_
 * `RTL UI Best Practices`_
-* `Accessibility Guidelines`_
+* :ref:`Accessibility Guidelines`
 * `Analytics Guidelines`_
 * `Eventing Design and Review Process`_
 

--- a/source/developers/references/developer_guide/process/overview.rst
+++ b/source/developers/references/developer_guide/process/overview.rst
@@ -32,7 +32,7 @@ questions or concerns.
   `Product Review Process`_
 * `Internationalization Coding Guidelines`_
 * `RTL UI Best Practices`_
-* `Accessibility Guidelines`_
+* :ref:`Accessibility Guidelines`
 * `Analytics Guidelines`_
 * `Eventing Design and Review Process`_
 

--- a/source/educators/concepts/accessibility/accessibility_guidelines.rst
+++ b/source/educators/concepts/accessibility/accessibility_guidelines.rst
@@ -1,22 +1,12 @@
-.. _edX Accessibility Guidelines:
+.. _Accessibility Guidelines:
 
-===============================================================
-What Is The edX Accessibility Best Practices Guidance Based On?
-===============================================================
+#######################################################################
+What Is The Open edX® Accessibility Best Practices Guidance Based On?
+#######################################################################
 
 .. tags:: educator, concept
 
-.. note:: This content has been migrated from legacy edx.org docs and has not yet been adjusted for the Open edX® Community
-
-edX measures and evaluates accessibility primarily using the World Wide Web Consortium's
-`Web Content Accessibility Guidelines (WCAG) 2.1 <https://www.w3.org/TR/WCAG/>`_
-(05 June 2018). All features that are merged into edX repositories are
-expected to `conform <https://www.w3.org/TR/WCAG21/#conformance>`_ to `Level AA
-<https://www.w3.org/TR/WCAG21/#cc1>`_ of this specification and satisfy the
-requirements outlined in the edX `Website Accessibility Policy
-<https://www.edx.org/accessibility>`_.
-
-As the edX platform is strongly based on well-accepted `HTML5 markup standards <https://html.spec.whatwg.org/>`_ and `WAI-ARIA <https://www.w3.org/WAI/standards-guidelines/aria/>`_, we expect that learners who require additional accessibility tools such as screen readers and screen magnifiers will enjoy strong compatibility. We test regularly with the most popular accessibility tools.
+As the Open edX® platform is strongly based on well-accepted `HTML5 markup standards <https://html.spec.whatwg.org/>`_ and `WAI-ARIA <https://www.w3.org/WAI/standards-guidelines/aria/>`_, we expect that learners who require additional accessibility tools such as screen readers and screen magnifiers will enjoy strong compatibility. We test regularly with the most popular accessibility tools.
 
 In addition, our guidance is based on principles of `universal
 design <https://en.wikipedia.org/wiki/Universal_design>`_ (usable by all, to the greatest extent possible, without the need for

--- a/source/educators/concepts/accessibility/accessibility_guidelines.rst
+++ b/source/educators/concepts/accessibility/accessibility_guidelines.rst
@@ -6,7 +6,7 @@ What Is The Open edX® Accessibility Best Practices Guidance Based On?
 
 .. tags:: educator, concept
 
-As the Open edX® platform is strongly based on well-accepted `HTML5 markup standards <https://html.spec.whatwg.org/>`_ and `WAI-ARIA <https://www.w3.org/WAI/standards-guidelines/aria/>`_, we expect that learners who require additional accessibility tools such as screen readers and screen magnifiers will enjoy strong compatibility. We test regularly with the most popular accessibility tools.
+As the Open edX® platform is strongly based on well-accepted `HTML5 markup standards <https://html.spec.whatwg.org/>`_ and `WAI-ARIA <https://www.w3.org/WAI/standards-guidelines/aria/>`_, we expect that learners who require additional accessibility tools such as screen readers and screen magnifiers will enjoy strong compatibility.
 
 In addition, our guidance is based on principles of `universal
 design <https://en.wikipedia.org/wiki/Universal_design>`_ (usable by all, to the greatest extent possible, without the need for

--- a/source/educators/concepts/accessibility/best_practices_course_content_dev.rst
+++ b/source/educators/concepts/accessibility/best_practices_course_content_dev.rst
@@ -6,23 +6,10 @@ Accessibility Best Practices for Developing Course Content
 
 .. tags:: educator, concept
 
-edX is dedicated to creating a platform that is not only itself accessible, but
+The Open edX project is dedicated to creating a platform that is not only itself accessible, but
 also enables course content creators to create accessible content. If you
 encounter platform issues that you believe might affect your ability to provide
-accessible course content, please contact us using one of the following
-methods. We welcome any comments and questions.
-
-* Send an email message to accessibility@edx.org.
-* Submit a comment on the edX `Website Accessibility Policy
-  <http://www.edx.org/accessibility>`_ page.
-* Submit a comment on the `Individualized Accessibility Process for Course
-  Creators <https://studio.edx.org/accessibility>`_ page.
-
-.. Do not modify wording of the following note. Exact wording is from Legal.
-
-.. note:: Use of authoring tools other than those provided by edX might result
-   in inaccessible course content. However, for clarity, use of edX authoring
-   tools does not ensure that your course content will be accessible.
+accessible course content, please `submit a Github issue <.. _Submit an Open edX Issue>`_ to the Open edX project. 
 
 .. contents::
    :local:
@@ -100,7 +87,7 @@ readable, and that there is sufficient contrast between the foreground and
 background. Do not use color as the sole means of visually distinguishing an
 element or conveying critical information. If you must create images that
 contain text, make sure that the text has good contrast with the background. Images of text cannot be scaled or
-color corrected as effectively as HTML text. If you choose to override edX platform's default font colors, make sure that the
+color corrected as effectively as HTML text. If you choose to override platform's default font colors, make sure that the
 foreground and background colors have `sufficient contrast
 <https://contrast-ratio.com/>`_.
 
@@ -113,7 +100,7 @@ than background sounds.
 Make Sure Your Course Content is Understandable
 ***********************************************
 
-Make sure your course content is readable and understandable. EdX courses have
+Make sure your course content is readable and understandable. Online courses often have
 a global and diverse audience, including learners whose native language is not
 the language in which you created your course, as well as learners who have a
 disability that affects reading, such as dyslexia or a visual impairment.
@@ -180,7 +167,7 @@ non-text content.
 
 The text alternative for an image depends on the image's context and purpose,
 and might not be a simple description of the image's visual characteristics.
-In general, for every image, edX recommends that you provide a text
+In general, for every image, it is recommended that you provide a text
 alternative that provides the equivalent information that a sighted learner
 would obtain from viewing the image. If the image contains words that are
 important for understanding the content, include the words in the text
@@ -337,7 +324,7 @@ that requires color perception or a diagram with tiny labels and annotations
 will likely be difficult to comprehend for learners with color blindness or low
 vision. All images present a barrier to learners who are blind.
 
-edX recommends that you follow these best practices for making information
+It is recommended that you follow these best practices for making information
 graphics accessible to visually impaired learners.
 
 * Avoid using only color to distinguish important features of an image. For
@@ -394,7 +381,7 @@ making them available through your course.
 Carefully consider the document format you choose for publishing your course
 materials, because some formats support accessibility better than others.
 Whenever possible, create course materials in HTML format, using the tools
-available to you in edX Studio. When you make digital textbooks (ebooks)
+available to you in Studio. When you make digital textbooks (ebooks)
 available within your course, ask digital book publishers for books in `EPUB 3
 <https://en.wikipedia.org/wiki/EPUB#Version_3.0.1>`_
 format. This digital book format includes unparalleled
@@ -411,7 +398,7 @@ parties, it helps to ask the right questions about accessibility.
   headings, and bookmarks?
 
 Natively accessible formats like those mentioned above might not always be
-available options. Other popular document formats included in edX courses
+available options. Other popular document formats included in online courses
 include PDF, Microsoft Word, Excel, or PowerPoint. Many of the same
 accessibility techniques and principles that apply to authoring web content
 apply to these document formats as well.
@@ -511,7 +498,7 @@ Best Practices for Authoring Accessible PDF Documents
 Evaluating PDF Files for Accessibility
 **************************************
 
-EdX highly recommends using the tools available in Adobe Acrobat Pro (for
+It is highly recommended that you use the tools available in Adobe Acrobat Pro (for
 example, "Accessibility Checker") to evaluate your PDF files for accessibility.
 Adobe Acrobat Pro also includes tools (for example, "Make Accessible") for
 fixing most common accessibility issues.
@@ -573,7 +560,7 @@ Accessible Microsoft Word Resources
 ===================================
 Creating Accessible Excel Documents
 ===================================
-
+ 
 Many of the same accessibility techniques and principles that apply to
 authoring data tables in HTML also apply to creating Excel spreadsheets.
 
@@ -676,16 +663,16 @@ accessible to people with vision impairments. Non-scalable images of
 mathematical content cannot be sufficiently enlarged or navigated by low-vision
 users and are not accessible to blind users at all.
 
-edX uses `MathJax <https://www.mathjax.org>`_ to render math content in a
+The Open edX® platform uses `MathJax <https://www.mathjax.org>`_ to render math content in a
 format that is clear, readable, and accessible to people who use screen
 readers. MathJax works together with math notation such as LaTeX and MathML to
-render mathematical equations as text instead of images. edX recommends that
+render mathematical equations as text instead of images. It is recommended that
 you use MathML to author your math content. MathJax renders MathML in a variety
 of formats on the client side, offering the end user the ability to consume
 math content in their preferred format.
 
-edX Studio also supports authoring math directly in LaTeX using the `LaTeX Source Compiler
-<https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_components/create_html_component.html#import-latex-code>`_ to transform LaTeX into MathML.
+Studio also supports authoring math directly in LaTeX using the :ref:`LaTeX Source Compiler
+<import latex code>` to transform LaTeX into MathML.
 
 
 =========================================
@@ -807,7 +794,7 @@ Third-Party Content
 ===================
 
 If you include links to third-party content in your course, be mindful of the
-accessibility of such resources. edX recommends that you evaluate third-party
+accessibility of such resources. It is recommended that you evaluate third-party
 content prior to sharing it with learners.
 
 You can use the eReader tool or :ref:`Add Files to a Course <Add Files to a Course>` to incorporate
@@ -839,9 +826,7 @@ Create Accessible Media
 ***********************
 
 Media-based course materials help to convey concepts and can bring course
-information to life. We require all videos in edX courses to include timed text
-captions in `SubRip (SRT) format
-<https://en.wikipedia.org/wiki/SubRip>`_. The edX media
+information to life.  The Open edX® platform media
 player displays caption files in an interactive sidebar that benefits a variety
 of learners, including learners who are hard of hearing or whose native
 language differs from the primary language of the media. This built-in
@@ -860,7 +845,7 @@ loss affects about 10% of the population to some degree. It causes disability
 in 5% (360 to 538 million) and moderate to severe disability in 124 million
 people.  Timed text captions also be helpful for learners whose native
 languages are languages other than the primary language of the media or who
-have cognitive conditions that benefit from visual. The edX media player
+have cognitive conditions that benefit from visual. The media player
 displays timed text captions as links in an interactive area adjacent to the
 video, which allows all learners to navigate to a specific section of the video
 by selecting some location within the caption text.
@@ -945,10 +930,10 @@ and adaptable across browsers and devices. Also, the information in HTML
 markup helps assistive technologies, such as screen reader software, to
 provide information and functionality to people with vision impairments.
 
-Most of the problem type templates in edX Studio conform to our recommended
+Most of the problem type templates in Studio conform to our recommended
 best practices in terms of good HTML markup. You can manually add appropriate
 HTML tagging even if it does not exist in the component template. Depending on
-the type of component you are adding to your course in edX Studio, the raw
+the type of component you are adding to your course in Studio, the raw
 HTML data is available either automatically or by selecting the "Advanced
 Editor" or "HTML" views.
 
@@ -1047,7 +1032,7 @@ guidelines.
   there is a justification, communicate these requirements to prospective
   learners in the course description and establish a plan for responding to
   learners who encounter barriers. If there is no justification for the
-  requirements, edX recommends that you redesign the learning activities to be
+  requirements, it is recommended that you redesign the learning activities to be
   more flexible and broadly accessible.
 
 =======================================
@@ -1059,7 +1044,7 @@ Universal Design for Learning Resources
 .. seealso::
  :class: dropdown
 
- :ref:`edX Accessibility Guidelines` (concept)
+ :ref:`Accessibility Guidelines` (concept)
 
  :ref:`Designing for Mobile` (concept)
 

--- a/source/educators/concepts/accessibility/best_practices_course_content_dev.rst
+++ b/source/educators/concepts/accessibility/best_practices_course_content_dev.rst
@@ -87,7 +87,7 @@ readable, and that there is sufficient contrast between the foreground and
 background. Do not use color as the sole means of visually distinguishing an
 element or conveying critical information. If you must create images that
 contain text, make sure that the text has good contrast with the background. Images of text cannot be scaled or
-color corrected as effectively as HTML text. If you choose to override platform's default font colors, make sure that the
+color corrected as effectively as HTML text. If you choose to override the platform's default font colors, make sure that the
 foreground and background colors have `sufficient contrast
 <https://contrast-ratio.com/>`_.
 

--- a/source/educators/concepts/accessibility/design_for_mobile.rst
+++ b/source/educators/concepts/accessibility/design_for_mobile.rst
@@ -16,7 +16,7 @@ For information about accessibility best practices, see :ref:`Accessibility
 Index <Accessibility Index>`.
 
 The percentage of learners who access MOOCs using smartphones is increasing
-every day. Most courses on edx.org can be viewed on smartphones using the edX
+every day. Courses on your instance may be viewed on smartphones using the
 Android and iPhone apps, although we still recommend that learners complete
 graded assignments on a desktop computer, depending on the type of assessments
 that their courses include. For information on which exercises and tools are
@@ -27,8 +27,8 @@ To make the course experience for mobile learners as rewarding as it is for
 learners using desktop computers, keep the following best practices in mind as
 you design, test, and run your course.
 
-* Course updates that you make might take longer to appear in the edX mobile
-  apps than on the edX site. In particular, newly published content can take up
+* Course updates that you make might take longer to appear in the mobile
+  apps than on your course site. In particular, newly published content can take up
   to an hour to update on the Android app.
 
 * Display names are critical for navigating through courses on smartphones. As
@@ -56,7 +56,7 @@ you design, test, and run your course.
 * Learners might be viewing your course materials on screens as large as a
   high-resolution Mac Thunderbolt display, or as small as a 5 inch smartphone
   screen, so it is difficult to size an image so that it displays well at all
-  resolutions. In general, edX recommends keeping most images under 0.5MB in
+  resolutions. In general, it is recommended to keep most images under 0.5MB in
   size so that learners who have low Internet bandwidth will not have trouble
   downloading the images. If you have a large image that requires zooming to
   view the full detail, in addition to providing an image that can be easily
@@ -69,11 +69,11 @@ you design, test, and run your course.
   ready assessment types. If you use assessment types that are not supported on
   smartphones, notify learners in the body of your course that they will not be
   able to complete assignments that contain unsupported assessment types using
-  the edX iPhone and Android mobile apps.
+  the iPhone and Android mobile apps.
 
 * Timed and proctored exams cannot be completed using the mobile app.
 
-* When learners access your course using the edX Android and iPhone apps, they
+* When learners access your course using the Android and iPhone apps, they
   progress from component to component by swiping through them. It might seem
   useful to include a Text component in a unit for the purpose of providing a
   demarcation point or guiding learners to the next unit, but having to swipe
@@ -81,7 +81,7 @@ you design, test, and run your course.
   experience for mobile users.
 
 * Make sure your JavaScript and CSS are compliant. You should verify that all
-  components render correctly in the edX Android and iPhone apps as well as
+  components render correctly in the Android and iPhone apps as well as
   directly in the LMS.
 
 **************************************
@@ -89,15 +89,15 @@ Testing Your Course For Mobile Devices
 **************************************
 
 If you have included some of the more complex problem types, or have highly
-customized the way course content displays, edX recommends that you test your
+customized the way course content displays, it is recommended that you test your
 course for multiple devices and displays.
 
 To test the mobile experience of your course, sign in to your course using the
-edX Android or iPhone app, and view each course unit to make sure that it
+Android or iPhone app, and view each course unit to make sure that it
 renders as you expect it to.
 
 .. note:: Keep in mind that course updates that you make might not be
-   immediately reflected in the edX mobile apps. In particular, newly
+   immediately reflected in the mobile apps. In particular, newly
    published content can take up to an hour to update on the Android app.
 
 .. seealso::
@@ -105,7 +105,7 @@ renders as you expect it to.
 
  :ref:`Accessibility Best Practices for Course Content Development` (concept)
 
- :ref:`edX Accessibility Guidelines` (concept)
+ :ref:`Accessibility Guidelines` (concept)
 
  :ref:`Supporting Learners with Diverse Needs` (concept)
 

--- a/source/educators/concepts/accessibility/supporting_learners_diverse_needs.rst
+++ b/source/educators/concepts/accessibility/supporting_learners_diverse_needs.rst
@@ -11,17 +11,10 @@ courses can reduce many barriers to education for these learners by providing
 access to courses from any location, at any time, and through the use of
 assistive technologies.
 
-edX is dedicated to creating a platform that is not only itself accessible,
+The Open edX project is dedicated to creating a platform that is not only itself accessible,
 but also enables course content creators to create accessible content. If you
 encounter platform issues that you believe might affect your ability to
-provide accessible course content, please contact us at accessibility@edx.org.
-We welcome any comments and questions.
-
-.. Do not modify wording of the following note. Exact wording is from Legal.
-
-.. note:: Use of authoring tools other than those provided by edX might result
-   in inaccessible course content. However, for clarity, use of edX authoring
-   tools does not ensure that your course content will be accessible.
+provide accessible course content, please `submit a Github issue <.. _Submit an Open edX Issue>`_ to the Open edX project. 
 
 
 ************************
@@ -62,21 +55,21 @@ diverse needs, such as those in the following list.
 Removing Barriers to Learning
 *****************************
 
-edX highly recommends that you implement the best practices in this document
+It is highly recommended that you implement the best practices in this document
 and in other resources. If you cannot easily address any of these barriers to
-providing accessible course content, edX recommends that you consult with
+providing accessible course content, it is recommended that you consult with
 resources at your organization such as Disability Services, or assistive
 technology and accessibility specialists.
 
 The following resources might also assist you in producing accessible course
 content.
 
-* `User Agent Accessibility Guidelines (UAAG) <https://www.w3.org/WAI/standards-guidelines/uaag/#user-agent-accessibility-guidelines-uaag>`_ may be useful if you're intending to implement a browser or browser extension that will be compatible with the edX platform.
-* `Authoring Tool Accessibility Guidelines (ATAG) <https://www.w3.org/WAI/standards-guidelines/atag/#atag>`_ guides our efforts to make edX Studio more accessible.
-* `HTML5 <https://html.spec.whatwg.org/>`_ and `WAI-ARIA (Accessible Rich Internet Applications) <https://www.w3.org/WAI/standards-guidelines/aria/#introduction>`_ are the standards we follow to ensure that the edX platform is accessible. You should follow the same standards to ensure that learner content inside `xBlocks <https://github.com/openedx/xblock-sdk>`_ (learning units) is accessible.
-* `EPUB 3.0 <http://idpf.org/epub/30>`_ is edX's preferred document format for ensuring that redistributable learning materials are accessible, though `Adobe PDF <https://www.adobe.com/accessibility/pdf/pdf-accessibility-overview.html>`_, `Microsoft Office <https://www.microsoft.com/en-us/accessibility/microsoft-365?activetab=pivot_1%3aprimaryr2>`_, and `Google Docs <https://support.google.com/docs/answer/6199477?hl=en>`_ may also be made accessible.
+* `User Agent Accessibility Guidelines (UAAG) <https://www.w3.org/WAI/standards-guidelines/uaag/#user-agent-accessibility-guidelines-uaag>`_ may be useful if you're intending to implement a browser or browser extension that will be compatible with the Open edX® platform.
+* `Authoring Tool Accessibility Guidelines (ATAG) <https://www.w3.org/WAI/standards-guidelines/atag/#atag>`_ guides efforts to make Studio more accessible.
+* `HTML5 <https://html.spec.whatwg.org/>`_ and `WAI-ARIA (Accessible Rich Internet Applications) <https://www.w3.org/WAI/standards-guidelines/aria/#introduction>`_ are the standards to help ensure that the platform is accessible. You should follow the same standards to ensure that learner content inside `xBlocks <https://github.com/openedx/xblock-sdk>`_ (learning units) is accessible.
+* `EPUB 3.0 <http://idpf.org/epub/30>`_ is a format for ensuring that redistributable learning materials are accessible, though `Adobe PDF <https://www.adobe.com/accessibility/pdf/pdf-accessibility-overview.html>`_, `Microsoft Office <https://www.microsoft.com/en-us/accessibility/microsoft-365?activetab=pivot_1%3aprimaryr2>`_, and `Google Docs <https://support.google.com/docs/answer/6199477?hl=en>`_ may also be made accessible.
 * The `DAISY Consortium <http://www.daisy.org/>`_ contributes to EPUB accessibility standards and has a tool for che checking EPUB document accessibility.
-* `MathML <http://www.w3.org/Math/>`_ is edX's preferred markup format for all math content.
+* `MathML <http://www.w3.org/Math/>`_ is a preferred markup format for all math content.
 * `MathJax <https://www.mathjax.org>`_ is the system we use for rendering MathML content.
 * `WCAG2ICT <http://www.w3.org/WAI/standards-guidelines/wcag/non-web-ict/>`_ covers non-web Information and Communications Technologies.
 
@@ -92,7 +85,7 @@ when creating a course.
 
  :ref:`Accessibility Best Practices for Course Content Development` (concept)
 
- :ref:`edX Accessibility Guidelines` (concept)
+ :ref:`Accessibility Guidelines` (concept)
 
  :ref:`Designing for Mobile` (concept)
 

--- a/source/links.txt
+++ b/source/links.txt
@@ -272,7 +272,6 @@
 .. _Oppia XBlock: https://github.com/oppia/xblock
 .. _Internationalization Coding Guidelines: https://openedx.atlassian.net/wiki/edx.readthedocs.io/projects/edx-developer-guide/en/latest/internationalization/i18n.html
 .. _RTL UI Best Practices: https://github.com/openedx/edx-platform/wiki/RTL-UI-Best-Practices
-.. _Accessibility Guidelines: http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/accessibility.html
 .. _Analytics Guidelines: http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/analytics.html
 .. _Eventing Design and Review Process: https://openedx.atlassian.net/wiki/display/AN/Eventing+Design+and+Review+Process
 .. _Product Review Process: https://openedx.atlassian.net/wiki/spaces/COMM/pages/3875962884/DRAFT+How+to+submit+an+open+source+contribution+for+Product+Review
@@ -626,6 +625,8 @@
 .. _Open edX Documentation: http://docs.openedx.org
 
 .. _GitHub repository: https://github.com/openedx/docs.openedx.org/issues/new
+
+.. _Submit an Open edX Issue: https://github.com/openedx/edx-platform/issues
 
 .. _Sphinx: http://sphinx-doc.org
 


### PR DESCRIPTION
Adjust docs related to accessibility to make them relevant to Open edX. Involved:
- Changing edx.org references
- Replacing edx.org-specific support (e.g. accessibility@edx.org) with Open edX community support (e.g. github issues)
- Replace edx.org-specific legalese that we should not adopt. 