### PR TITLE
Fix seealso tables and :ref: links

### DIFF
--- a/source/educators/how-tos/add_update_full_profile.rst
+++ b/source/educators/how-tos/add_update_full_profile.rst
@@ -6,7 +6,7 @@ Add or Update a Full Profile
 
 .. note:: You must specify your year of birth on the **Account Settings** page
    before you can share a full profile. If you are under 13 years of age, you
-   can share only a `Create or Edit a Limited Profile`_.
+   can share only a Limited Profile.
 
 If you create a full profile, you share the following information in
 addition to your username and profile image.
@@ -60,10 +60,14 @@ The site saves your changes automatically.
    saved, and becomes visible again to other learners and course teams if you
    change your profile back to **Full Profile**.
 
+
 .. seealso::
  :class: dropdown
 
  :doc:`what_is_profile_page <../concepts/open_edx_platform/what_is_profile_page>` (concept)
+
  :doc:`add_update_limited_profile` (how-to)
+
  :doc:`add_links_to_social_media_accounts` (how-to)
+
  :doc:`view_another_learners_profile` (how-to)

--- a/source/educators/how-tos/content-tagging-how-tos/add_delete_tags_course_content.rst
+++ b/source/educators/how-tos/content-tagging-how-tos/add_delete_tags_course_content.rst
@@ -1,3 +1,5 @@
+.. _Add and delete tags on course content:
+
 Add and delete tags on course content
 #####################################
 

--- a/source/educators/how-tos/content-tagging-how-tos/build_taxonomy_using_template.rst
+++ b/source/educators/how-tos/content-tagging-how-tos/build_taxonomy_using_template.rst
@@ -63,7 +63,9 @@ create a taxonomy of cities, like this:
 
   For a tag like “United States” which is a “root” tag in the taxonomy, we leave “parent_id” empty. We can also leave “comments” empty.
 
-  **Choosing an ID:** The “id” column is required, but its exact value is not particularly important at this stage. The main requirement is that each row (each tag) has a unique ID. (Though remember that the “values” of each row also must be unique.) For learning purposes, feel free to use numbers like 1, 2, 3, 4 as the IDs. You could also just make the “id” the same as the “value” (i.e. put “United States” as both the ID and the value), or make up a short ID like “USA”. To understand more, and learn how IDs play an important role when updating the taxonomy, please read `Concept: Why does each tag need an ID when importing a taxonomy? <https://openedx.atlassian.net/l/cp/U1i001z1>`_.
+  **Choosing an ID:** The “id” column is required, but its exact value is not particularly important at this stage. The main requirement is that each row (each tag) has a unique ID. (Though remember that the “values” of each row also must be unique.) For learning purposes, feel free to use numbers like 1, 2, 3, 4 as the IDs. You could also just make the “id” the same as the “value” (i.e. put “United States” as both the ID and the value), or make up a short ID like “USA”. To understand more, and learn how IDs play an important role when updating the taxonomy, please read :ref:`tag-ids-for-taxonomy-import`
+
+  
 
 3. Creating "child" tags
 ************************
@@ -104,18 +106,18 @@ create a taxonomy of cities, like this:
 .. seealso::
  :class: dropdown
 
- :ref: `Add and delete tags on courses` (how-to)
+ :ref:`Add and delete tags on course content` (how-to)
 
- :ref: `Create a flat taxonomy by uploading a CSV` (how-to) 
+ :ref:`add-tags-to-a-course` (how-to)
 
- :ref: `Import and export a taxonomy` (how-to)
+ :ref:`create-flat-taxonomy` (how-to) 
 
- :ref: `Update/Re-import a taxonomy` (how-to)
+ :ref:`import-export-taxonomy` (how-to)
 
- :ref: `Why does each tag need an ID when importing a taxonomy?` (concept)
+ :ref:`Update/Re-import a taxonomy` (how-to)
+
+ :ref:`tag-ids-for-taxonomy-import` (concept)
  
