### PR TITLE
FC-0068 docs: Reference cleaning by edunext #7

### DIFF
--- a/source/educators/how-tos/course_development/text_components/add_link_website_unit_file.rst
+++ b/source/educators/how-tos/course_development/text_components/add_link_website_unit_file.rst
@@ -4,7 +4,7 @@
 Add Link to Website, Course Unit, or a File
 #############################################
 
-.. tags:: educator, reference
+.. tags:: educator, how-to
 
 .. _Add a Link in a Text Component:
 

--- a/source/educators/how-tos/preview_content.rst
+++ b/source/educators/how-tos/preview_content.rst
@@ -1,0 +1,36 @@
+.. _Preview Draft Content:
+
+Preview Draft Content
+#######################
+
+.. tags:: educator, how-to
+
+To preview draft content and see how it would appear to members of different
+groups when it is released, follow these steps.
+
+#. From a unit page in the **Course Outline** in Studio, select **Preview**.
+
+   A separate browser tab opens for the course in the LMS.
+
+#. In the LMS, select one of the **View this course as** options, as described
+   in :ref:`Roles for Viewing Course Content`.
+
+The course view refreshes to present course content as it is currently
+configured in Studio, and as a learner in the selected group would see it.
+
+.. note:: If you use randomized content blocks in your course, you cannot
+   preview unpublished units that contain content from randomized content
+   blocks, because the randomized content is not assigned until after the unit
+   is published. For information about viewing the actual content that has
+   been assigned to a particular learner from a randomized content block in a
+   live course, see :ref:`Specific Student View`.
+
+.. seealso::
+ :class:dropdown
+
+ :ref:`Testing Your Course Content` (reference)
+
+ :ref:`Roles for Viewing Course Content` (reference)
+
+ :ref:`How to View Published and Released Content` (how-to)
+

--- a/source/educators/how-tos/view_published_released_content.rst
+++ b/source/educators/how-tos/view_published_released_content.rst
@@ -1,0 +1,36 @@
+.. _How to View Published and Released Content:
+
+How to View Published and Released Content
+###########################################
+
+.. tags:: educator, how-to
+
+.. note:: Click here to learn more about :ref:`View Published Content`.
+
+To view published and released content as it would appear to members of
+different groups, follow these steps.
+
+#. From the Studio **Course Outline** page, select **View Live**.
+   Alternatively, from a unit page, select **View Live Version**.
+
+   A separate browser tab opens for the course in the LMS.
+
+#. In the LMS, select one of the **View this course as** options, as described
+   in :ref:`Roles for Viewing Course Content`.
+
+The course view refreshes to present published course content as a learner in
+the selected group would see it.
+
+For more information about each view, see :ref:`Staff View`, :ref:`Student
+View`, or :ref:`Specific Student View`. For more information about viewing
+cohort-specific course content, see :ref:`Viewing Cohort Specific Courseware`.
+
+
+.. seealso::
+ :class:dropdown
+
+ :ref:`Testing Your Course Content` (reference)
+
+ :ref:`Roles for Viewing Course Content` (reference)
+
+ :ref:`Preview Draft Content` (how-to)

--- a/source/educators/navigation/content_creation_management.rst
+++ b/source/educators/navigation/content_creation_management.rst
@@ -48,7 +48,7 @@ Add Text Components
    ../references/course_development/text_components/text_components.rst
    ../how-tos/course_development/text_components/work_with_html.rst
    ../how-tos/course_development/text_components/create_text_component.rst
-   ../references/course_development/text_components/add_link_website_unit_file.rst
+   ../how-tos/course_development/text_components/add_link_website_unit_file.rst
    ../how-tos/course_development/text_components/add_image.rst
    ../how-tos/course_development/exercise_tools/create_full_screen_image.rst
    ../how-tos/course_development/text_components/paste_without_formatting.rst
