### PR TITLE
FC-0068 docs: how-to cleaning by edunext #19

### DIFF
--- a/source/educators/how-tos/add_dropdown.rst
+++ b/source/educators/how-tos/add_dropdown.rst
@@ -1,3 +1,5 @@
+.. _Add a Dropdown Problem:
+
 Add a Dropdown Problem
 ######################
 
@@ -6,3 +8,20 @@ Add a Dropdown Problem
 This video explains how to add a dropdown-type problem:
 
 .. youtube:: e6HxKo18_xE
+
+.. seealso::
+  :class: dropdown
+
+  :ref:`Single Select Overview` (concept)
+
+  :ref:`Multiple Choice` (reference)
+
+  :ref:`Single Select` (how-to)
+
+  :ref:`Awarding Partial Credit in a Multiple Choice Problem` (how-to)
+
+  :ref:`Editing Single Select Problems using the Advanced Editor` (how-to)
+
+  :ref:`Single Select Problem XML` (reference)
+
+  :ref:`Add a Multiple Choice Problem` (how-to)

--- a/source/educators/how-tos/add_dropdown.rst
+++ b/source/educators/how-tos/add_dropdown.rst
@@ -12,16 +12,10 @@ This video explains how to add a dropdown-type problem:
 .. seealso::
   :class: dropdown
 
-  :ref:`Single Select Overview` (concept)
+  :ref:`Dropdown` (reference)
 
-  :ref:`Multiple Choice` (reference)
+  :ref:`Dropdown Problem XML` (reference)
 
-  :ref:`Single Select` (how-to)
+  :ref:`Use Hints in a Dropdown Problem` (how-to)
 
-  :ref:`Awarding Partial Credit in a Multiple Choice Problem` (how-to)
-
-  :ref:`Editing Single Select Problems using the Advanced Editor` (how-to)
-
-  :ref:`Single Select Problem XML` (reference)
-
-  :ref:`Add a Multiple Choice Problem` (how-to)
+  :ref:`Use Feedback in a Dropdown Problem` (how-to)

--- a/source/educators/how-tos/add_multiple_choice.rst
+++ b/source/educators/how-tos/add_multiple_choice.rst
@@ -1,3 +1,5 @@
+.. _Add a Multiple Choice Problem:
+
 Add a Multiple Choice Problem
 #############################
 

--- a/source/educators/how-tos/course_development/exercise_tools/add_recommenderXBlock.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/add_recommenderXBlock.rst
@@ -1,8 +1,7 @@
 .. _RecommenderXBlock:
 
-##################
 Recommender Tool
-##################
+################
 
 .. tags:: educator, how-to
 
@@ -14,9 +13,8 @@ and the learners.
   :local:
   :depth: 2
 
-***********
 Overview
-***********
+********
 
 The most common use of the recommender is for remediation of errors and
 misconceptions, followed by providing additional, more advanced resources.
@@ -54,9 +52,8 @@ assure that they are accessible before making them available through your
 course. For more information, see :ref:`Accessibility Best Practices for Course
 Content Development`.
 
-**************************************************
 Enable the Recommender Tool
-**************************************************
+***************************
 
 Before you can add a recommender component to your course, you must enable the
 recommender tool in Studio.
@@ -66,9 +63,8 @@ the **Advanced Module List** on the **Advanced Settings** page. (Be sure to
 include the quotation marks around the key value.) For more information, see
 :ref:`Enable Additional Exercises and Tools`.
 
-********************************
 Add a Recommender
-********************************
+*****************
 
 To add a recommender to a course, follow these steps.
 
@@ -87,8 +83,9 @@ To add a recommender to a course, follow these steps.
      sees the recommender, there will be a short guided tutorial.
 
    * Whether to disable the user interface functions which are under
-     development. Because these are untested and under development, please leave
-     these disabled unless otherwise advised by edX staff.
+     development. Because these are untested and under development, please
+     leave these disabled unless your Open edX instance requieres another
+     settings.
 
    * How many resources you want to show in each page of the resource list.
 
@@ -99,3 +96,14 @@ To add a recommender to a course, follow these steps.
 #. Select **Save**.
 
 #. Optionally, open the unit in the LMS and suggest some resources.
+
+.. seealso::
+ :class: dropdown
+
+ :ref:`Notes Tool` (how-to)
+
+ :ref:`Annotation` (how-to)
+
+ :ref:`Calculator` (how-to)
+
+ :ref:`Enable Completion` (how-to)

--- a/source/educators/how-tos/course_development/exercise_tools/add_single_select.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/add_single_select.rst
@@ -1,22 +1,9 @@
 .. _Single Select:
 
-#####################
-Single Select Problem
-#####################
+Add a Single Select Problem
+###########################
 
 .. tags:: educator, how-to
