### PR TITLE
Jswope00/change external refs to internal

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -104,14 +104,6 @@ intersphinx_mapping = {
     "event-routing-backends": (
         f"https://event-routing-backends.readthedocs.io/{rtd_language}/{rtd_version}", None
     ),
-    "edx-installing-configuring-and-running": (
-        f"https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/{rtd_language}/{rtd_version}",
-        None,
-    ),
-    "openedx-building-and-running-a-course": (
-        f"https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/{rtd_language}/{rtd_version}",
-        None,
-    ),
     "edx-platform": (
         f"https://docs.openedx.org/projects/edx-platform/{rtd_language}/{rtd_version}",
         None,

--- a/source/developers/references/developer_guide/extending_platform/extending.rst
+++ b/source/developers/references/developer_guide/extending_platform/extending.rst
@@ -61,7 +61,7 @@ ways to extend the platform, starting with the following table.
      - Yes
    * - Clean UI Integration
      - Yes
-     - No (see :doc:`openedx-building-and-running-a-course:exercises_tools/lti_component`)
+     - No (see :ref:`LTI Component`)
      - Yes
      - Yes
      - Yes
@@ -72,13 +72,13 @@ ways to extend the platform, starting with the following table.
      - Yes
      - Yes
    * - Server Side Grading
-     - Possibly (See :doc:`openedx-building-and-running-a-course:exercises_tools/custom_javascript`)
+     - Possibly (See :ref:`Custom JavaScript`)
      - Yes
      - Yes
      - Yes
      - Yes
    * - Usage Data
-     - No (See :doc:`openedx-building-and-running-a-course:exercises_tools/custom_javascript`)
+     - No (See :doc:`Custom JavaScript`)
      - No
      - Limited
      - Yes

--- a/source/developers/references/developer_guide/extending_platform/xblocks.rst
+++ b/source/developers/references/developer_guide/extending_platform/xblocks.rst
@@ -166,7 +166,7 @@ other course content component, or for sequential or vertical course container
 component. There are several ways to find the ``usage_id`` for an XBlock in the
 LMS, including viewing either the staff debug info or the page source. For more
 information, see
-:doc:`openedx-building-and-running-a-course:course_features/lti/lti_address_content`.
+:ref:`Determine Content Addresses`.
 
 
 Example XBlock URLs

--- a/source/educators/concepts/accessibility/design_for_mobile.rst
+++ b/source/educators/concepts/accessibility/design_for_mobile.rst
@@ -12,8 +12,7 @@ to everyone, regardless of any physical limitation that they might have, and
 regardless whether they are accessing your course using a Web browser or using
 mobile apps.
 
-For information about accessibility best practices, see :ref:`Accessibility
-Index <Accessibility Index>`.
+For information about accessibility best practices, see :ref:`Accessibility Best Practices for Course Content Development`.
 
 The percentage of learners who access MOOCs using smartphones is increasing
 every day. Courses on your instance may be viewed on smartphones using the

--- a/source/educators/concepts/advanced_features/lti_reuse_content.rst
+++ b/source/educators/concepts/advanced_features/lti_reuse_content.rst
@@ -35,7 +35,7 @@ content in the context of an external LMS.
    :depth: 1
 
 For information about the content that you can include in an external LMS, see
-:ref:`Preparing Content`.
+:ref:`Planning for Content Reuse`.
 
 **********************************
 Course Roster Management
@@ -74,7 +74,7 @@ example, edX course discussions can identify participants by their edX IDs
 instead of the usernames they would normally see in the external LMS. As a
 result, some edX content is not currently suitable for use in an external LMS.
 
-For more information, see :ref:`Preparing Content`.
+For more information, see :ref:`Planning for Content Reuse`.
 
 ******************************
 Learner Progress and Grades

--- a/source/educators/concepts/advanced_features/offering_differentiated_content.rst
+++ b/source/educators/concepts/advanced_features/offering_differentiated_content.rst
@@ -41,15 +41,13 @@ If you have enabled cohorts in your course, you can associate one or more cohort
 For example, you might intend all learners in your course to have substantially the same course experience, except that you want to show learners who are either current students or alumni of your institution a special video in several sections. You already have your institution's current students in one cohort and alumni in another cohort. By associating both of
 these cohorts with the same content group, and restricting access to the special institutional-related video to only this content group, you can provide a customized course experience.
 
-For information about creating differentiated content using cohorts, see :ref:`Cohorts Overview` and :ref:`Cohorted Courseware Overview`.
+For information about creating differentiated content using cohorts, see :ref:`Cohorts Overview`.
 
 .. seealso::
 
  :ref:`Enrollment Track Specific Courseware Overview` (how-to)
 
  :ref:`Cohorts Overview` (concept)
-
- :ref:`Cohorted Courseware Overview` (concept)
 
  :ref:`About Content Groups` (concept)
 

--- a/source/educators/concepts/advanced_features/teams_learner_experience.rst
+++ b/source/educators/concepts/advanced_features/teams_learner_experience.rst
@@ -7,7 +7,7 @@ The Learner's Experience of Teams
 
 .. tags:: educator, concept
 
-After you have :ref:`enabled teams <Teams Setup>` and created topics in your
+After you have :ref:`enabled teams <Enable and Configure Teams>` and created topics in your
 course, learners can begin browsing topics and joining teams. Teams are formed
 within topics. Each learner can belong to only one team.
 

--- a/source/educators/concepts/advanced_features/using_openedx_as_LTI_provider.rst
+++ b/source/educators/concepts/advanced_features/using_openedx_as_LTI_provider.rst
@@ -51,7 +51,7 @@ requirements.
   a learner and not a TA or course designer.
 
 For more information about constructing an LTI URL for a course component, see
-:ref:`Determining Content Addresses`.
+:ref:`Determine Content Addresses`.
 
 .. seealso::
  :class: dropdown
@@ -62,6 +62,6 @@ For more information about constructing an LTI URL for a course component, see
 
  :ref:`Planning for Content Reuse (LTI)<Planning for Content Reuse>` (reference)
 
- :ref:`Example: edX as an LTI Provider to Canvas<edX as an LTI Provider to Canvas>` (reference)
+ :ref:`Example: Open edX as an LTI Provider to Canvas<Open edX as an LTI Provider to Canvas>` (reference)
 
- :ref:`Example: edX as an LTI Provider to Blackboard<edX as an LTI Provider to Blackboard>` (reference)
+ :ref:`Example: edX as an LTI Provider to Blackboard<Open edX as an LTI Provider to Blackboard>` (reference)

--- a/source/educators/concepts/exercise_tools/OpenResponseAssessments.rst
+++ b/source/educators/concepts/exercise_tools/OpenResponseAssessments.rst
@@ -18,7 +18,7 @@ assessment) to complete the assignment.
    an open response assessment divided by cohort, you must create that
    assessment in a course component that is defined as cohort-specific. For  more
    information about cohorts and creating cohort-specific course content, see
-   :ref:`Cohorts Overview <cohorts overview>` and :ref:`Cohorted Courseware Overview <cohorted courseware overview>`.
+   :ref:`Cohorts Overview <cohorts overview>` and :ref:`Offering Differentiated Content to Different Learner Groups <Offering Differentiated Content>`.
 
 The following topics provide conceptual information about open response
 assessments.
@@ -374,7 +374,7 @@ steps, and make it available only to the members of one or more specific
 cohorts. For the members of the remaining cohorts, you create an ORA assignment
 that has only the peer assessment step. For details about creating different
 course experiences for learners in different cohorts, see
-:ref:`Cohorted Courseware Overview <cohorted courseware overview>`.
+:ref:`Cohorted Courseware Overview <cohorts overview>`.
 
 For details about performing grading in staff assessment steps, see
 :ref:`Perform a Staff Assessment`.

--- a/source/educators/concepts/open_edx_platform/outline_studio_lms.rst
+++ b/source/educators/concepts/open_edx_platform/outline_studio_lms.rst
@@ -42,5 +42,4 @@ If a learner selects the **Resume Course** option, the course opens to the
 unit that the learner most recently completed.
 
 For information about more specific learner data, including the learner's
-grades or answers for individual problems, see :ref:`Manage Student Progress
-Index`.
+grades or answers for individual problems, see :ref:`Learner Data`.

--- a/source/educators/concepts/planning_course_run_information/set_up_course.rst
+++ b/source/educators/concepts/planning_course_run_information/set_up_course.rst
@@ -16,4 +16,4 @@ types of basic information about your course.
   information such as the course staff and start and end dates.
 
 For information about how to develop your course content in the Studio course
-outline, see :ref:`Developing Your Course Index <Developing Your Course Index>`.
+outline, see :ref:`Developing Your Course Outline`.

--- a/source/educators/concepts/proctored_exams/preparing_learners_proctored_exams.rst
+++ b/source/educators/concepts/proctored_exams/preparing_learners_proctored_exams.rst
@@ -15,8 +15,7 @@ To prepare learners for a proctored exam, follow these guidelines:
 * Explain what proctored exams are, and provide learners with links to the
   `OE SFD Proctored Exams`_ topic in the *Open edX
   Learner’s Guide*.
-* Communicate the rules for proctored exams, including the :ref:`online
-  proctoring rules<CA Online Proctoring Rules>` in the *Open edX Learner’s
+* Communicate the rules for proctored exams, including the :ref:`Online Proctoring Rules` in the *Open edX Learner’s
   Guide* as well as any specific rules for a particular exam. For information
   about creating specific rules, see
   :ref:`specifying_exam_rules_and_exceptions`.

--- a/source/educators/concepts/proctored_exams/proctored_exams_overview.rst
+++ b/source/educators/concepts/proctored_exams/proctored_exams_overview.rst
@@ -10,7 +10,7 @@ Proctored exams are timed exams that learners take while online proctoring
 software monitors their computer, environment, and behavior. When learners
 complete a proctored exam, the recording of the exam is examined to
 determine whether the learner complied with the :ref:`online proctoring rules
-<CA Online Proctoring Rules>`.
+<Online Proctoring Rules>`.
 
 Learners must be in the verified enrollment track to take a proctored exam.
 

--- a/source/educators/how-tos/advanced_features/add_cohorts.rst
+++ b/source/educators/how-tos/advanced_features/add_cohorts.rst
@@ -26,7 +26,7 @@ add a cohort to your course, follow these steps.
 #. Optionally, select **Select a Content Group** to associate the cohort with a
    :ref:`content group<About Content Groups>`. For information about creating
    cohort-specific course content by associating cohorts with content groups,
-   see :ref:`Cohorted Courseware Overview`.
+   see :ref:`Cohorts Overview` and :ref:`Offering Differentiated Content`.
 
 #. Select **Save**.
 

--- a/source/educators/how-tos/advanced_features/cohorted_courseware.rst
+++ b/source/educators/how-tos/advanced_features/cohorted_courseware.rst
@@ -17,7 +17,7 @@ cohorts.
 Overview
 *********
 
-If you have :ref:`enabled cohorts<Enabling and Configuring Cohorts>` in your
+If you have :ref:`enabled cohorts<Manage Course Cohorts>` in your
 course, you can create different course experiences for learners in different
 cohorts.
 
@@ -36,7 +36,7 @@ Complete these steps to create cohort-specific content in your course.
 
 In Studio
 
-#. :ref:`Enable cohorts in your course<Enabling and Configuring Cohorts>`.
+#. :ref:`Enable cohorts in your course<Manage Course Cohorts>`.
 #. :ref:`Create content groups<Creating Content Groups>`.
 #. :ref:`Specify components or units as available only to particular content
    groups<Specify Content as Available Only to Certain Content Groups>`.
@@ -61,7 +61,7 @@ University Alumni and Current University Students. Learners who are not in
 either of these cohorts are automatically placed into a third cohort, the
 default cohort, when they access the **Course** or **Discussion** tabs in the
 course. For more information about enabling cohorts in your course and
-assigning students to cohorts, see :ref:`Enabling and Configuring Cohorts`.
+assigning students to cohorts, see :ref:`Manage Course Cohorts`.
 
 You intend all learners to have substantially the same course experience, with
 the exception that only learners in the two university-related cohorts will

--- a/source/educators/how-tos/advanced_features/create_content_experiment.rst
+++ b/source/educators/how-tos/advanced_features/create_content_experiment.rst
@@ -24,7 +24,7 @@ completed the following tasks.
    The content experiment includes a container for each group that is defined
    in the group configuration you selected. You create content for each
    experiment group as you do any other component. For more information, see
-   :ref:`Developing Course Components`.
+   :ref:`Add a Component`.
 
 #. Select either **Select a Group Configuration** or **Edit** to open the
    content experiment component.

--- a/source/educators/how-tos/advanced_features/lti_blackboard_example.rst
+++ b/source/educators/how-tos/advanced_features/lti_blackboard_example.rst
@@ -35,7 +35,7 @@ To use Open edX course content in the Blackboard LMS, you add a new app to the c
      :alt: The Blackboard Create Web Link page with example name and URL
          values.
 
-   For more information, see :ref:`Determining Content Addresses`.
+   For more information, see :ref:`Determine Content Addresses`.
 
 #. Review the content to verify that it appears as you expect.
 
@@ -54,4 +54,4 @@ To use Open edX course content in the Blackboard LMS, you add a new app to the c
 
  :ref:`Planning for Content Reuse (LTI)<Planning for Content Reuse>` (reference)
 
- :ref:`Example: edX as an LTI Provider to Canvas<edX as an LTI Provider to Canvas>` (reference)
+ :ref:`Example: Open edX as an LTI Provider to Canvas<Open edX as an LTI Provider to Canvas>` (reference)

--- a/source/educators/how-tos/advanced_features/lti_canvas_example.rst
+++ b/source/educators/how-tos/advanced_features/lti_canvas_example.rst
@@ -26,7 +26,7 @@ To use Open edX course content in the Canvas LMS, you add a new app to the cours
      :alt: The Canvas page where you add an external tool and supply the LTI
          URL.
 
-   For more information, see :ref:`Determining Content Addresses`.
+   For more information, see :ref:`Determine Content Addresses`.
 
 #. Review the content to verify that it appears as you expect.
 

--- a/source/educators/how-tos/advanced_features/lti_determine_content_address.rst
+++ b/source/educators/how-tos/advanced_features/lti_determine_content_address.rst
@@ -238,7 +238,7 @@ LTI URLs for Text components include "html+block" or "html", as follows.
 
  :ref:`Planning for Content Reuse (LTI)<Planning for Content Reuse>` (reference)
 
- :ref:`Example: edX as an LTI Provider to Canvas<edX as an LTI Provider to Canvas>` (reference)
+ :ref:`Example: Open edX as an LTI Provider to Canvas<Open edX as an LTI Provider to Canvas>` (reference)
 
  :ref:`Example: edX as an LTI Provider to Blackboard<edX as an LTI Provider to Blackboard>` (reference)
 

--- a/source/educators/how-tos/advanced_features/lti_prepare_content.rst
+++ b/source/educators/how-tos/advanced_features/lti_prepare_content.rst
@@ -64,6 +64,6 @@ steps.
 
  :ref:`Planning for Content Reuse (LTI)<Planning for Content Reuse>` (reference)
 
- :ref:`Example: edX as an LTI Provider to Canvas<edX as an LTI Provider to Canvas>` (reference)
+ :ref:`Example: Open edX as an LTI Provider to Canvas<Open edX as an LTI Provider to Canvas>` (reference)
 
  :ref:`Example: edX as an LTI Provider to Blackboard<edX as an LTI Provider to Blackboard>` (reference)

--- a/source/educators/how-tos/advanced_features/timed_exams.rst
+++ b/source/educators/how-tos/advanced_features/timed_exams.rst
@@ -6,6 +6,8 @@ Configure Timed Exams
 
 .. tags:: educator, how-to
 
+.. _Enable Timed Exams:
+
 *******************
 Enable Timed Exams
 *******************
@@ -59,7 +61,7 @@ steps.
 
      If your course has the proctored exam feature enabled, the
      **Advanced** tab also shows options for :ref:`proctored and practice
-     proctored exams<CA_ProctoredExams>`.
+     proctored exams<ProctoredExams_Overview:>`.
 
 #. In the **Time Allotted** field, enter the length of time that you want
    learners to have to complete the problems in the subsection. Enter the time

--- a/source/educators/how-tos/communication/configure-discussions.rst
+++ b/source/educators/how-tos/communication/configure-discussions.rst
@@ -88,9 +88,11 @@ Discussion list now includes the topic you added.
    configure these topics to be divided by cohort. For more information, see
    :ref:`Divide Course Wide Discussion Topics`.
 
+.. _Enable Discussion on a Course Unit:
 
-Upgraded Open edX Forum
-=======================
+**********************************
+Enable Discussion on a Course Unit
+**********************************
 
 Discussion can be enabled for a course unit, which is equivalent to adding
 a content-specific discussion topic in that unit in the :ref:`legacy version of

--- a/source/educators/how-tos/communication/setting_up_divided_discussions.rst
+++ b/source/educators/how-tos/communication/setting_up_divided_discussions.rst
@@ -12,8 +12,7 @@ Setting Up Divided Discussions
 
 
 By default, all :ref:`course-wide discussion topics<Create CourseWide
-Discussion Topics>` and :ref:`content-specific discussion topics<Create
-ContentSpecific Discussion Topics>` are unified: all learners can interact
+Discussion Topics>` and :ref:`content-specific discussion topics<Content Specific Discussion Topics>` are unified: all learners can interact
 with all posts, responses, and comments. You can change discussion topics of
 either type to be divided or unified on the discussions configuration page
 (see :ref:`Create CourseWide Discussion Topics`).
@@ -39,8 +38,7 @@ topics.
 Divide All Content-Specific Discussion Topics
 *********************************************
 
-When you :ref:`create content-specific discussion topics<Create
-ContentSpecific Discussion Topics>` by adding discussion components to units
+When you :ref:`create content-specific discussion topics<Enable Discussion on a Course Unit>` by adding discussion components to units
 in Studio, these discussion topics are by default unified. All learners in the
 course can see and respond to posts from all other learners. You can change
 content-specific discussion topics to be divided, so that only members of the

--- a/source/educators/how-tos/configure_prerequisite_content.rst
+++ b/source/educators/how-tos/configure_prerequisite_content.rst
@@ -12,7 +12,7 @@ in the course outline with a lock icon, and learners cannot view the subsection
 content until they have earned a minimum score in the prerequisite subsection.
 
 .. note::
-   You must first :ref:`Enable Course Prerequisites` before
+   You must first :ref:`Set up Course Prerequisites` before
    prerequisite course subsections can be used.
 
 .. _enabling_subsection_gating:
@@ -47,8 +47,7 @@ subsection, follow these steps.
     learners.
 
 .. note::
-    You cannot use :ref:`open response assessments<Open Response Assessments
-    Two>` that have a point value of 0 as the prerequisite for other course
+    You cannot use :ref:`Open Response Assessments` that have a point value of 0 as the prerequisite for other course
     subsections.
 
 #. Enable subsection prerequisites for your course. For more information, see
@@ -114,7 +113,7 @@ subsection, follow these steps.
      :width: 600
 
   .. note:: Prerequisite course subsection settings are not retained when
-     you :ref:`export or import a course<Exporting and Importing a Course>`, or
+     you :ref:`Export a Course` and :ref:`Import a Course`, or
      when you :ref:`re-run a course<Rerun a Course>`.
 
 .. seealso::

--- a/source/educators/how-tos/course_development/additional_video_options.rst
+++ b/source/educators/how-tos/course_development/additional_video_options.rst
@@ -132,7 +132,7 @@ Transcript
 
     * - **Transcript Languages**
       - The transcript files for any additional languages. For more
-        information, see :ref:`Transcripts in Additional Languages`.
+        information, see :ref:`Transcripts in Additional Languages<Add a Transcript>`.
 
     * - **Download Transcript Allowed**
       - Specifies whether you want to allow learners to download the .srt or

--- a/source/educators/how-tos/proctored_exams/create_proctored_exam_rpnow.rst
+++ b/source/educators/how-tos/proctored_exams/create_proctored_exam_rpnow.rst
@@ -65,7 +65,7 @@ Specify Exam Rules and Exceptions
 *********************************
 
 By default, reviewers evaluate exam attempts according to a standard set of
-:ref:`online proctoring rules <CA Online Proctoring Rules>` that the
+:ref:`online proctoring rules <Online Proctoring Rules>` that the
 proctoring service has provided.
 
 .. note::

--- a/source/educators/references/advanced_features/planning_content_reuse.rst
+++ b/source/educators/references/advanced_features/planning_content_reuse.rst
@@ -63,7 +63,7 @@ example, you can use a spreadsheet column to identify the type of content (for
 example, component, unit, subsection), and add their display names to the next
 column. Additional columns can contain the values that you use to construct the
 addresses for your LTI links. For more information about addressing content,
-see :ref:`Determining Content Addresses`.
+see :ref:`Determine Content Addresses`.
 
 Optionally, you can streamline the contents of units and subsections by
 removing components, or disable course features that you do not plan to use.

--- a/source/educators/references/course_development/course_outline.rst
+++ b/source/educators/references/course_development/course_outline.rst
@@ -20,7 +20,7 @@ building blocks in the course outline.
 * :ref:`Developing Course Sections`
 * :ref:`Developing Course Subsections`
 * :ref:`Developing Course Units`
-* :ref:`Developing Course Components`
+* :ref:`Add a Component`
 
 ****************************
 Open the Course Outline

--- a/source/educators/references/course_development/course_units.rst
+++ b/source/educators/references/course_development/course_units.rst
@@ -25,7 +25,7 @@ What is a Unit?
 A unit is a part of a :ref:`subsection<Developing Course Subsections>` that
 learners view as a single page.
 
-A unit contains one or more :ref:`components<Developing Course Components>`,
+A unit contains one or more :ref:`components<Add a Component>`,
 such as text with :ref:`HTML<Working with Text Components>` markup,
 :ref:`problems<Working with Problem Components>`, a :ref:`discussion<Working
 with Discussion Components>`, or a

--- a/source/educators/references/course_development/text_components/text_components.rst
+++ b/source/educators/references/course_development/text_components/text_components.rst
@@ -18,7 +18,7 @@ with your Text components in a "visual" or WYSIWYG editor that hides the HTML
 code details, or in a "raw" editor that requires you to mark up your content.
 
 .. note::
- Review :ref:`Developing Your Course Index` and :ref:`Best Practices for HTML
+ Review :ref:`Developing Your Course Outline` and :ref:`Best Practices for HTML
  Markup` before you start working with Text components.
 
 

--- a/source/educators/references/course_development/unit_workflow_and_status.rst
+++ b/source/educators/references/course_development/unit_workflow_and_status.rst
@@ -13,7 +13,7 @@ The typical workflow includes these steps.
 
 #. :ref:`Create a unit<Create a Unit>`.
 #. :ref:`Add components to the unit<Add a Component>`.
-#. :ref:`Modify components in the unit<Developing Course Components>`.
+#. :ref:`Modify components in the unit<Add a Component>`.
 
 .. The following image could use some re-work to make the contrast greater.
 

--- a/source/educators/references/proctored_exams/pt_proctored_exam_report.rst
+++ b/source/educators/references/proctored_exams/pt_proctored_exam_report.rst
@@ -144,7 +144,7 @@ Values in the ``review_status`` Column
 
 After learners complete a proctored exam, a reviewer from the proctoring
 service provider reviews the exam according to specific criteria, including the
-:ref:`Online Proctoring Rules <CA Online Proctoring Rules>`. The value in the
+:ref:`Online Proctoring Rules <Online Proctoring Rules>`. The value in the
 ``review_status`` column shows the outcome of the proctored exam review.
 
 Additionally, the value in the ``review_status`` column affects the following

--- a/source/educators/references/proctored_exams/rpnow_proctored_exam_report.rst
+++ b/source/educators/references/proctored_exams/rpnow_proctored_exam_report.rst
@@ -140,7 +140,7 @@ Values in the ``review_status`` Column
 
 After learners complete a proctored exam, a reviewer from the proctoring
 service provider reviews the exam according to specific criteria, including the
-:ref:`Online Proctoring Rules <CA Online Proctoring Rules>`. The value in the
+:ref:`Online Proctoring Rules <Online Proctoring Rules>`. The value in the
 ``review_status`` column shows the outcome of the proctored exam review.
 
 Additionally, the value in the ``review_status`` column affects the following

--- a/source/educators/references/workflow.rst
+++ b/source/educators/references/workflow.rst
@@ -33,7 +33,7 @@ Before you begin, you should understand the building blocks of an edX course.
   subsection contains one or more units.
 * :ref:`Course units <Developing Course Units>` are lessons in a subsection
   that learners view as single pages. A unit contains one or more components.
-* :ref:`Course components<Developing Course Components>` are objects within
+* :ref:`Course components<Add a Component>` are objects within
   units that contain your actual course content.
 
 .. _Creating New Course Content:


### PR DESCRIPTION
Removing the intersphinx_mapping setting that creates links to legacy docs, and fixing all breaking links that result. 