@@ -194,6 +194,8 @@ Test Your Course
 
    ../references/testing_course_content.rst
    ../references/roles_for_viewing.rst
+   ../how-tos/view_published_released_content.rst
+   ../how-tos/preview_content.rst
 
 Embed IFrames
 *******************************************************

--- a/source/educators/references/course_development/about_video_guidelines.rst
+++ b/source/educators/references/course_development/about_video_guidelines.rst
@@ -1,8 +1,7 @@
 .. _Course About Video Guidelines:
 
-********************************
 Course About Video Guidelines
-********************************
+##############################
 
 .. tags:: educator, reference
 
@@ -38,3 +37,14 @@ as your course content videos.
 
 For information about how to add an About video to your course About page, see
 :ref:`Add an About Video <Add an About Video>`.
+
+.. seealso::
+ :class:dropdown
+
+ :ref:`Introduction to Video` (reference)
+
+ :ref:`Add an About Video` (how-to)
+
+ :ref:`Course and Program Images and Videos` (reference)
+
+ :ref:`Additional Video Options` (how-to)

--- a/source/educators/references/course_development/add_video_to_course.rst
+++ b/source/educators/references/course_development/add_video_to_course.rst
@@ -1,8 +1,7 @@
 .. _Introduction to Video:
 
-************************
 Introduction to Video
-************************
+#########################
 
 .. tags:: educator, reference
 
@@ -28,9 +27,8 @@ For more information about how learners can interact with course videos, see
 
 .. _Working with Video Components:
 
-#############################
 Working with Video Components
-#############################
+******************************
 
 You use video components to add videos to your course in Studio. In video
 components, you add the name and location of your video, as well as the video
@@ -46,9 +44,8 @@ Video Options`.
 
 .. _Adding a Video to a Course:
 
-##########################
 Adding a Video to a Course
-##########################
+**************************
 
 To make a video visible in your course, you create a video component in a Unit
 in Studio, and then you add information for the video to the video component.
@@ -70,12 +67,7 @@ that site. Keep the following guidelines in mind.
   you upload on sites such as Vimeo, Dailymotion, or other sites that use their
   own player.
 
-  To help make sure all standard browsers can play your video, edX strongly
-  recommends that you use .mp4 format.
-
-  The video URL might resemble the following example.
-
-  ``https://s3.amazonaws.com/edx-course-videos/edx-edx101/EDXSPCPJSP13-G030300.mp4``
+  To ensure that all standard browsers can play your video, you should use the .mp4 format.
 
 * If you have copies of a video in multiple resolutions, you must upload each
   copy to the hosting site. For more information, see :ref:`Video Guidelines`.
@@ -83,3 +75,16 @@ that site. Keep the following guidelines in mind.
 * After you upload a video on a hosting site, you must make sure you have the
   URL for that copy of the video. If you upload copies of your video on more
   than one hosting site, make sure you have the URL for each video location.
+
+.. seealso::
+ :class:dropdown
+
+ :ref:`Course About Video Guidelines` (reference)
+
+ :ref:`Add an About Video` (how-to)
+
+ :ref:`Course and Program Images and Videos` (reference)
+
+ :ref:`Additional Video Options` (how-to)
+
+ :ref:`Troubleshoot Videos` (reference)

--- a/source/educators/references/course_development/course_export_terminology.rst
+++ b/source/educators/references/course_development/course_export_terminology.rst
@@ -1,8 +1,7 @@
 .. _Course Export File Terminology:
 
-********************************************
 Course Outline Terminology in Exported Files
-********************************************
+#############################################
 
 .. tags:: educator, reference
 
@@ -30,11 +29,6 @@ of files.
 For example, if you want to find a specific section in your course when you
 open the list of files that your course contains, look in the **Chapter**
 directory. To find a unit, look in the **Vertical** directory.
-
-.. only:: Partners
-
-  For more information, see `course_structure <course_structure_research_guide>`_ in the **EdX
-  Research Guide**.
 
 .. seealso::
  :class: dropdown

--- a/source/educators/references/course_development/exercise_tools/SCORM_overview.rst
+++ b/source/educators/references/course_development/exercise_tools/SCORM_overview.rst
@@ -1,12 +1,15 @@
 .. _SCORM Overview:
 
+SCORM Overview
+###############
+
 ********
 Overview
 ********
 
 .. tags:: educator, reference
 
-The SCORM `XBlock <https://edx.readthedocs.io/projects/xblock-tutorial/en/latest/overview/introduction.html>`_ provides the ability to display SCORM content within the Open edX LMS and Studio.
+The :ref:`SCORM XBlock` provides the ability to display SCORM content within the Open edX LMS and Studio.
 It can save a learners state and report scores to the progress tab of the course.
 It currently supports SCORM 1.2 and SCORM 2004 standard.
 