-
-The single select problem type is a simple problem type that can be added to
-any course. At a minimum, single select problems include a question or
-prompt and several answer options. By adding hints, feedback, or both, you can
-give learners guidance and help when they work on a problem.
-
-For more information about the simple problem types, see
-:ref:`Working with Problem Components`.
-
-******************************
-Adding a Single Select Problem
-******************************
 
 You add single select problems in Studio by selecting the **Problem**
 component. In the problem editor, select the **Single select** option.
@@ -43,17 +30,14 @@ Creating a single select problem is as simple as:
 If you have any questions on the specifics of using the simple editor, please check
 out :ref:`Simple Editor` and :ref:`Problem Settings`.
 
-Note
-
 .. note:: With the single select problem type, although the learner only selects
   one answer, you can set more than one correct answer. You can do this by ticking
   more than one of the checkboxes in the Answers section.
 
 .. _Use Feedback in a Single Select Problem:
 
-===============
 Adding Feedback
-===============
+***************
 
 For an overview of feedback in problems, see :ref:`Adding Feedback and Hints to
 a Problem`. You can add feedback for each of the answer options you provide in
@@ -84,9 +68,8 @@ learner submits this answer.
 
 .. _Use Hints in a Single Select Problem:
 
-============
 Adding Hints
-============
+************
 
 You can add hints to a single select problem . For an overview of hints in
 problems, see :ref:`Adding Feedback and Hints to a Problem`.
@@ -98,6 +81,6 @@ problems, see :ref:`Adding Feedback and Hints to a Problem`.
 
  :ref:`Single Select Problem XML` (reference)
 
- :ref:`Awarding Partial Credit in a Multiple Choice Problem` (how to)
+ :ref:`Awarding Partial Credit in a Multiple Choice Problem` (how-to)
 
- :ref:`Editing Single Select Problems using the Advanced Editor` (how to)
+ :ref:`Editing Single Select Problems using the Advanced Editor` (how-to)

--- a/source/educators/how-tos/course_development/exercise_tools/add_single_select_num_input.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/add_single_select_num_input.rst
@@ -56,7 +56,7 @@ Single Select and Numerical Input Problem Code
 
  :ref:`Numerical Input` (reference)
 
- :ref:`Adding Numerical Input Problems` (how-to)
+ :ref:`Adding Numerical Input Problem` (how-to)
 
  :ref:`Single Select Overview` (concept)
 

--- a/source/educators/how-tos/course_development/exercise_tools/add_single_select_num_input.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/add_single_select_num_input.rst
@@ -1,7 +1,7 @@
 .. _Single Select and Numerical Input:
 
-Single Select and Numerical Input Problem
-#########################################
+Add a Single Select and Numerical Input Problem
+###############################################
 
 .. tags:: educator, how-to
 

--- a/source/educators/how-tos/course_development/exercise_tools/add_single_select_num_input.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/add_single_select_num_input.rst
@@ -1,8 +1,7 @@
 .. _Single Select and Numerical Input:
 
-############################################
 Single Select and Numerical Input Problem
-############################################
+#########################################
 
 .. tags:: educator, how-to
 
@@ -16,31 +15,29 @@ but also provide more specific information, if necessary.
 .. note::
  Currently, students can only enter numerals in the text field. Students
  cannot enter words or mathematical expressions, which might be confusing to
- students who are accustomed to other edX numerical input fields.
+ students who are accustomed to other Open edX numerical input fields.
 
  You can make a calculator available to your learners on every unit
  page. For more information, see :ref:`Calculator`.
 
 .. _Create an MCNI Problem:
 
-********************************************************
 Create a Single Select and Numerical Input Problem
-********************************************************
+**************************************************
 
 To create a single select and numerical input problem, follow these steps.
 
 #. In the unit where you want to create the problem, click **Problem** under
    **Add New Component**.
-#. Clicke ** Advanced problem types**. Then click **Blank Advanced Problem**.
+#. Click in **Advanced problem types**. Then click **Blank Advanced Problem**.
 #. In the component editor, paste the code from below.
 #. Replace the example problem and response options with your own text.
 #. Click **Save**.
 
 .. _MCNI Problem Code:
 
-************************************************
 Single Select and Numerical Input Problem Code
-************************************************
+**********************************************
 
 .. code-block:: xml
 
@@ -53,3 +50,14 @@ Single Select and Numerical Input Problem Code
       </radiotextgroup>
     </choicetextresponse>
   </problem>
+
+.. seealso::
+ :class: dropdown
+
+ :ref:`Numerical Input` (reference)
+
+ :ref:`Adding Numerical Input Problems` (how-to)
+
+ :ref:`Single Select Overview` (concept)
+
+ :ref:`Single Select` (how-to)

--- a/source/educators/how-tos/course_development/exercise_tools/award_partial_credit_multiple_choice.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/award_partial_credit_multiple_choice.rst
@@ -1,14 +1,12 @@
 .. _Awarding Partial Credit in a Multiple Choice Problem:
 