- :ref: `Manage Permissions on a Taxonomy` (how-to)
+ :ref:`Manage Permissions on a Taxonomy` (how-to) 
 
- :ref: `Add and delete tags on courses` (how-to)
-
- :ref: `Export tag data from a course` (how-to)
+ :ref:`Export tag data from a course` (how-to)

--- a/source/educators/how-tos/content-tagging-how-tos/export_tag_data_from_course.rst
+++ b/source/educators/how-tos/content-tagging-how-tos/export_tag_data_from_course.rst
@@ -1,4 +1,5 @@
-#############################
+.. _Export tag data from a course:
+
 Export tag data from a course
 #############################
 

--- a/source/educators/how-tos/content-tagging-how-tos/manage_permissions_taxonomy.rst
+++ b/source/educators/how-tos/content-tagging-how-tos/manage_permissions_taxonomy.rst
@@ -1,3 +1,5 @@
+.. _Manage Permissions on a Taxonomy:
+
 Manage Permissions on a Taxonomy
 ################################
 

--- a/source/educators/how-tos/content-tagging-how-tos/update_reimport_taxonomy.rst
+++ b/source/educators/how-tos/content-tagging-how-tos/update_reimport_taxonomy.rst
@@ -1,3 +1,5 @@
+.. _Update/Re-import a taxonomy:
+
 Update/Re-import a taxonomy
 ###########################
 

--- a/source/educators/how-tos/course_development/exercise_tools/add_calculator.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/add_calculator.rst
@@ -59,6 +59,15 @@ To enable the calculator tool, follow these steps.
 .. seealso::
  :class: dropdown
 
- :ref: `Annotation Problem` (how-to)
-
  :ref:`Chemical Equation` (how-to)
+
+ :ref:`Notes Tool` (how-to)
+
+ :ref:`RecommenderXBlock` (how-to)
+
+ :ref:`Annotation` (how-to)
+
+ :ref:`Enable Completion` (how-to)
+
+
+

--- a/source/educators/how-tos/update_rerun_course.rst
+++ b/source/educators/how-tos/update_rerun_course.rst
@@ -70,9 +70,6 @@ who enroll in the new course run.
   input, or math expression input problems, review the
   :ref:`Markdown-style formatting <Simple Editor>` or :ref:`OLX markup
   <Advanced Editor>` of any problems created before September 2016.
-  For more information about the updates that you can make to improve the
-  accessibility of these problem types, see the `Release Notes
-  <http://edx.readthedocs.io/projects/edx-release-notes/en/latest/studio_index.html#updates-to-capa-problem-types>`_.
 
 * If your course uses prerequisite course subsections to hide course
   subsections until learners complete other, prerequisite subsections,

--- a/source/educators/how-tos/use_section_independently_of_course_outline.rst
+++ b/source/educators/how-tos/use_section_independently_of_course_outline.rst
@@ -1,4 +1,5 @@
-###############################################################
+.. _Use a Section from a Course independently of the Course Outline:
+
 Use a Section from a Course independently of the Course Outline
 ###############################################################
 

--- a/source/educators/references/resources_for_course_teams.rst
+++ b/source/educators/references/resources_for_course_teams.rst
@@ -14,14 +14,10 @@ on an Open edX site.
  :local:
  :depth: 1
 
-Open edX Demo Course
-====================
 
-The `Open edX Demo Course <https://sandbox.openedx.org/courses/course-v1:OpenedX+01-2024+2024-1/about>`_ course is designed to discuss the tools and features that you can leverage in your learning program. After providing details about the platform, the course shows the different types of content that can be created, showcase the variety of assessment tools, and explore the different ways that you can engage your learners with social interactions.
-
-*************
+#############
 Documentation
-*************
+#############
 
 Documentation for course teams is available from the docs.openedx.org web page.
 

--- a/source/educators/references/resources_for_course_teams.rst
+++ b/source/educators/references/resources_for_course_teams.rst
@@ -1,6 +1,5 @@
 .. _Resources for Open edX Course Teams: 
 