@@ -25,7 +28,6 @@ Try to limit the SCORM package to 1 quiz or scored component.
 *********************
 Technical information
 *********************
-
 
 There are 2 events a SCORM package can emit in order to communicate with the Open edX platform.
 

--- a/source/educators/references/course_development/exercise_tools/conditional_module.rst
+++ b/source/educators/references/course_development/exercise_tools/conditional_module.rst
@@ -1,8 +1,7 @@
 .. _Conditional Module:
 
-##################
 Conditional Module
-##################
+###################
 
 .. tags:: educator, reference
 
@@ -97,3 +96,8 @@ Examples of conditional depends on problem
     <conditional sources="i4x://MITx/0.000x/problem/Conditional:lec27_Q1" attempted="False">
         <html display_name="HTML for not attempted problem">You see this because "lec27_Q1" was not attempted.</html>
     </conditional>
+
+.. seealso::
+ :class:dropdown
+
+ :ref: `add_delete_course_tags` (how-to)

--- a/source/educators/references/course_development/exercise_tools/google_docs.rst
+++ b/source/educators/references/course_development/exercise_tools/google_docs.rst
@@ -24,7 +24,7 @@ body. For more information, see :ref:`Google Calendar Tool`.
 .. note:: Google services are not available in some regions and countries. If
   Google services are not available in a learner's area, the learner might see
   an "image unavailable" message in the place of the Google Drive file or
-  calendar. 
+  calendar.  It is recommended that you provide alternative resources for learners in these areas.
 
 *********
 Overview

--- a/source/educators/references/course_development/exercise_tools/google_docs.rst
+++ b/source/educators/references/course_development/exercise_tools/google_docs.rst
@@ -24,8 +24,7 @@ body. For more information, see :ref:`Google Calendar Tool`.
 .. note:: Google services are not available in some regions and countries. If
   Google services are not available in a learner's area, the learner might see
   an "image unavailable" message in the place of the Google Drive file or
-  calendar. EdX strongly suggests that you provide alternative resources for
-  learners in these areas.
+  calendar. 
 
 *********
 Overview

--- a/source/educators/references/course_development/exercise_tools/mathjax_studio.rst
+++ b/source/educators/references/course_development/exercise_tools/mathjax_studio.rst
@@ -1,13 +1,12 @@
 .. _MathJax in Studio:
 
-##############################
 MathJax for Mathematics
 ##############################
 
 .. tags:: educator, reference
 
 To produce clear and professional-looking symbols and equations in web browser,
-edX uses `MathJax <https://www.mathjax.org/>`_. MathJax automatically formats
+Open edX platform uses `MathJax <https://www.mathjax.org/>`_. MathJax automatically formats
 the mathematical symbols and equations that you enter in Text and problem
 components using LaTeX notation into beautiful math.
 
@@ -46,3 +45,9 @@ For display equations, you can do either of the following.
  :class: dropdown
 
  :ref:`Adding MathJax` (reference)
