### PR TITLE
FC-0068 docs: how-to cleaning by edunext #18

### DIFF
--- a/source/educators/how-tos/course_development/exercise_tools/create_problem_in_latex.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/create_problem_in_latex.rst
@@ -1,8 +1,7 @@
 .. _Problem Written in LaTeX:
 
-############################
 Problem Written in LaTeX
-############################
+########################
 
 .. tags:: educator, how-to
 
@@ -24,9 +23,8 @@ into the LaTeX editor, you make a few adjustments.
 .. image:: /_images/educator_how_tos/ProblemWrittenInLaTeX.png
  :alt: Image of a problem written in LaTeX
 
-************************************
 Create a Problem Written in LaTeX
-************************************
+*********************************
 
 To create a problem written in LaTeX, follow these steps.
 
@@ -47,4 +45,19 @@ To create a problem written in LaTeX, follow these steps.
    file into the editor from your computer by clicking **Upload** in the bottom
    right corner.
 #. In the lower left corner of the LaTeX source compiler, click **Save &
-   Compile to edX XML**.
+   Compile to Open edX XML**.
+
+.. seealso::
+ :class: dropdown
+
+ :ref:`Numerical Input` (reference)
+
+ :ref:`Numerical Input Problem XML` (reference)
+
+ :ref:`Editing Numerical Input Problems using the Advanced Editor` (how-to)
+
+ :ref:`Awarding Partial Credit in a Numerical Input Problem` (how-to)
+
+ :ref:`Work with Latex Code` (how-to)
+
+ :ref:`Adding Numerical Input Problem` (how-to)

--- a/source/educators/how-tos/course_development/exercise_tools/create_problem_with_hint.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/create_problem_with_hint.rst
@@ -1,8 +1,7 @@
 .. _Problem with Adaptive Hint:
 
-################################
 Problem with Adaptive Hint
-################################
+##########################
 
 .. tags:: educator, how-to
 
@@ -14,9 +13,8 @@ input problems or single select problems.
 .. image:: /_images/educator_how_tos/ProblemWithAdaptiveHintExample.png
  :alt: Image of a problem with an adaptive hint
 
-******************************************
 Create a Problem with an Adaptive Hint
-******************************************
+**************************************
 
 To create the problem illustrated above, follow these steps.
 
@@ -66,4 +64,3 @@ To create the problem illustrated above, follow these steps.
  :class: dropdown
 
  :ref:`Problem with Adaptive Hint XML` (reference)
-

--- a/source/educators/how-tos/course_development/exercise_tools/create_protein_builder.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/create_protein_builder.rst
@@ -1,8 +1,7 @@
 .. _Protein Builder:
 
-############################
 Protex Protein Builder Tool
-############################
+###########################
 
 .. tags:: educator, how-to
 
@@ -16,9 +15,8 @@ a simple line.
 
 .. _Create the Protein Builder:
 
-********************************
 Create the Protein Builder Tool
-********************************
+*******************************
 
 To create the protein builder, follow these steps.
 
@@ -31,7 +29,6 @@ To create the protein builder, follow these steps.
 
 .. _Protein Builder Code:
 
-*************************
 Protein Builder Tool Code
 *************************
 
@@ -102,3 +99,12 @@ In this code:
        - W
        - Y
        - V
+
+.. seealso::
+ :class: dropdown
+
+ :ref:`Chemical Equation` (how-to)
+
+ :ref:`Custom JavaScript` (reference)
+
+ :ref:`Gene Explorer` (reference)

--- a/source/educators/how-tos/proctored_exams/allow_opt_out_proctored_exam.rst
+++ b/source/educators/how-tos/proctored_exams/allow_opt_out_proctored_exam.rst
@@ -1,16 +1,12 @@
 .. _Allow Opting Out of Proctored Exams:
 
-***************************************************
 Allow Opting Out of Proctored Exams
-***************************************************
+###################################
 
 .. tags:: educator, how-to
 
 When a proctored exam opens, by default, verified learners must take the exam
 with proctoring.
-
-If you want to allow Verified or Master's learners the option to take proctored exams
-without proctoring, please contact your edX partner manager to enable this option.
 
 .. note::
    If a learner opts to take an exam without proctoring, the exam will not be
@@ -19,20 +15,18 @@ without proctoring, please contact your edX partner manager to enable this optio
    any time. You can reduce the ability to view the exam by selecting a due
    date for the exam.
 
-.. only:: Open_edX
+To enable the option for learners to opt out of proctored exams for a course,
+follow these steps.
 