-=======================
-Awarding Partial Credit
-=======================
+Award Partial Credit in a Multiple Choice Problem
+#################################################
 
 .. tags:: educator, how-to
 
 You can configure a single select problem so that specific incorrect answers
 award learners partial credit for the problem.
-
 
 In the following example, the learner selected a wrong answer and received
 partial credit.
@@ -59,9 +57,8 @@ provides partial credit of 25% for an answer option.
 
 .. _Shuffle Answers in a Single Select Problem:
 
-===============
 Shuffle Answers
-===============
+***************
 
 Optionally, you can configure a single select problem so that it shuffles
 the order of possible answers.
@@ -123,9 +120,8 @@ Then, you select **Settings** to specify an option other than **Never** for the
 
 .. _Answer Pools in a Single Select Problem:
 
-============
 Answer Pools
-============
+************
 
 You can configure a single select problem so that a random subset of choices
 are shown to each learner. For example, you can add 10 possible choices to the
@@ -202,8 +198,8 @@ explanation ID.
 
  :ref:`Single Select Overview` (concept)
 
- :ref:`Single Select` (how to)
+ :ref:`Single Select` (how-to)
 
  :ref:`Single Select Problem XML` (reference)
 
- :ref:`Editing Single Select Problems using the Advanced Editor` (how to)
+ :ref:`Editing Single Select Problems using the Advanced Editor` (how-to)

--- a/source/educators/how-tos/course_development/exercise_tools/edit_single_select_advanced.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/edit_single_select_advanced.rst
@@ -1,8 +1,7 @@
 .. _Editing Single Select Problems using the Advanced Editor:
 
-********************************************************
 Editing Single Select Problems using the Advanced Editor
-********************************************************
+########################################################
 
 .. tags:: educator, how-to
 
@@ -53,9 +52,8 @@ You can see the OLX for the example problem from the Overview section below.
   changes you make in the advanced editor, you may not be able to cannot
   switch back to the simple editor.
 
-===============
 Adding Feedback
-===============
+***************
 
 In the advanced editor, you configure feedback with the following syntax.
 
@@ -97,9 +95,8 @@ For example, the following problem has feedback for each answer.
 
 .. _Targeted Feedback in a Single Select Problem:
 
------------------
 Targeted Feedback
------------------
+=================
 
 You can configure a single select problem so that explanations for specific
 answers are automatically shown to learners. You can use these explanations to
@@ -175,9 +172,8 @@ targeted feedback.
     </targetedfeedbackset>
   </problem>
 
-============
 Adding Hints
-============
+************
 
 You can add hints to a single select problem . For an overview of hints in
 problems, see :ref:`Adding Feedback and Hints to a Problem`.
@@ -187,8 +183,8 @@ problems, see :ref:`Adding Feedback and Hints to a Problem`.
 
  :ref:`Single Select Overview` (concept)
 
- :ref:`Single Select` (how to)
+ :ref:`Single Select` (how-to)
 
  :ref:`Single Select Problem XML` (reference)
 
- :ref:`Awarding Partial Credit in a Multiple Choice Problem` (how to)
+ :ref:`Awarding Partial Credit in a Multiple Choice Problem` (how-to)

--- a/source/educators/how-tos/course_development/exercise_tools/edit_single_select_advanced.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/edit_single_select_advanced.rst
@@ -1,7 +1,7 @@
 .. _Editing Single Select Problems using the Advanced Editor:
 
-Editing Single Select Problems using the Advanced Editor
-########################################################
+Edit Single Select Problems using the Advanced Editor
+#####################################################
 
 .. tags:: educator, how-to
 

--- a/source/educators/how-tos/course_development/exercise_tools/use_randomized_content_blocks.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/use_randomized_content_blocks.rst
@@ -1,10 +1,7 @@
 .. _Use Randomized Content Blocks:
 
-.. _Use Components from Libraries in a Course:
-
-*****************************************
-Use Components from Libraries in a Course
-*****************************************
+Use Randomized Content Blocks
+#############################
 
 .. tags:: educator, how-to
 
@@ -39,9 +36,8 @@ these topics.
 
 .. _Enable Content Libraries:
 
-************************************************
 Enable Content Libraries
-************************************************
+************************
 
 Before you can add a randomized content blocks to your course, you must enable
 the content library tool in Studio.
@@ -52,9 +48,8 @@ information, see :ref:`Enable Additional Exercises and Tools`.
 
 .. _Add a Randomized Content Block to Your Course:
 
-=============================================
 Add a Randomized Content Block to Your Course
-=============================================
+*********************************************
 
 After you :ref:`enable content libraries<Enable Content Libraries>` you can add
 library content to your courses using the Randomized Content Block advanced