+
+ :ref:`Math Expression Input` (reference)
+
+ :ref:`Math Expression Input Problem XML` (reference)
+
+ :ref:`Adding MathJax` (how-to)

--- a/source/educators/references/course_development/exercise_tools/mathjax_studio.rst
+++ b/source/educators/references/course_development/exercise_tools/mathjax_studio.rst
@@ -6,7 +6,7 @@ MathJax for Mathematics
 .. tags:: educator, reference
 
 To produce clear and professional-looking symbols and equations in web browser,
-Open edX platform uses `MathJax <https://www.mathjax.org/>`_. MathJax automatically formats
+the Open edX platform uses `MathJax <https://www.mathjax.org/>`_. MathJax automatically formats
 the mathematical symbols and equations that you enter in Text and problem
 components using LaTeX notation into beautiful math.
 

--- a/source/educators/references/course_development/exercise_tools/text_input.rst
+++ b/source/educators/references/course_development/exercise_tools/text_input.rst
@@ -25,8 +25,8 @@ Overview
 In text input problems, learners enter text into a response field. The
 response can include numbers, letters, and special characters such as
 punctuation marks. Because the text that the learner enters must match the
-instructor's specified answer exactly, including spelling and punctuation, edX
-recommends that you specify more than one correct answer for text input
+instructor's specified answer exactly, including spelling and punctuation, it is
+recommend that you specify more than one correct answer for text input
 problems to allow for differences in capitalization and typographical errors.
 
 =============================

--- a/source/educators/references/course_development/exercise_tools/text_input_xml.rst
+++ b/source/educators/references/course_development/exercise_tools/text_input_xml.rst
@@ -1,14 +1,12 @@
 .. _Text Input Problem XML:
 
-********************************
 Text Input Problem XML Reference
-********************************
+#################################
 
 .. tags:: educator, reference
 
-==============
 Template
-==============
+*********
 
 .. code-block:: xml
 
@@ -32,9 +30,9 @@ Template
     </demandhint>
   </problem>
 
-=========
+
 Elements
-=========
+*********
 
 For text input problems, the ``<problem>`` element can include this
 hierarchy of child elements.
@@ -54,15 +52,15 @@ hierarchy of child elements.
 
 In addition, standard HTML tags can be used to format text.
 
----------------------
+
 ``<stringresponse>``
----------------------
+=====================
 
 Required. Indicates that the problem is a text input problem.
 
-^^^^^^^^^^
+
 Attributes
-^^^^^^^^^^
+-----------
 
 .. list-table::
    :widths: 20 80
@@ -89,9 +87,9 @@ Attributes
        example, ``<stringresponse type="regexp cs">`` specifies that the
        problem allows regular expressions and is case sensitive.
 
-^^^^^^^^^^
+
 Children
-^^^^^^^^^^
+---------
 
 * ``<label>``
 * ``<description>``
@@ -101,54 +99,53 @@ Children
 * ``<stringequalhint>``
 * ``<solution>``
 
----------------------
+
 ``<label>``
----------------------
+=============
 
 Required. Identifies the question or prompt. You can include HTML tags within
 this element.
 
-^^^^^^^^^^
+
 Attributes
-^^^^^^^^^^
+-----------
 
 None.
 
-^^^^^^^^^^
+
 Children
-^^^^^^^^^^
+---------
 
 None.
 
----------------------
+
 ``<description>``
----------------------
+===================
 
 Optional. Provides clarifying information about how to answer the question. You
 can include HTML tags within this element.
 
-^^^^^^^^^^
 Attributes
-^^^^^^^^^^
+-----------
 
 None.
 
-^^^^^^^^^^
+
 Children
-^^^^^^^^^^
+---------
 
 None.
 
----------------------
+
 ``<textline>``
----------------------
+===============
 
 Required. Creates a response field in the LMS where the learner enters a text
 string.
 
-^^^^^^^^^^
+
 Attributes