-    To enable the option for learners to opt out of proctored exams for a course,
-    follow these steps.
+#. In Studio, select **Settings**, then select **Proctored Exam Settings**.
 
-    #. In Studio, select **Settings**, then select **Proctored Exam Settings**.
+#. Locate the **Allow Opting Out of Proctored Exams** policy key. The default
+   value is ``No``, which requires Verified and Master's learners to take
+   proctored exams with proctoring.
 
-    #. Locate the **Allow Opting Out of Proctored Exams** policy key. The default
-       value is ``No``, which requires Verified and Master's learners to take
-       proctored exams with proctoring.
+#. Change the value of the setting to ``Yes``.
 
-    #. Change the value of the setting to ``Yes``.
-
-    #. Select **Submit**.
+#. Select **Submit**.
 
 .. seealso::
  :class: dropdown

--- a/source/educators/how-tos/proctored_exams/create_proctored_exam_pt.rst
+++ b/source/educators/how-tos/proctored_exams/create_proctored_exam_pt.rst
@@ -32,9 +32,7 @@ Proctortrack.
    * Create an Onboarding subsection in the first section of any course using
      Proctortrack proctoring, as described below.
 
-   * Add in-course messaging that completing Onboarding early is important, and
-     that access to Onboarding requires to be in a paid track (e.g. Verified or
-     Master's).
+   * Add in-course messaging that completing Onboarding early is important.
 
    * Nudge learners who have not yet completed Onboarding a week before the
      first proctored exam.

--- a/source/educators/how-tos/proctored_exams/create_proctored_exam_pt.rst
+++ b/source/educators/how-tos/proctored_exams/create_proctored_exam_pt.rst
@@ -1,58 +1,61 @@
 .. _Create a Proctored Exam with Proctortrack:
 
-#########################################
 Create a Proctored Exam with Proctortrack
 #########################################
 
 .. tags:: educator, how-to
-   
-After you enable proctored exams with Proctortrack for your course, you can create proctored exams.
 
-To create a proctored exam for Proctortrack, you first create a single Onboarding exam subsection in your course, and then create one or more proctored exam subsections.
+After you enable proctored exams with Proctortrack for your course, you can
+create proctored exams.
 
-The Onboarding exam is a practice proctored experience which ensures the learner’s
-computer passes system requirements and establishes the learner’s identity
-with Verificient by creating an onboarding profile.
+To create a proctored exam for Proctortrack, you first create a single
+Onboarding exam subsection in your course, and then create one or more
+proctored exam subsections.
 
+The Onboarding exam is a practice proctored experience which ensures the
+learner's computer passes system requirements and establishes the learner's
+identity with Verificient by creating an onboarding profile.
 
-*********************************
 Creating an Onboarding Subsection
 *********************************
-
 
 Proctortrack requires all learners to complete an onboarding process before
 they take a proctored exam. In the onboarding process, learners download and
 install the necessary client software and verify their identity with
 Proctortrack.
 
-
-.. note::  Onboarding includes a mandatory identity verification step which
-   establishes an identity baseline with Verificient. This is required to gain access to the first Proctored Exam, and can take 5+ business days for learners to complete, so we recommend you:
+.. note:: Onboarding includes a mandatory identity verification step which
+   establishes an identity baseline with Verificient. This is required to gain
+   access to the first Proctored Exam, and can take 5+ business days for
+   learners to complete, so we recommend you:
 
    * Create an Onboarding subsection in the first section of any course using
      Proctortrack proctoring, as described below.
 
-   * Add in-course messaging that completing Onboarding early is important, and that access to Onboarding requires to be in a paid track (e.g. Verified or Master’s).
+   * Add in-course messaging that completing Onboarding early is important, and
+     that access to Onboarding requires to be in a paid track (e.g. Verified or
+     Master's).
 
-   * Nudge learners who have not yet completed Onboarding a week before the first proctored exam.
-
-   This identity baseline is aged off every 1 year. A valid baseline will work across future Proctortrack courses on edX.org as well, but we recommend learners re-take Onboarding as a practice exam in every course, to make sure their current system is still ready for proctoring in advance of each proctored exam.
+   * Nudge learners who have not yet completed Onboarding a week before the
+     first proctored exam.
 
 To set up Proctortrack onboarding for your course, follow these steps.
 
 #. Add and :ref:`develop a subsection <Developing Course Subsections>` as you
    would any other subsection.
 
-   #. Change the name to something clear to learners, like “Proctortrack Onboarding”.
+   #. Change the name to something clear to learners, like “Proctortrack
+      Onboarding”.
 
-   #. As in the note above, add instructions to learners, explaining why it is important to complete Onboarding early.
+   #. As in the note above, add instructions to learners, explaining why it is
+      important to complete Onboarding early.
 
-   #. Position the Onboarding subsection at an early stage in your course - we recommend positioning it in the first section.
-
+   #. Position the Onboarding subsection at an early stage in your course - we
+      recommend positioning it in the first section.
 
 #. Select the **Configure** icon for the subsection.
 
-#.  The **Settings** dialog box opens to the **Basic** tab.
+#. The **Settings** dialog box opens to the **Basic** tab.
 
 #. In the **Grading** section, set the :ref:`assignment type and due date<Set
    the Assignment Type and Due Date for a Subsection>` for the subsection.
@@ -68,7 +71,6 @@ To set up Proctortrack onboarding for your course, follow these steps.
 
 #. Select **Save**.
 
-*************************
 Creating a Proctored Exam
 *************************
 
@@ -103,7 +105,6 @@ Creating a Proctored Exam
 
 .. _specifying_pt_exam_rules_and_exceptions:
 
-*********************************
 Specify Exam Rules and Exceptions
 *********************************
 
@@ -114,20 +115,21 @@ steps.
 
 #. In the course outline, select **Proctoring Settings**.
 
-   The Verificient Proctortrack dashboard opens in a new browser window. Navigate to this window.
+   The Verificient Proctortrack dashboard opens in a new browser window.
+   Navigate to this window.
 
-#. (optional) Open the **Identify Verification** tab. Select the identity verification rules that you
-   want to enforce for the in-exam identity check and disable the rules that you do not want to enforce.
+#. (optional) Open the **Identify Verification** tab. Select the identity
+   verification rules that you want to enforce for the in-exam identity check
+   and disable the rules that you do not want to enforce.
 
-#. (optional) Open the **Test Settings** tab. Select
-   the rules that you want to enforce for the proctored exam and disable
-   the rules that you do not want to enforce.
+#. (optional) Open the **Test Settings** tab. Select the rules that you want to
+   enforce for the proctored exam and disable the rules that you do not want to
+   enforce.
 
 #. (optional) Open the **Student Settings** tab. Specify any per-learner special
-   exam exemptions and accommodations (Test Settings, Whitelist Url/Apps, or Special Notes
-   for custom student needs). This information will be sent over to the exam reviewers along
-   with the learner’s attempt.
-
+   exam exemptions and accommodations (Test Settings, Whitelist Url/Apps, or
+   Special Notes for custom student needs). This information will be sent over
+   to the exam reviewers along with the learner's attempt.
 
 .. seealso::
  :class: dropdown

--- a/source/educators/how-tos/proctored_exams/create_proctored_exam_rpnow.rst
+++ b/source/educators/how-tos/proctored_exams/create_proctored_exam_rpnow.rst
@@ -1,6 +1,5 @@
 .. _Create a Proctored Exam with RPNow:
 
-##################################
 Create a Proctored Exam with RPNow
 ##################################
 
@@ -11,14 +10,14 @@ exam or a practice exam using your choice of either RPNow or Proctortrack.
 To create a proctored exam or a practice proctored exam for RPNow, follow these
 steps.
 
-  .. note::
-    Practice proctored exams are visible to all learners, regardless of
-    enrollment track.
+.. note::
+   Practice proctored exams are visible to all learners, regardless of
+   enrollment track.
 
 #. Add and :ref:`develop a subsection <Developing Course Subsections>` as you
    would any other subsection.
 
-   For a practice proctored exam, edX recommends that you include only a few
+   For a practice proctored exam, it is recommended that you include only a few
    problems in this subsection. Or, you could add a unit with a text component
    that provides information about the exam.
 
@@ -52,20 +51,20 @@ steps.
    to allow for the exam as HH:MM, where HH is hours and MM is minutes.
 
 #. (optional) For a proctored exam, in the **Review Rules** field, enter any
-   additions or exceptions to the :ref:`default rules for proctored exams<Online Proctoring Rules>`. 
-   For more information, see :ref:`specifying_exam_rules_and_exceptions`.
+   additions or exceptions to the :ref:`default rules for proctored exams
+   <Online Proctoring Rules>`. For more information, see
+   :ref:`specifying_exam_rules_and_exceptions`.
 
 #. Select **Save**.
 
 .. _specifying_exam_rules_and_exceptions:
 
-*********************************
 Specify Exam Rules and Exceptions
 *********************************
 
 By default, reviewers evaluate exam attempts according to a standard set of
-:ref:`online proctoring rules <Online Proctoring Rules>` that the
-proctoring service has provided.
+:ref:`online proctoring rules <Online Proctoring Rules>` that the proctoring
+service has provided.
 
 .. note::
   The course grace period setting does not apply to proctored exams. For more
@@ -78,11 +77,10 @@ exam.
 
 To specify custom proctored exam rules, follow these steps.
 
-  .. note::
-
-    Your additional rules must be clear, specific, and easy to understand so
-    that reviewers do not incorrectly review a learner’s exam. Use simple
-    sentences and words for a global English speaking audience.
+.. note::
+   Your additional rules must be clear, specific, and easy to understand so
+   that reviewers do not incorrectly review a learner's exam. Use simple
+   sentences and words for a global English speaking audience.
 
 #. In Studio, open your course outline and select the subsection for the exam.
 

--- a/source/educators/how-tos/proctored_exams/enable_proctored_exams.rst
+++ b/source/educators/how-tos/proctored_exams/enable_proctored_exams.rst
@@ -1,8 +1,7 @@
 .. _Enable Proctored Exams:
 
-########################################
 Enable Proctored Exams
-########################################
+######################
 
 .. tags:: educator, how-to
 
@@ -21,10 +20,8 @@ To enable proctored exams in your course, follow these steps.
 
 #. Select **Submit**. You can now create proctored exams in your course.
 
-
-*****************************************
 Configuring Proctoring Provider
-*****************************************
+*******************************
 
 The choice of proctoring provider can be configured. Since Fall 2019,
 the default proctoring provider is **RPNow** by PSI.  To use

--- a/source/educators/how-tos/proctored_exams/manage_proctored_exams.rst
+++ b/source/educators/how-tos/proctored_exams/manage_proctored_exams.rst
@@ -1,23 +1,12 @@
 .. _Manage Proctored Exams:
 
-########################
 Manage Proctored Exams
-########################
+######################
 
 .. tags:: educator, how-to
 
-When you administer a proctored exam in your course, learners might have
-questions or concerns about the exam. Usually, you can direct learners to the
-FAQ section on edx.org or to `Taking Timed and Proctored Exams`_ in the edX
-Help Center to answer their questions.
-
-If learners need accommodations for disabilities, or have a technical problem
-with the exam, you work with edX support to determine a solution on a
-case by case basis.
-
 .. _Respond to Learner Concerns about Proctored Exams:
 
-**************************************
 Accommodate Learners with Disabilities
 **************************************
 
@@ -57,7 +46,6 @@ To make a special policy accommodation for learners, follow these steps.
 
    ``Learner has a disability. Allow one additional person in the room.``
 
-
 #. Select **Create Allowance**.
 
 When you have set up the allowance, let the learner know that their special
@@ -66,10 +54,8 @@ allowance has been granted.
 When the proctoring service reviews the learner’s proctored exam results, the
 reviewer takes the special allowance into account.
 
-
 .. _Resuming Proctored Exams in an Error State:
 
-******************************************
 Resuming Proctored Exams in an Error State
 ******************************************
 
@@ -81,10 +67,8 @@ The procedures for allowing learners to resume a proctored exam and a timed
 exam are the same. To allow learners to resume an exam, see :ref:`Resuming
 an Exam in an Error State`.
 
-
 .. _Requests for Retaking a Proctored Exam:
 
-******************************************
 Allow Learners to Retake a Proctored Exam
 ******************************************
 
@@ -95,21 +79,8 @@ The procedures for allowing learners to retake a proctored exam and a timed
 exam are the same. To allow learners to retake an exam, see :ref:`Allow
 Learners to Retake a Timed Exam`.
 
-
-.. _CA_Situations_Learners_Encounter_Proctored_Exams:
-
-*************************************************
-Manage Technical Problems During a Proctored Exam
-*************************************************
-
-For information about what learners should do if they experience technical
-problems during an exam, see `Technical problems during a proctored exam`_ in
-the edX Help Center.
-
-
 .. _View_Proctortrack_Onboarding_Status:
 
-***********************************
 View Proctortrack Onboarding Status
 ***********************************
 
@@ -156,10 +127,6 @@ To view learners' onboarding status for your course, follow these steps.
 
    #. **Error**: The learner encountered an error while taking the onboarding exam,
       and their attempt must be reset.
-
-      .. note::  Learners can self-service reset their onboarding exam. See
-         `Checking Your Onboarding Status and Resetting Your Onboarding Exam`_ in
-         the edX Help Center.
 
 .. seealso::
  :class: dropdown

--- a/source/educators/how-tos/proctored_exams/review_pt_results.rst
+++ b/source/educators/how-tos/proctored_exams/review_pt_results.rst
@@ -1,15 +1,14 @@
 .. _Review PT Proctored Session Results:
 
-###################################################
-Viewing Proctored Session Results with Proctortrack
-###################################################
+View Proctored Session Results with Proctortrack
+################################################
 
 .. tags:: educator, how-to
 
 To review individual violation videos and screenshots, follow these steps:
 
-#. In the LMS, open the Proctortrack Review Dashboard by navigating to the **edX Instructor Dashboard**
-   -> **Special Exams** tab -> **Review Dashboard**.
+#. In the LMS, open the Proctortrack Review Dashboard by navigating to the **Instructor Dashboard**
+   > **Special Exams** tab > **Review Dashboard**.
 
 #. The Verificient **Proctortrack Review Dashboard** will load inline in the LMS.
 
@@ -19,7 +18,7 @@ To review individual violation videos and screenshots, follow these steps:
 
 #. Review all learners who are flagged as “Require Attention” as follows.
 
-#. To review an individual learner’s session, click on the learner’s name to pop out
+#. To review an individual learner's session, click on the learner's name to pop out
    their detailed exam results in a new tab. Here you can review their exam data, including Video
    Monitoring, Online Violations, Verification scans, and Onboarding tabs to understand what infractions
    (if any) were flagged as suspicious
@@ -53,9 +52,8 @@ sections.
 
 .. _Viewing PT Proctored Session Results:
 
-*********************************************
 Download the Proctored Exam Results Report
-*********************************************
+******************************************
 
 At any time after learners have taken the proctored exam in your course, you
 can download a .csv file that displays the current status of the proctoring
@@ -106,7 +104,6 @@ steps.
 
 .. _Determine if Learner Passed Proctoring Review:
 
-*******************************************************
 Determine if a Learner Passed the Proctored Exam Review
 *******************************************************
 
@@ -114,7 +111,6 @@ To determine whether a specific learner passed the proctored exam review, you
 can either view the Proctored Session Results report or view the course as the
 learner.
 
-=========================================
 View the Proctored Session Results Report
 =========================================
 
@@ -126,7 +122,6 @@ View the Proctored Session Results Report
      learner automatically receives a score of 0 on the exam. Additionally, for
      most courses, the learner is no longer eligible for academic credit.
 
-==============================
 View the Course as the Learner
 ==============================
 

--- a/source/educators/how-tos/proctored_exams/review_rpnow_results.rst
+++ b/source/educators/how-tos/proctored_exams/review_rpnow_results.rst
@@ -1,8 +1,7 @@
 .. _Review RP Proctored Session Results:
 
-############################################
-Viewing Proctored Session Results with RPNow
-############################################
+View Proctored Session Results with RPNow
+#########################################
 
 .. tags:: educator, how-to
 
@@ -27,7 +26,6 @@ sections.
 
 .. _Viewing RPNow Proctored Session Results:
 
-*********************************************
 Download the Proctored Exam Results Report
 *********************************************
 
@@ -81,7 +79,6 @@ steps.
 
 .. _Determine if Learner Passed RPNow Proctoring Review:
 
-*******************************************************
 Determine if a Learner Passed the Proctored Exam Review
 *******************************************************
 
@@ -89,7 +86,6 @@ To determine whether a specific learner passed the proctored exam review, you
 can either view the Proctored Session Results report or view the course as the
 learner.
 
-=========================================
 View the Proctored Session Results Report
 =========================================
 
@@ -101,7 +97,6 @@ View the Proctored Session Results Report
      learner automatically receives a score of 0 on the exam. Additionally, for
      most courses, the learner is no longer eligible for academic credit.
 
-==============================
 View the Course as the Learner
 ==============================
 


### PR DESCRIPTION
This PR modifies a series of how-to documents migrated from the legacy repositories to the educators' documentation.

The updated files were:
- `create_problem_in_latex.rst`
- `create_problem_with_hint.rst`
- `create_protein_builder.rst`
- `allow_opt_out_proctored_exam.rst`
- `create_proctored_exam_pt.rst`
- `create_proctored_exam_rpnow.rst`
- `enable_proctored_exams.rst`
- `manage_proctored_exams.rst`
- `review_pt_results.rst`
- `review_rpnow_results.rst`