@@ -68,31 +63,30 @@ component.
 #. In the unit where you want to add a set of randomized problems, select **Add
    New Component**
 
-#. Select **Advanced**, and then select **Randomized Content Block**.
-
-   The randomized content block is added to your unit.
+#. Select **Advanced**, and then select **Randomized Content Block**. The
+   randomized content block is added to your unit.
 
 #. Select **Edit**.
 
 #. In the randomized content block settings, specify the details of the content
    you want to add in this block.
 
-  - For **Count**, enter the number of problems to display to each student.
+   - For **Count**, enter the number of problems to display to each student.
 
-  - For **Display Name**, enter the name that you want students to see for this
-    block.
+   - For **Display Name**, enter the name that you want students to see for
+     this block.
 
-  - For **Library**, select the library from which you want to draw problems.
+   - For **Library**, select the library from which you want to draw problems.
 
-  - For **Problem Type**, from the drop down list select a specific type of
-    problem to be drawn from the library. Select **Any Type** if you do not
-    want to specify a particular type of problem.
+   - For **Problem Type**, from the drop down list select a specific type of
+     problem to be drawn from the library. Select **Any Type** if you do not
+     want to specify a particular type of problem.
 
-    .. image:: /_images/educator_how_tos/ContentLibraries_RCBSelectProblemType.png
-     :alt: Problem type dropdown list in randomized content block settings.
+     .. image:: /_images/educator_how_tos/ContentLibraries_RCBSelectProblemType.png
+      :alt: Problem type dropdown list in randomized content block settings.
 
-  - For **Scored**, from the drop down list select **True** or **False** to
-    indicate whether the assignment should be graded.
+   - For **Scored**, from the drop down list select **True** or **False** to
+     indicate whether the assignment should be graded.
 
    .. note:: Grading is subject to the setting of this unit's subsection. If the
       subsection is not graded, selecting **True** here has no impact. If the
@@ -111,9 +105,8 @@ Contents of a Library`.
 
 .. _View the Matching Components in a Randomized Content Block:
 
-***********************************************************
 View the Matching Components in a Randomized Content Block
-***********************************************************
+==========================================================
 
 In a unit that uses a randomized content block, you can view the list of all
 components that match the filters specified in that block.
@@ -128,7 +121,6 @@ student.
    references your library.
 
 #. In the randomized content block, select **View**.
-
 
    .. image:: /_images/educator_how_tos/ContentLibraries_ViewMatching.png
       :alt: The View button for a randomized content block
@@ -145,9 +137,8 @@ To view the randomized content that was assigned to a specific learner, see
 
 .. _Edit Components in Randomized Content Blocks:
 
-******************************************************
 Editing Components in Randomized Content Blocks
-******************************************************
+===============================================
 
 In Studio, in the course unit that uses a randomized content block, you can
 edit each component within the randomized content block in the same way as you
@@ -178,9 +169,8 @@ Select **Clear** to restore the library default setting for that field.
 
 .. _Get the Latest Version of Library Content:
 
-*********************************************
 Getting the Latest Version of Library Content
-*********************************************
+=============================================
 
 If you modify the contents of a library that is referenced by randomized
 content blocks in one or more courses, those courses do not automatically use
@@ -235,9 +225,8 @@ with the version in the library.
 
 .. _Preview Randomized Content in Student View:
 
-***********************************************
 Preview the Randomized Content in Student View
-***********************************************
+==============================================
 
 You can preview course content before a course is live or before you publish
 specific units, to test how content will appear to students when it is
@@ -245,23 +234,19 @@ released. To view the number and type of components from a randomized content
 block as students would see them, follow the steps described in the
 :ref:`Preview a Unit` topic.
 
-
 .. _View Specific Student Assigned Problems from Randomized Content Block:
 
-***************************************************************************
 View a Specific Student's Assigned Problems from a Randomized Content Block
-***************************************************************************
+===========================================================================
 
 In a live course, to view the components that are assigned to a specific
 student from a randomized content block, follow the steps described in the
 :ref:`Specific Student View` topic.
 
-
 .. _Adjust Grades for a Problem from a Randomized Content Block:
 
-***********************************************************
 Adjust Grades for a Problem from a Randomized Content Block
-***********************************************************
+===========================================================
 
 To adjust a grade or reset the attempts for a problem that was assigned from a
 randomized content block, you can view the course as a specific student to


### PR DESCRIPTION
This PR modifies a series of how-to documents migrated from the legacy repositories to the educators' documentation.

The updated files were:
- `add_dropdown.rst`
- `add_multiple_choice.rst`
- `add_recommenderXBlock.rst`
- `add_single_select.rst`
- `add_single_select_num_input.rst`
- `award_partial_credit_multiple_choice.rst`
- `edit_single_select_advanced.rst`
- `use_randomized_content_blocks.rst`