-^^^^^^^^^^
+-----------
 
 .. list-table::
    :widths: 20 80
@@ -168,22 +165,22 @@ Attributes
 
 .. reviewers, note that I could not get "correct_answer" to work ^^. The answer attribute of stringresponse is required and overrides whatever I put in here. Can this attribute be removed or marked as deprecated? - Alison 10 Aug
 
-^^^^^^^^^^
+
 Children
-^^^^^^^^^^
+---------
 
 None.
 
-------------------------
+
 ``<additional_answer>``
-------------------------
+========================
 
 Optional. Specifies an additional correct answer for the problem. A problem can
 contain an unlimited number of additional answers.
 
-^^^^^^^^^^
+
 Attributes
-^^^^^^^^^^
+-----------
 
 .. list-table::
    :widths: 20 80
@@ -194,22 +191,22 @@ Attributes
    * - ``answer``
      - Required. The text of the alternative correct answer.
 
-^^^^^^^^^^
+
 Children
-^^^^^^^^^^
+---------
 
 ``<correcthint>``
 
-------------------------
+
 ``<correcthint>``
-------------------------
+===================
 
 Optional. Specifies feedback to appear after the learner submits a correct
 answer.
 
-^^^^^^^^^^
+
 Attributes
-^^^^^^^^^^
+-----------
 
 .. list-table::
    :widths: 20 80
@@ -220,22 +217,22 @@ Attributes
    * - ``label``
      - Optional. The text of the custom feedback label.
 
-^^^^^^^^^^
+
 Children
-^^^^^^^^^^
+---------
 
 None.
 
-------------------------
+
 ``<stringequalhint>``
-------------------------
+======================
 
 Optional. Specifies feedback to appear after the learner submits an incorrect
 answer.
 
-^^^^^^^^^^
+
 Attributes
-^^^^^^^^^^
+-----------
 
 .. list-table::
    :widths: 20 80
@@ -248,15 +245,15 @@ Attributes
    * - ``label``
      - Optional. The text of the custom feedback label.
 
-^^^^^^^^^^
+
 Children
-^^^^^^^^^^
+-----------
 
 None.
 
-------------------------
+
 ``<solution>``
-------------------------
+===============
 
 Optional. Identifies the explanation or solution for the problem, or for one of
 the questions in a problem that contains more than one question.
@@ -264,40 +261,40 @@ the questions in a problem that contains more than one question.
 This element contains an HTML division ``<div>``. The division contains one or
 more paragraphs ``<p>`` of explanatory text.
 
-------------------------
+
 ``<demandhint>``
-------------------------
+=================
 
 Optional. Specifies hints for the learner. For problems that include multiple
 questions, the hints apply to the entire problem.
 
-^^^^^^^^^^
+
 Attributes
-^^^^^^^^^^
+-----------
 
 None.
 
-^^^^^^^^^^
+
 Children
-^^^^^^^^^^
+---------
 
 ``<hint>``
 
-------------------------
+
 ``<hint>``
-------------------------
+============
 
 Required. Specifies additional information that learners can access if needed.
 
-^^^^^^^^^^
+
 Attributes
-^^^^^^^^^^
+-----------
 
 None.
 
-^^^^^^^^^^
+
 Children
-^^^^^^^^^^
+---------
 
 None.
 

--- a/source/educators/references/course_development/files_page.rst
+++ b/source/educators/references/course_development/files_page.rst
@@ -1,8 +1,7 @@
 .. _The Files Page:
 
-**************
 The Files Page
-**************
+################
 
 .. tags:: educator, reference
 
@@ -140,3 +139,5 @@ To reset the list and view files of all types, clear all checkboxes.
  :class: dropdown
 
  :ref:`Add Files to a Course` (how-to)
+
+ :ref:`manage_files` (how-to)