-####################################
 Resources for Open edX Course Teams
 ####################################
 
@@ -14,10 +13,14 @@ on an Open edX site.
  :local:
  :depth: 1
 
+Open edX Demo Course
+********************
 
-#############
+The `Open edX Demo Course <https://sandbox.openedx.org/courses/course-v1:OpenedX+01-2024+2024-1/about>`_ course is designed to discuss the tools and features that you can leverage in your learning program. After providing details about the platform, the course shows the different types of content that can be created, showcase the variety of assessment tools, and explore the different ways that you can engage your learners with social interactions.
+
+
 Documentation
-#############
+*************
 
 Documentation for course teams is available from the docs.openedx.org web page.
 
@@ -37,48 +40,46 @@ a PDF version, select **v: latest** at the lower right of the page, then select
  search feature for the HTML versions of the Open edX guides. This is a known
  limitation.
 
-*******************
+
 Wikis and Web Sites
 *******************
 
-The Open edX product team maintains public product roadmaps at this `public roadmap <https://github.com/orgs/openedx/projects/4>`_and, you can get involved with defining the roadmap by joining the `Product Working Group <https://openedx.atlassian.net/wiki/spaces/OEPM/overview>`_.
+The Open edX product team maintains public product roadmaps at this `public roadmap <https://github.com/orgs/openedx/projects/4>`_ and you can get involved with defining the roadmap by joining the `Product Working Group <https://openedx.atlassian.net/wiki/spaces/OEPM/overview>`_.
 
 
 .. seealso::
  :class: dropdown
 
- :ref: `Course Outline` (concept)
+ :ref:`Course Outline` (concept)
 
- :ref: `Creating a New Course in Studio` (how-to)
+ :ref:`Creating a New Course in Studio <Creating a New Course>` (how-to)
 
- :ref: `Create a New Course Screen` (quick start)
+ :ref:`Quick Start Build a Course` (quick start)
 
- :ref: `Create the Course About Page` (how-to)
+ :ref:`Create the Course About Page` (how-to)
 
- :ref: `Understanding a Course Outline` (reference)
+ :ref:`Understanding a Course Outline <Understanding Your Course Outline>` (reference)
 
- :ref: `Add Content in the Course Outline` (reference)
+ :ref:`Add Content in the Course Outline` (reference)
 
- :ref: `Developing Your Course Outline` (reference)
+ :ref:`Developing Your Course Outline` (reference)
 
- :ref: `Modify Settings for Objects in the Course Outline` (reference)
+ :ref:`Modify Settings for Objects in the Course Outline` (reference)
 
- :ref: `Publish Content from the Course Outline` (reference)
+ :ref:`Publish Content from the Course Outline` (reference)
 
- :ref: `Developing Course Sections` (reference)
+ :ref:`Developing Course Sections` (reference)
 
- :ref: `Developing Course Subsections` (reference)
+ :ref:`Developing Course Subsections` (reference)
 
- :ref: `Create a Section` (how-to)
+ :ref:`Create a Section` (how-to)
 
- :ref: `Create a Subsection` (how-to)
+ :ref:`Create a Subsection` (how-to)
 
- :ref: `Create a Section` (how-to)
+ :ref:`Add Course Metadata` (how-to)
 
- :ref: `Add Course Metadata` (how-to)
+ :ref:`Use a Section from a Course independently of the Course Outline` (how-to)
 
- :ref: `Use a Section from a Course independently of the Course Outline` (how-to)
+ :ref:`Hiding a Subsection from Learners  <Hide a Subsection from Students>` (how-to)
 
- :ref: `Hiding a Subsection from Learners` (how-to)
-
- :ref: `Resources for Open edX` (reference)
+ :ref:`Resources for Open edX` (reference)


### PR DESCRIPTION
* Fixes `:ref:` links that had spaces, which broke the reference
* Adds targets to titles in various files, so we can use the `:ref:` directive
* Remove duplicate reference links
* Adjusts headings