--- a/source/educators/references/course_development/files_page.rst
+++ b/source/educators/references/course_development/files_page.rst
@@ -140,4 +140,4 @@ To reset the list and view files of all types, clear all checkboxes.
 
  :ref:`Add Files to a Course` (how-to)
 
- :ref:`manage_files` (how-to)
+ `Manage Course Files <https://docs.openedx.org/en/latest/educators/how-tos/manage_files.html>`_ (how-to)

--- a/source/educators/references/course_development/parent_child_components.rst
+++ b/source/educators/references/course_development/parent_child_components.rst
@@ -1,15 +1,14 @@
 .. _Components that Contain Other Components:
 
-******************************************
 Components that Contain Other Components
-******************************************
+#########################################
 
 .. tags:: educator, reference
 
 For specific use cases, you configure course content so that components contain
 other components. For example, if you want to include conditional components or
 content experiments, you have to create components inside components. See
-:ref:`Creating Content Experiments` for more information.
+:ref:`Add Content Experiments to Your Course` for more information.
 
 The component that contains other components is referred to as the *parent*;
 the contained components are referred to as child components, or children.
@@ -22,9 +21,9 @@ On a unit page, a parent component appears with its display name and a
  :width: 500
 
 
-========================
+
 Edit a Parent Component
-========================
+*************************
 
 A parent component does not directly contain content. Content such as HTML,
 videos, or problems are in the child components.
@@ -37,9 +36,9 @@ select **Edit** in the parent component to change the display name.
   additional attributes that you edit.
 
 
-======================
+
 View Child Components
-======================
+**********************
 
 When you select **View** in the parent component, the parent component page
 opens, showing all child components. In this example, Child Component A
@@ -59,9 +58,9 @@ For more information, see the following topics.
 * :ref:`Duplicate a Component`
 * :ref:`Delete a Component`
 
-======================================
+
 Add a Child Component
-======================================
+**********************
 
 If the containing unit is private or in draft, you can add a child component in
 its parent component.
@@ -79,9 +78,9 @@ want.
 - :ref:`Working with Video Components`
 
 
-======================================
+
 XML for Parent and Child Components
-======================================
+************************************
 
 You develop parent and child components in XML, then import the XML course into
 Studio to verify that the structure is as you intended.
@@ -132,9 +131,9 @@ Theoretically, there is no limit to the levels of component nesting you can use
 in your course.
 
 
-======================================
+
 The Learner View of Nested Components
-======================================
+**************************************
 
 For learners, all parent and child components appear on the unit page.
 
@@ -148,3 +147,16 @@ The following example shows the learner view of the unit described above.
 .. image:: /_images/educator_references/nested_components_student_view.png
  :alt: The learner's view of nested components.
  :width: 400
+
+.. seealso::
+ :class:dropdown
+
+ :ref:`Unit States and Visibility to Students` (reference)
+
+ :ref:`Working with Discussion Components` (reference)
+ 
+ :ref:`Working with Text Components` (reference)
+ 
+ :ref:`Working with Problem Components` (reference)
+ 
+ :ref:`Working with Video Components` (reference)

--- a/source/educators/references/course_development/troubleshoot_video.rst
+++ b/source/educators/references/course_development/troubleshoot_video.rst
@@ -19,9 +19,7 @@ When you use video, you might experience one of the following problems.
     video elements`_.
 
   * Verify that file metadata, particularly the MIME type, is correctly set on
-    the host site. For example, when Open edX platform offered support for Internet Explorer
-    10 browsers, videos did not play if the MIME type was not set. The HTTP
-    header ``Content-Type`` had to be set to video/mp4 for an .mp4 file.
+    the host site. 
 
     As an example of how you might set metadata on a video host site, the
     *Console User Guide* for Amazon Simple Storage Service (S3) provides

--- a/source/educators/references/course_development/troubleshoot_video.rst
+++ b/source/educators/references/course_development/troubleshoot_video.rst
@@ -19,7 +19,7 @@ When you use video, you might experience one of the following problems.
     video elements`_.
 
   * Verify that file metadata, particularly the MIME type, is correctly set on
-    the host site. For example, when edX offered support for Internet Explorer
+    the host site. For example, when Open edX platform offered support for Internet Explorer
     10 browsers, videos did not play if the MIME type was not set. The HTTP
     header ``Content-Type`` had to be set to video/mp4 for an .mp4 file.
 
@@ -33,3 +33,15 @@ When you use video, you might experience one of the following problems.
   YouTube account settings for playback are set to always show captions. To
   correct this problem, select **CC** again or change your YouTube account
   settings.
+
+.. seealso::
+ :class:dropdown
+
+ :ref:`Introduction to Video` (reference)
+
+ :ref:`Add an About Video` (how-to)
+
+ :ref:`Additional Video Options` (how-to)
+
+ :ref:`Course and Program Images and Videos` (reference)
+

--- a/source/educators/references/course_development/work_with_targz_file.rst
+++ b/source/educators/references/course_development/work_with_targz_file.rst
@@ -1,8 +1,7 @@
 .. _Work with the targz File:
 
-***********************************
 Working with the ``.tar.gz`` File
-***********************************
+###################################
 
 .. tags:: educator, reference
 

--- a/source/educators/references/testing_course_content.rst
+++ b/source/educators/references/testing_course_content.rst
@@ -75,29 +75,6 @@ mode, keep the following points in mind.
 For information about unit publishing statuses, see :ref:`Unit Publishing
 Status`.
 
-========================================
-View Published and Released Content
-========================================
-
-To view published and released content as it would appear to members of
-different groups, follow these steps.
-
-#. From the Studio **Course Outline** page, select **View Live**.
-   Alternatively, from a unit page, select **View Live Version**.
-
-   A separate browser tab opens for the course in the LMS.
-
-#. In the LMS, select one of the **View this course as** options, as described
-   in :ref:`Roles for Viewing Course Content`.
-
-The course view refreshes to present published course content as a learner in
-the selected group would see it.
-
-For more information about each view, see :ref:`Staff View`, :ref:`Student
-View`, or :ref:`Specific Student View`. For more information about viewing
-cohort-specific course content, see :ref:`Viewing Cohort Specific Courseware`.
-
-
 .. _Preview Unpublished Content:
 
 ************************
@@ -122,27 +99,12 @@ When you use **Staff** view in preview mode, you also see any content that is
 :ref:`Visible to Staff Only`.
 
 
-=============================
-Preview Draft Content
-=============================
+.. seealso::
+ :class:dropdown
 
-To preview draft content and see how it would appear to members of different
-groups when it is released, follow these steps.
+ :ref:`Roles for Viewing Course Content` (reference)
 
-#. From a unit page in the **Course Outline** in Studio, select **Preview**.
+ :ref:`How to View Published and Released Content` (how-to)
 
-   A separate browser tab opens for the course in the LMS.
-
-#. In the LMS, select one of the **View this course as** options, as described
-   in :ref:`Roles for Viewing Course Content`.
-
-The course view refreshes to present course content as it is currently
-configured in Studio, and as a learner in the selected group would see it.
-
-.. note:: If you use randomized content blocks in your course, you cannot
-   preview unpublished units that contain content from randomized content
-   blocks, because the randomized content is not assigned until after the unit
-   is published. For information about viewing the actual content that has
-   been assigned to a particular learner from a randomized content block in a
-   live course, see :ref:`Specific Student View`.
+ :ref:`Preview Draft Content` (how-to)
 


### PR DESCRIPTION
This PR modifies a series of reference documents migrated from the legacy repositories to the educators' documentation.

The principal changes are in the add_link_website_unit_file, which was modified to be a how-to and create two how-tos based on testing_course_content.

In this PR, some articles maintain links that direct to edX legacy repositories, as the content has not been migrated to Open edX repositories.