### PR TITLE
Remove `:class: dropdown` from tables as it is unnecessary

### DIFF
--- a/source/documentors/references/doc_checklist.rst
+++ b/source/documentors/references/doc_checklist.rst
@@ -84,7 +84,7 @@ Then referenced in topics as:
   `Link Name_`
 
 .. note::
- :class: dropdown
+ 
 
  Each ``Link Name`` in the entire documentation project must be unique.
 
@@ -96,7 +96,7 @@ Then referenced in topics as:
 .. code-block:: RST
 
   .. seealso::
-  :class: dropdown
+  
 
     :ref:`Offering Differentiated Content` (concept)
     :ref:`Configure Your Course for Content Experiments` (how-to)

--- a/source/documentors/references/doc_guidelines.rst
+++ b/source/documentors/references/doc_guidelines.rst
@@ -15,7 +15,7 @@ Anyone can propose updates to the documentation, following a process known as th
 The Open edX team will review the proposed changes, collaborate with the author, and merge the documentation when it is ready. You will then see it on the `Open edX Documentation`_ site.
 
 .. note:: Create a GitHub Account
-   :class: dropdown
+   
 
     .. include:: ../how-tos/reusable_content/create_github_account.txt
 

--- a/source/documentors/references/doc_style_guide.rst
+++ b/source/documentors/references/doc_style_guide.rst
@@ -301,7 +301,7 @@ This directive is useful for referencing other documents related to the topic th
 Additionally, “See Also Tables” is an important way for users to find documents related to the topic they are exploring. Good docs will have thorough, accurate, and relevant links in the See Also section through this syntax.
 
 .. seealso::
-    :class: dropdown
+    
 
     :ref:`Offering Differentiated Content` (concept)
     

--- a/source/documentors/references/quick_reference_rst.rst
+++ b/source/documentors/references/quick_reference_rst.rst
@@ -10,12 +10,12 @@ Headings
 .. include:: ../references/rst_samples/headings.txt
 
 .. tip::
-   :class: dropdown
+   
 
    Here's a way to remember the symbols for heading levels: ``#`` has four lines, ``*`` has three lines, ``=`` has two lines, ``-`` has one line, and ``~`` has zero lines.
 
 .. note::
-   :class: dropdown
+   
 
    RST allows you to use almost any symbol to underline headings as long as you're consistent between heading levels. However, the abovementioned way is how headings should be defined in all Open edX documentation.
 

--- a/source/educators/concepts/accessibility/accessibility_guidelines.rst
+++ b/source/educators/concepts/accessibility/accessibility_guidelines.rst
@@ -34,7 +34,7 @@ For more information, see the following topics.
 * :ref:`Accessibility Best Practices for Course Content Development`
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Accessibility Best Practices for Course Content Development` (concept)
 

--- a/source/educators/concepts/accessibility/best_practices_course_content_dev.rst
+++ b/source/educators/concepts/accessibility/best_practices_course_content_dev.rst
@@ -1042,7 +1042,7 @@ Universal Design for Learning Resources
 * `The National Center on Universal Design for Learning <https://udlguidelines.cast.org/>`_ provides a helpful overview on Universal Design for Learning.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Accessibility Guidelines` (concept)
 

--- a/source/educators/concepts/accessibility/design_for_mobile.rst
+++ b/source/educators/concepts/accessibility/design_for_mobile.rst
@@ -100,7 +100,7 @@ renders as you expect it to.
    published content can take up to an hour to update on the Android app.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Accessibility Best Practices for Course Content Development` (concept)
 

--- a/source/educators/concepts/accessibility/supporting_learners_diverse_needs.rst
+++ b/source/educators/concepts/accessibility/supporting_learners_diverse_needs.rst
@@ -81,7 +81,7 @@ you will quickly see how important it is to address accessibility concerns
 when creating a course.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Accessibility Best Practices for Course Content Development` (concept)
 

--- a/source/educators/concepts/advanced_features/cohorts_overview.rst
+++ b/source/educators/concepts/advanced_features/cohorts_overview.rst
@@ -150,7 +150,7 @@ Learners who are in the default cohort see a cohort name of "Default Group" in d
 You can check the :ref:`learner profile information report<View and download student data>` for your course to see if any learners are assigned to the default cohort, and change their cohort assignments. Note, however, that in divided discussion topics learners can only see posts by members of their currently assigned cohort: when a learner is reassigned, posts that he previously saw will seem to have "disappeared". To avoid negatively affecting the learner experience, any cohort assignment changes should be done as early in the course run as possible, so that learners' views of discussion posts and contributions remain consistent over time.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Manage Course Cohorts` (how-to)
 

--- a/source/educators/concepts/advanced_features/group_configurations.rst
+++ b/source/educators/concepts/advanced_features/group_configurations.rst
@@ -25,7 +25,7 @@ different types of problems. For this content experiment, you need a
 group configuration that assigns your learners to four experiment groups.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Offering Differentiated Content` (concept)
 

--- a/source/educators/concepts/advanced_features/guidlines_modifying_group_configuration.rst
+++ b/source/educators/concepts/advanced_features/guidlines_modifying_group_configuration.rst
@@ -37,7 +37,7 @@ Removing an experiment group affects event data for the course. Ensure that rese
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Offering Differentiated Content` (concept)
 

--- a/source/educators/concepts/advanced_features/lti_reuse_content.rst
+++ b/source/educators/concepts/advanced_features/lti_reuse_content.rst
@@ -79,7 +79,7 @@ To obtain learner engagement and performance data, you use the features
 available in the external LMS.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Using Open edX as an LTI Tool Provider` (concept)
 

--- a/source/educators/concepts/advanced_features/managing_teams_discussions.rst
+++ b/source/educators/concepts/advanced_features/managing_teams_discussions.rst
@@ -49,7 +49,7 @@ Responses and comments made by discussion moderators or discussion
 administrators have a **Staff** label.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Teams Overview <CA_Teams_Overview>` (concept)
 

--- a/source/educators/concepts/advanced_features/teams_learner_experience.rst
+++ b/source/educators/concepts/advanced_features/teams_learner_experience.rst
@@ -103,7 +103,7 @@ For information about course discussions and managing discussions, see
 :ref:`Discussions` and :ref:`Guidance for Discussion Moderators`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Teams Overview <CA_Teams_Overview>` (concept)
 

--- a/source/educators/concepts/advanced_features/teams_overview.rst
+++ b/source/educators/concepts/advanced_features/teams_overview.rst
@@ -38,7 +38,7 @@ to connect socially, consider using discussions within the course rather than te
 For more information about using discussions, see :ref:`Running_discussions`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Managing Team Discussions <Teams Discussions>` (concept)
 

--- a/source/educators/concepts/advanced_features/timed_exams.rst
+++ b/source/educators/concepts/advanced_features/timed_exams.rst
@@ -23,7 +23,7 @@ the subsection, but only if learners request additional time **before**
 starting a timed exam.
 
 .. seealso::
- :class:dropdown
+ 
 
  :ref:`Configure Timed Exams`
 

--- a/source/educators/concepts/advanced_features/using_openedx_as_LTI_provider.rst
+++ b/source/educators/concepts/advanced_features/using_openedx_as_LTI_provider.rst
@@ -40,7 +40,7 @@ For more information about constructing an LTI URL for a course component, see
 :ref:`Determine Content Addresses`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Create a Duplicate Course for LTI use` (how-to)
 

--- a/source/educators/concepts/communication/about_divided_discussions.rst
+++ b/source/educators/concepts/communication/about_divided_discussions.rst
@@ -61,7 +61,7 @@ Discussion Topics` and :ref:`Running_discussions`.
   see :ref:`Setting Up Divided Discussions`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Setting Up Divided Discussions` (how-to)
 

--- a/source/educators/concepts/communication/course_discussions.rst
+++ b/source/educators/concepts/communication/course_discussions.rst
@@ -101,6 +101,6 @@ topics, see :ref:`Visibility of Discussion Topics`.
    see :ref:`Divide All Content Specific Discussion Topics`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Configuring Open edX Discussions` (how-to)

--- a/source/educators/concepts/communication/discussion_guidance_moderators.rst
+++ b/source/educators/concepts/communication/discussion_guidance_moderators.rst
@@ -168,7 +168,7 @@ Feature Requests
   those as well.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Guidance for Discussion Moderators` (concept)
 

--- a/source/educators/concepts/communication/manage_divided_discussions.rst
+++ b/source/educators/concepts/communication/manage_divided_discussions.rst
@@ -224,7 +224,7 @@ For other options that you can use to view posts, see
 :ref:`Moderating_discussions`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Guidance for Discussion Moderators` (concept)
 

--- a/source/educators/concepts/communication/moderating_discussions.rst
+++ b/source/educators/concepts/communication/moderating_discussions.rst
@@ -196,7 +196,7 @@ all** drop-down menu.
 * **Flagged**, to list only posts that learners have reported as inappropriate.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Guidance for Discussion Moderators` (concept)
 

--- a/source/educators/concepts/communication/running_discussions.rst
+++ b/source/educators/concepts/communication/running_discussions.rst
@@ -187,7 +187,7 @@ units and all course-wide topics are affected.
   can continue to add to discussions.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Discussions` (concept)
 

--- a/source/educators/concepts/data/learner_data.rst
+++ b/source/educators/concepts/data/learner_data.rst
@@ -68,7 +68,7 @@ As a result, you might want to download learner data periodically to gain an
 understanding of how the learner population changes over time.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Columns in the Student Profile Report` (reference)
 

--- a/source/educators/concepts/exercise_tools/OpenResponseAssessments.rst
+++ b/source/educators/concepts/exercise_tools/OpenResponseAssessments.rst
@@ -705,7 +705,7 @@ information, see `Configuring ora2 to prohibit submission of file types`_.
        .vbscript, .workflow .ws, .wsc, .wsf, .wsh
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`PA Create an ORA Assignment` (how-to)
 

--- a/source/educators/concepts/exercise_tools/create_exercises.rst
+++ b/source/educators/concepts/exercise_tools/create_exercises.rst
@@ -38,7 +38,7 @@ The topics in this section introduce the core set of problem types and a
 selection of other exercises and tools that you can add to your course.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Core Problem Types` (reference)
 

--- a/source/educators/concepts/exercise_tools/drag_and_drop.rst
+++ b/source/educators/concepts/exercise_tools/drag_and_drop.rst
@@ -93,7 +93,7 @@ message informs the learner that the problem is complete.
       and the final feedback message appears below the background image.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Creating a Drag and Drop Problem` (how-to)
 

--- a/source/educators/concepts/exercise_tools/external_graders.rst
+++ b/source/educators/concepts/exercise_tools/external_graders.rst
@@ -109,7 +109,7 @@ When you build your external grader, keep the following requirements in mind.
   responds with appropriate scores and messages.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`External Grader Problem Requirements` (reference)
 

--- a/source/educators/concepts/exercise_tools/peer_instruction.rst
+++ b/source/educators/concepts/exercise_tools/peer_instruction.rst
@@ -105,6 +105,6 @@ include quotation marks around the key value. For more information, see
  University of British Columbia.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Add Peer Instruction Assignment` (how to)

--- a/source/educators/concepts/exercise_tools/randomized_content.rst
+++ b/source/educators/concepts/exercise_tools/randomized_content.rst
@@ -20,6 +20,6 @@ tab on the Studio Home page. For details about content libraries, see
 :ref:`Content Libraries Overview`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Use Randomized Content Blocks` (how to)

--- a/source/educators/concepts/exercise_tools/single_select_overview.rst
+++ b/source/educators/concepts/exercise_tools/single_select_overview.rst
@@ -76,7 +76,7 @@ literature. A few guidelines for the creation of such questions follow.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Single Select` (how to)
 

--- a/source/educators/concepts/exercise_tools/staff_graded.rst
+++ b/source/educators/concepts/exercise_tools/staff_graded.rst
@@ -16,6 +16,6 @@ While your course is running, after learners have had a chance to complete the o
 #. **Review result** File is uploaded, validated, scores are overwritten for non-blank rows. You’ll get a readout at the bottom of the screen.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`StaffGraded` (how to)

--- a/source/educators/concepts/grading/graded_subsections.rst
+++ b/source/educators/concepts/grading/graded_subsections.rst
@@ -50,7 +50,7 @@ For more information about how to designate a subsection as a timed exam, see
 :ref:`Timed Exams`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Gradebook Assignment Types` (reference)
 

--- a/source/educators/concepts/instructional_design/feedback_best_practices.rst
+++ b/source/educators/concepts/instructional_design/feedback_best_practices.rst
@@ -24,7 +24,7 @@ such as single select and dropdown problems, the feedback should provide a
 reason why the selection is correct.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Working with Problem Components` (reference)
 

--- a/source/educators/concepts/instructional_design/id_course_dev_process_overview.rst
+++ b/source/educators/concepts/instructional_design/id_course_dev_process_overview.rst
@@ -220,7 +220,7 @@ Templates for the Information Collection phase that may be helpful:
 Remember: Course development is an iterative process. It is important to assume that there will be some changes made after the first group of learners completes the course and provides feedback.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Instructional Design Overview` (concept)
 

--- a/source/educators/concepts/instructional_design/id_instructional_design_overview.rst
+++ b/source/educators/concepts/instructional_design/id_instructional_design_overview.rst
@@ -353,7 +353,7 @@ As you get started building your online course on your platform, here are five i
 5.  Create a course outline before you start building.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Course Development Process` (concept)
 

--- a/source/educators/concepts/instructional_design/id_templates.rst
+++ b/source/educators/concepts/instructional_design/id_templates.rst
@@ -119,7 +119,7 @@ If your team is involved in the delivery of a course, you may want to spend some
    :alt: Thumbnail of Downloadable Template for Support Calendar
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Instructional Design Overview` (concept)
 

--- a/source/educators/concepts/instructional_design/libraries.rst
+++ b/source/educators/concepts/instructional_design/libraries.rst
@@ -40,7 +40,7 @@ The libraries that you create or have access to are listed on the **Libraries**
 tab on the Studio Home page.
 
 .. seealso::
- :class: dropdown
+ 
 
  :doc:`/community/release_notes/sumac/content_libraries_redesign_beta`
 

--- a/source/educators/concepts/open_edx_platform/outline_studio_lms.rst
+++ b/source/educators/concepts/open_edx_platform/outline_studio_lms.rst
@@ -43,7 +43,7 @@ For information about more specific learner data, including the learner's
 grades or answers for individual problems, see :ref:`Nav Learner Data`.
 
 .. seealso::
- :class: dropdown
+ 
  
  :ref:`Understanding a Course Outline <Understanding Your Course Outline>` (reference)
 

--- a/source/educators/concepts/open_edx_platform/what_is_course_dashboard.rst
+++ b/source/educators/concepts/open_edx_platform/what_is_course_dashboard.rst
@@ -31,7 +31,7 @@ The dashboard has two main pages.
 *  The **Programs** page lists any programs offer by your Open edX instance for courses that you are enrolled in. Programs appear on this page if you are enrolled in any course that is part of that program. This page also shows how many courses in the program you have completed, how many are in progres, and the number of remaining courses you have left in the program.
 
 .. seealso::
- :class: dropdown
+ 
 
  :doc:`Share Courses Social Media <../../how-tos/share_courses_social_media>` (how-to)
 

--- a/source/educators/concepts/open_edx_platform/what_is_lms.rst
+++ b/source/educators/concepts/open_edx_platform/what_is_lms.rst
@@ -20,7 +20,7 @@ To continue working on your course, return to the browser tab that shows
 Studio.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Course Outline` (concept)
 

--- a/source/educators/concepts/open_edx_platform/what_is_profile_page.rst
+++ b/source/educators/concepts/open_edx_platform/what_is_profile_page.rst
@@ -42,7 +42,7 @@ You can share either a limited profile or a full profile.
      linked social media icons, in addition to username and profile image.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Add or Update a Limited Profile` (how-to)
 

--- a/source/educators/concepts/open_edx_platform/what_is_programs_page.rst
+++ b/source/educators/concepts/open_edx_platform/what_is_programs_page.rst
@@ -32,7 +32,7 @@ On the **Programs** page, you can perform the following actions.
   the program, or to view the certificate, select the name of the program.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`What is the Course Dashboard` (concept)
 

--- a/source/educators/concepts/open_edx_platform/what_is_studio.rst
+++ b/source/educators/concepts/open_edx_platform/what_is_studio.rst
@@ -17,7 +17,7 @@ You use Studio directly through your browser. You do not need any additional
 software.
 
 .. seealso::
- :class: dropdown
+ 
  
  :ref:`Getting Started with Course Content Development` (reference)
 

--- a/source/educators/concepts/planning_course_run_information/additional_course_run_information.rst
+++ b/source/educators/concepts/planning_course_run_information/additional_course_run_information.rst
@@ -35,7 +35,7 @@ Effort indicates the number of hours each week you expect learners to work on
 your course, rounded to the nearest whole number.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Course Dates` (reference)
 

--- a/source/educators/concepts/planning_course_run_information/set_up_course.rst
+++ b/source/educators/concepts/planning_course_run_information/set_up_course.rst
@@ -19,7 +19,7 @@ For information about how to develop your course content in the Studio course
 outline, see the section on :ref:`Creating a Course in Open edX® <Creating Course TOC>`.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Course Title Guidelines` (reference)
 

--- a/source/educators/concepts/proctored_exams/preparing_learners_proctored_exams.rst
+++ b/source/educators/concepts/proctored_exams/preparing_learners_proctored_exams.rst
@@ -56,7 +56,7 @@ practice proctored exam.
   actual proctored exam.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`ProctoredExams_Overview` (concept)
 

--- a/source/educators/concepts/proctored_exams/proctored_exams_overview.rst
+++ b/source/educators/concepts/proctored_exams/proctored_exams_overview.rst
@@ -86,7 +86,7 @@ For more information about the way that learners experience proctored exams,
 see `Taking Timed and Proctored Exams` in the edX Help Center.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Enable Proctored Exams` (how-to)
 

--- a/source/educators/concepts/releasing-course/beta_testing.rst
+++ b/source/educators/concepts/releasing-course/beta_testing.rst
@@ -190,7 +190,7 @@ unit<Publish a Unit>`.
  attempt to access any other content in the course.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Add Beta Testers to a Course` (how-to)
 

--- a/source/educators/how-tos/add_checkbox.rst
+++ b/source/educators/how-tos/add_checkbox.rst
@@ -10,7 +10,7 @@ To create a checkbox (also known as "multi-select") problem, follow this video g
 .. youtube:: 6VYKcMeZrxg
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Multi select` (reference)
 

--- a/source/educators/how-tos/add_content_iframe.rst
+++ b/source/educators/how-tos/add_content_iframe.rst
@@ -8,7 +8,7 @@ If you have externally hosted content, you can add it to a course via an iframe:
 .. youtube:: Fw5zb1WBD_o
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Add a Course Update` (how-to)
 

--- a/source/educators/how-tos/add_course_creators.rst
+++ b/source/educators/how-tos/add_course_creators.rst
@@ -36,7 +36,7 @@ For a step-by-step to grant staff permissions to courses, check out this video:
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Add Beta Testers to a Course` (how-to)
 

--- a/source/educators/how-tos/add_course_page.rst
+++ b/source/educators/how-tos/add_course_page.rst
@@ -10,7 +10,7 @@ You can create a custom course page as demonstrated in the following video:
 .. youtube:: vIR9auBmiFU
 
 .. seealso::
- :class:dropdown
+ 
 
  :ref:`Add Files to a Course` (how-to)
 

--- a/source/educators/how-tos/add_course_updates.rst
+++ b/source/educators/how-tos/add_course_updates.rst
@@ -8,7 +8,7 @@ Watch this video to understand how to add course updates and handouts:
 .. youtube:: 3rPeuFR6UDI
 
 .. seealso::
- :class:dropdown
+ 
 
  :ref:`Adding Course Updates and Handouts` (reference)
 

--- a/source/educators/how-tos/add_dropdown.rst
+++ b/source/educators/how-tos/add_dropdown.rst
@@ -10,7 +10,7 @@ This video explains how to add a dropdown-type problem:
 .. youtube:: e6HxKo18_xE
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Dropdown` (reference)
 

--- a/source/educators/how-tos/add_image.rst
+++ b/source/educators/how-tos/add_image.rst
@@ -11,7 +11,7 @@ This video will take you through adding images (and text!) to your course:
 .. youtube:: -CQekI4-Hjw
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Creating a Course About Page` (reference)
 

--- a/source/educators/how-tos/add_links_to_social_media_accounts.rst
+++ b/source/educators/how-tos/add_links_to_social_media_accounts.rst
@@ -36,7 +36,7 @@ can click those icons to visit your social media account page.
     :alt: A learner's full profile, with social media icons circled.
 
 .. seealso::
- :class: dropdown
+ 
 
  :doc:`what_is_profile_page <../concepts/open_edx_platform/what_is_profile_page>` (concept)
  :doc:`add_update_full_profile` (how-to)

--- a/source/educators/how-tos/add_multiple_choice.rst
+++ b/source/educators/how-tos/add_multiple_choice.rst
@@ -37,7 +37,7 @@ This video explains how to add a multiple choice (also known as "single-select")
 
 
 .. seealso::
- :class: dropdown
+ 
  
  :ref:`Overview` (concept)
 

--- a/source/educators/how-tos/add_transcript_other_language.rst
+++ b/source/educators/how-tos/add_transcript_other_language.rst
@@ -11,7 +11,7 @@ Watch this for an overview of how to add a transcript to a video, including diff
 .. youtube:: qABNazvnAE0
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Video Process Overview` (how-to)
 

--- a/source/educators/how-tos/add_update_full_profile.rst
+++ b/source/educators/how-tos/add_update_full_profile.rst
@@ -63,7 +63,7 @@ The site saves your changes automatically.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :doc:`what_is_profile_page <../concepts/open_edx_platform/what_is_profile_page>` (concept)
 

--- a/source/educators/how-tos/add_update_limited_profile.rst
+++ b/source/educators/how-tos/add_update_limited_profile.rst
@@ -41,7 +41,7 @@ To add or update a limited profile, follow these steps.
 The site saves your changes automatically.
 
 .. seealso::
- :class: dropdown
+ 
 
  :doc:`what_is_profile_page <../concepts/open_edx_platform/what_is_profile_page>` (concept)
  :doc:`add_update_full_profile` (how-to)

--- a/source/educators/how-tos/add_video.rst
+++ b/source/educators/how-tos/add_video.rst
@@ -23,7 +23,7 @@ This name appears as a heading above the video in the LMS, and it identifies the
 #. Click :guilabel:`Save` to save the video in the unit.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Course About Video Guidelines` (reference)
 

--- a/source/educators/how-tos/add_video_quiz.rst
+++ b/source/educators/how-tos/add_video_quiz.rst
@@ -11,7 +11,7 @@ It's possible to add quizzes directly to a video!  Watch this for a how-to:
 .. youtube:: 87WT3nGOHwc
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Video Process Overview` (how-to)
 

--- a/source/educators/how-tos/add_written_content.rst
+++ b/source/educators/how-tos/add_written_content.rst
@@ -11,6 +11,6 @@ This video will take you through adding text (and images!) to your course:
 .. youtube:: -CQekI4-Hjw
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Working with Text Components` (reference)

--- a/source/educators/how-tos/advanced_features/add_cohorts.rst
+++ b/source/educators/how-tos/advanced_features/add_cohorts.rst
@@ -52,7 +52,7 @@ learner, review the learner profile information for your course. See
    :ref:`Altering Cohort Configuration`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Cohorts Overview` (concept)
 

--- a/source/educators/how-tos/advanced_features/add_content_experiments_olx.rst
+++ b/source/educators/how-tos/advanced_features/add_content_experiments_olx.rst
@@ -86,7 +86,7 @@ In this example:
 For information about the ``policy.json`` file, see :ref:`Set Up Group Configuration for OLX Courses`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Offering Differentiated Content` (concept)
 

--- a/source/educators/how-tos/advanced_features/assign_learners_cohort_csv.rst
+++ b/source/educators/how-tos/advanced_features/assign_learners_cohort_csv.rst
@@ -176,7 +176,7 @@ Unicode characters are correctly saved and displayed.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Cohorts Overview` (concept)
 

--- a/source/educators/how-tos/advanced_features/assign_learners_cohort_manually.rst
+++ b/source/educators/how-tos/advanced_features/assign_learners_cohort_manually.rst
@@ -58,7 +58,7 @@ learner profile information for your course. See :ref:`View and download
 student data`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Cohorts Overview` (concept)
 

--- a/source/educators/how-tos/advanced_features/associate_cohort_with_groups.rst
+++ b/source/educators/how-tos/advanced_features/associate_cohort_with_groups.rst
@@ -43,7 +43,7 @@ For an example of using content groups to create cohort-specific course
 content, see :ref:`Cohorted Courseware Example`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Cohorts Overview` (concept)
 

--- a/source/educators/how-tos/advanced_features/chage_learner_cohort_assignment.rst
+++ b/source/educators/how-tos/advanced_features/chage_learner_cohort_assignment.rst
@@ -29,7 +29,7 @@ different cohorts manually in the LMS by selecting **Instructor** and then
 Cohort Groups by uploading CSV>` in a .csv file.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Cohorts Overview` (concept)
 

--- a/source/educators/how-tos/advanced_features/change_assignment_method_cohort.rst
+++ b/source/educators/how-tos/advanced_features/change_assignment_method_cohort.rst
@@ -45,7 +45,7 @@ To change the assignment method of a cohort, follow these steps.
    other cohorts.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Cohorts Overview` (concept)
 

--- a/source/educators/how-tos/advanced_features/change_group_configuration_content_experiment.rst
+++ b/source/educators/how-tos/advanced_features/change_group_configuration_content_experiment.rst
@@ -40,7 +40,7 @@ groups, as well as create new components.
    groups. You can also create new components in the new groups.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Offering Differentiated Content` (concept)
 

--- a/source/educators/how-tos/advanced_features/cohorted_courseware.rst
+++ b/source/educators/how-tos/advanced_features/cohorted_courseware.rst
@@ -122,7 +122,7 @@ For an example of using content groups to create cohort-specific course
 content, see :ref:`Cohorted Courseware Example`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Cohorts Overview` (concept)
 

--- a/source/educators/how-tos/advanced_features/configure_content_experiments.rst
+++ b/source/educators/how-tos/advanced_features/configure_content_experiments.rst
@@ -57,7 +57,7 @@ Configuration>`.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Offering Differentiated Content` (concept)
 

--- a/source/educators/how-tos/advanced_features/create_content_experiment.rst
+++ b/source/educators/how-tos/advanced_features/create_content_experiment.rst
@@ -53,7 +53,7 @@ You can now create content for the groups in the experiment.
    is not supported.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Offering Differentiated Content` (concept)
 

--- a/source/educators/how-tos/advanced_features/create_content_experiment_groups.rst
+++ b/source/educators/how-tos/advanced_features/create_content_experiment_groups.rst
@@ -39,7 +39,7 @@ For example, you can add a Text component and a video to Group A.
    performance.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Offering Differentiated Content` (concept)
 

--- a/source/educators/how-tos/advanced_features/create_content_for_specific_enrollment_tracks.rst
+++ b/source/educators/how-tos/advanced_features/create_content_for_specific_enrollment_tracks.rst
@@ -176,6 +176,6 @@ For details see :ref:`Testing Your Course Content` and :ref:`Roles for Viewing
 Course Content`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Offering Differentiated Content` (concept)

--- a/source/educators/how-tos/advanced_features/create_content_group.rst
+++ b/source/educators/how-tos/advanced_features/create_content_group.rst
@@ -29,7 +29,7 @@ instructor dashboard. For details, see :ref:`Associate Cohorts with Content
 Groups`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Cohorts Overview` (concept)
 

--- a/source/educators/how-tos/advanced_features/create_group_configuration.rst
+++ b/source/educators/how-tos/advanced_features/create_group_configuration.rst
@@ -45,7 +45,7 @@ in use in the course:
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Overview of Content Experiments` (concept)
 

--- a/source/educators/how-tos/advanced_features/create_teams.rst
+++ b/source/educators/how-tos/advanced_features/create_teams.rst
@@ -51,7 +51,7 @@ To create a team, follow these steps.
    Your new team is added to the list of teams under your selected team-set.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Teams Overview <CA_Teams_Overview>` (concept)
 

--- a/source/educators/how-tos/advanced_features/delete_content_groups.rst
+++ b/source/educators/how-tos/advanced_features/delete_content_groups.rst
@@ -24,7 +24,7 @@ Delete Content Groups
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Cohorts Overview` (concept)
 

--- a/source/educators/how-tos/advanced_features/delete_group_configuration.rst
+++ b/source/educators/how-tos/advanced_features/delete_group_configuration.rst
@@ -21,7 +21,7 @@ Delete a Group Configuration
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Offering Differentiated Content` (concept)
 

--- a/source/educators/how-tos/advanced_features/delete_teams.rst
+++ b/source/educators/how-tos/advanced_features/delete_teams.rst
@@ -42,7 +42,7 @@ To delete a team, follow these steps.
    no longer belong to a team.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Teams Overview <CA_Teams_Overview>` (concept)
 

--- a/source/educators/how-tos/advanced_features/disable_cohorts.rst
+++ b/source/educators/how-tos/advanced_features/disable_cohorts.rst
@@ -39,7 +39,7 @@ you understand the consequences of these actions. For more details, see
 :ref:`Altering Cohort Configuration`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Cohorts Overview` (concept)
 

--- a/source/educators/how-tos/advanced_features/edit_group_configuration.rst
+++ b/source/educators/how-tos/advanced_features/edit_group_configuration.rst
@@ -87,7 +87,7 @@ contains the content experiment.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Guidelines for Modifying Group Configurations` (concept)
 

--- a/source/educators/how-tos/advanced_features/edit_teams.rst
+++ b/source/educators/how-tos/advanced_features/edit_teams.rst
@@ -26,7 +26,7 @@ To edit a team's details, follow these steps.
    The team's details are updated.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Teams Overview <CA_Teams_Overview>` (concept)
 

--- a/source/educators/how-tos/advanced_features/enable_cohorts.rst
+++ b/source/educators/how-tos/advanced_features/enable_cohorts.rst
@@ -23,7 +23,7 @@ You can now :ref:`add cohorts<Add Cohorts>` to your course.
    see :ref:`Altering Cohort Configuration`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Cohorts Overview` (concept)
 

--- a/source/educators/how-tos/advanced_features/enable_teams.rst
+++ b/source/educators/how-tos/advanced_features/enable_teams.rst
@@ -25,7 +25,7 @@ To change access to the course team configuration options, follow these steps.
 #. Select **Apply** to save your configuration changes.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Teams Overview <CA_Teams_Overview>` (concept)
 

--- a/source/educators/how-tos/advanced_features/lti_blackboard_example.rst
+++ b/source/educators/how-tos/advanced_features/lti_blackboard_example.rst
@@ -44,7 +44,7 @@ To use Open edX course content in the Blackboard LMS, you add a new app to the c
       Blackboard system.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Using Open edX as an LTI Tool Provider` (concept)
 

--- a/source/educators/how-tos/advanced_features/lti_canvas_example.rst
+++ b/source/educators/how-tos/advanced_features/lti_canvas_example.rst
@@ -35,7 +35,7 @@ To use Open edX course content in the Canvas LMS, you add a new app to the cours
       Canvas system.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Using Open edX as an LTI Tool Provider` (concept)
 

--- a/source/educators/how-tos/advanced_features/lti_determine_content_address.rst
+++ b/source/educators/how-tos/advanced_features/lti_determine_content_address.rst
@@ -208,7 +208,7 @@ LTI URLs for Text components include "html+block" or "html", as follows.
   ``https://openedx-lti.org/lti_provider/courses/course-v1:OpenedX+01-2024+2024-1/block-v1:OpenedX+01-2024+2024-1+type@html+block@f9f3a25e7bab46e583fd1fbbd7a2f6a0``
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Using Open edX as an LTI Tool Provider` (concept)
 

--- a/source/educators/how-tos/advanced_features/lti_prepare_content.rst
+++ b/source/educators/how-tos/advanced_features/lti_prepare_content.rst
@@ -54,7 +54,7 @@ steps.
 #. Publish the unit. For more information, see :ref:`Publish a Unit`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Using Open edX as an LTI Tool Provider` (concept)
 

--- a/source/educators/how-tos/advanced_features/managing_cohorts.rst
+++ b/source/educators/how-tos/advanced_features/managing_cohorts.rst
@@ -153,7 +153,7 @@ consequences of these actions.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Cohorts Overview` (concept)
 

--- a/source/educators/how-tos/advanced_features/remove_learner_from_team.rst
+++ b/source/educators/how-tos/advanced_features/remove_learner_from_team.rst
@@ -48,7 +48,7 @@ To remove a learner from a team, follow these steps.
    and the count of team members is updated wherever it appears on team pages.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Teams Overview <CA_Teams_Overview>` (concept)
 

--- a/source/educators/how-tos/advanced_features/rename_cohort.rst
+++ b/source/educators/how-tos/advanced_features/rename_cohort.rst
@@ -26,7 +26,7 @@ To rename a cohort, follow these steps.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Cohorts Overview` (concept)
 

--- a/source/educators/how-tos/advanced_features/search_teams.rst
+++ b/source/educators/how-tos/advanced_features/search_teams.rst
@@ -24,7 +24,7 @@ To clear the existing search term, select the **X** next to the search field,
 or select all the text within the field and enter text to replace it.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Teams Overview <CA_Teams_Overview>` (concept)
 

--- a/source/educators/how-tos/advanced_features/set_up_group_configuration_olx.rst
+++ b/source/educators/how-tos/advanced_features/set_up_group_configuration_olx.rst
@@ -98,7 +98,7 @@ experiment groups, and the second divides learners into three experiment groups.
   group configurations in your course.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Offering Differentiated Content` (concept)
 

--- a/source/educators/how-tos/advanced_features/specify_content_particular_content_groups.rst
+++ b/source/educators/how-tos/advanced_features/specify_content_particular_content_groups.rst
@@ -37,7 +37,7 @@ Group` and :ref:`Viewing Cohort Specific Courseware`.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Cohorts Overview` (concept)
 

--- a/source/educators/how-tos/advanced_features/test_content_experiments.rst
+++ b/source/educators/how-tos/advanced_features/test_content_experiments.rst
@@ -38,7 +38,7 @@ different experiment group of learners sees.
  make learners aware of the experiment.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Offering Differentiated Content` (concept)
 

--- a/source/educators/how-tos/advanced_features/timed_exams.rst
+++ b/source/educators/how-tos/advanced_features/timed_exams.rst
@@ -209,7 +209,7 @@ affected, and their scores for the exam remain visible on the **Progress** page.
 
 
 .. seealso::
- :class:dropdown
+ 
 
  :ref:`Timed Exams` (concept)
 

--- a/source/educators/how-tos/advanced_features/view_cohort_specific_courseware.rst
+++ b/source/educators/how-tos/advanced_features/view_cohort_specific_courseware.rst
@@ -57,7 +57,7 @@ Courseware`.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Cohorts Overview` (concept)
 

--- a/source/educators/how-tos/allow_anonymous_discussions.rst
+++ b/source/educators/how-tos/allow_anonymous_discussions.rst
@@ -69,7 +69,7 @@ Enable/Disable "Allow Anonymous Discussion Posts to Peers"
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Discussions` (concept)
 

--- a/source/educators/how-tos/communication/add_course_updates_handouts.rst
+++ b/source/educators/how-tos/communication/add_course_updates_handouts.rst
@@ -90,6 +90,6 @@ To add a course handout, follow these steps.
 #. Select **Save**.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Adding Course Updates and Handouts` (reference)

--- a/source/educators/how-tos/communication/administer_discussions.rst
+++ b/source/educators/how-tos/communication/administer_discussions.rst
@@ -112,7 +112,7 @@ can unenroll that learner from the course. For more information, see
 enrollment period for the course is over.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Guidance for Discussion Moderators` (concept)
 

--- a/source/educators/how-tos/communication/assigning_discussion_roles.rst
+++ b/source/educators/how-tos/communication/assigning_discussion_roles.rst
@@ -72,7 +72,7 @@ author or have the Admin role.
    The person who you removed no longer appears in the list.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Guidance for Discussion Moderators` (concept)
 

--- a/source/educators/how-tos/communication/closing_discussions.rst
+++ b/source/educators/how-tos/communication/closing_discussions.rst
@@ -36,7 +36,7 @@ reopen, follow these steps.
 6. Select **Save Changes**.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Discussions` (concept)
 

--- a/source/educators/how-tos/communication/configure-discussions.rst
+++ b/source/educators/how-tos/communication/configure-discussions.rst
@@ -192,7 +192,7 @@ that are anonymous to other learners, as seen below.
   :alt: Options for anonymous posting while creating a post.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Discussions` (concept)
 

--- a/source/educators/how-tos/communication/email_task_history_report.rst
+++ b/source/educators/how-tos/communication/email_task_history_report.rst
@@ -68,7 +68,7 @@ No **Task Progress** messages display for tasks that have a **State** of
 Failure.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Bulk Email` (reference)
 

--- a/source/educators/how-tos/communication/review_sent_messages.rst
+++ b/source/educators/how-tos/communication/review_sent_messages.rst
@@ -39,7 +39,7 @@ message text.
    review and test it thoroughly before you send it to all course participants.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Bulk Email` (reference)
 

--- a/source/educators/how-tos/communication/send_bulk_email.rst
+++ b/source/educators/how-tos/communication/send_bulk_email.rst
@@ -91,7 +91,7 @@ To send a scheduled email message to course participants, follow these steps.
    processing.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Bulk Email` (reference)
 

--- a/source/educators/how-tos/communication/setting_up_divided_discussions.rst
+++ b/source/educators/how-tos/communication/setting_up_divided_discussions.rst
@@ -112,6 +112,6 @@ For information about managing discussions that are divided, see :ref:`Managing
 Divided Discussion Topics`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`About Divided Discussions` (concept)

--- a/source/educators/how-tos/communication/setup_cohorted_discussions.rst
+++ b/source/educators/how-tos/communication/setup_cohorted_discussions.rst
@@ -21,7 +21,7 @@ Divided Discussion Topics` and :ref:`Moderating_discussions`.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Discussions` (concept)
 

--- a/source/educators/how-tos/configure_prerequisite_content.rst
+++ b/source/educators/how-tos/configure_prerequisite_content.rst
@@ -117,6 +117,6 @@ subsection, follow these steps.
      when you :ref:`re-run a course<Rerun a Course>`.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Controlling Content Visibility` (reference)     

--- a/source/educators/how-tos/connect_teams_content_groups.rst
+++ b/source/educators/how-tos/connect_teams_content_groups.rst
@@ -24,7 +24,7 @@ Connecting Teams to Content Groups
      .. image:: /_images/educator_how_tos/teams_within_groups.png
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Teams Overview  <CA_Teams_Overview>` (concept)
 

--- a/source/educators/how-tos/content-tagging-how-tos/Create_flat_taxonomy_by_uploading_CSV.rst
+++ b/source/educators/how-tos/content-tagging-how-tos/Create_flat_taxonomy_by_uploading_CSV.rst
@@ -45,7 +45,7 @@ taxonomy. Here's how to do that:
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`build-taxonomy-using-template` (how-to)
 

--- a/source/educators/how-tos/content-tagging-how-tos/add_delete_course_tags.rst
+++ b/source/educators/how-tos/content-tagging-how-tos/add_delete_course_tags.rst
@@ -82,7 +82,7 @@ Deleting Tags from the Course Outline Page
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`build-taxonomy-using-template` (how-to)
 

--- a/source/educators/how-tos/content-tagging-how-tos/build_taxonomy_using_template.rst
+++ b/source/educators/how-tos/content-tagging-how-tos/build_taxonomy_using_template.rst
@@ -104,7 +104,7 @@ create a taxonomy of cities, like this:
 * Import your taxonomy following the How To :ref:`import-export-taxonomy`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Add and delete tags on course content` (how-to)
 

--- a/source/educators/how-tos/content-tagging-how-tos/export_tag_data_from_course.rst
+++ b/source/educators/how-tos/content-tagging-how-tos/export_tag_data_from_course.rst
@@ -15,7 +15,7 @@ Export a CSV file that reports on which tags have been added to which parts of t
 #. A CSV file will download to your local machine. It may take a few minutes.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`build-taxonomy-using-template` (how-to)
 

--- a/source/educators/how-tos/content-tagging-how-tos/update_reimport_taxonomy.rst
+++ b/source/educators/how-tos/content-tagging-how-tos/update_reimport_taxonomy.rst
@@ -63,7 +63,7 @@ do that.
    associated tags in the taxonomy view page.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`build-taxonomy-using-template` (how-to)
 

--- a/source/educators/how-tos/copy_paste_course_content.rst
+++ b/source/educators/how-tos/copy_paste_course_content.rst
@@ -40,7 +40,7 @@ Copy and Paste Course Content
     in the original.
 
 .. seealso::
-   :class: dropdown
+   
 
    :ref:`Copy and Paste Course Units <Copy and Paste Course Units>` (how-to)
 

--- a/source/educators/how-tos/copy_paste_units.rst
+++ b/source/educators/how-tos/copy_paste_units.rst
@@ -84,7 +84,7 @@ From the Unit Page
    Authors can also paste Units copied from the Unit Page into the Course Outline, and vice versa.
 
 .. seealso::
-   :class: dropdown
+   
 
    :ref:`Copy and Paste Course Content <Copy and Paste Course Content>` (how-to)
    

--- a/source/educators/how-tos/course_development/Subsection_configure_hints.rst
+++ b/source/educators/how-tos/course_development/Subsection_configure_hints.rst
@@ -20,7 +20,7 @@ Configure a Hint in a Problem
   and views the next one by selecting **Hint** again.
 
 .. seealso::
- :class:dropdown
+ 
 
  :ref:`Adding Feedback and Hints to a Problem` (reference)
 

--- a/source/educators/how-tos/course_development/add_components_library.rst
+++ b/source/educators/how-tos/course_development/add_components_library.rst
@@ -34,7 +34,7 @@ a Library` and :ref:`Get the Latest Version of Library Content <Get the Latest V
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :doc:`/community/release_notes/sumac/content_libraries_redesign_beta`
  

--- a/source/educators/how-tos/course_development/add_course_files.rst
+++ b/source/educators/how-tos/course_development/add_course_files.rst
@@ -151,7 +151,7 @@ download all files, select the very first checkbox, then select the Action
 button and then select Download.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`The Files Page` (reference)
 

--- a/source/educators/how-tos/course_development/add_custom_page.rst
+++ b/source/educators/how-tos/course_development/add_custom_page.rst
@@ -49,7 +49,7 @@ The new page is immediately available to the specified audience if the course ha
 For details on reordering course pages, see additional detail in :ref:`Reordering and deleting custom pages`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Adding Pages to a Course` (how to)
 

--- a/source/educators/how-tos/course_development/add_edit_components.rst
+++ b/source/educators/how-tos/course_development/add_edit_components.rst
@@ -23,7 +23,7 @@ After you add a component, it is not visible to learners until you
 :ref:`publish the unit<Publish a Unit>`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Add a Component` (how-to)
 

--- a/source/educators/how-tos/course_development/add_pages.rst
+++ b/source/educators/how-tos/course_development/add_pages.rst
@@ -63,7 +63,7 @@ Additional applications and resources can be enabled depending on your course ne
 * :ref:`Custom Pages<Add Custom Page>`
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Enable Notes` (how to)
 

--- a/source/educators/how-tos/course_development/add_textbooks.rst
+++ b/source/educators/how-tos/course_development/add_textbooks.rst
@@ -94,6 +94,6 @@ Delete a Chapter
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Enable Textbook` (how to)

--- a/source/educators/how-tos/course_development/add_video_to_course.rst
+++ b/source/educators/how-tos/course_development/add_video_to_course.rst
@@ -35,7 +35,7 @@ To add a video, follow these steps.
    see :ref:`Video Settings`.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Video Process Overview` (how-to)
 

--- a/source/educators/how-tos/course_development/additional_transcript_options.rst
+++ b/source/educators/how-tos/course_development/additional_transcript_options.rst
@@ -103,7 +103,7 @@ To add another downloadable transcript, follow these steps.
    **Open**.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Video Process Overview` (how-to)
 

--- a/source/educators/how-tos/course_development/additional_video_options.rst
+++ b/source/educators/how-tos/course_development/additional_video_options.rst
@@ -222,7 +222,7 @@ License
           a Course`.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Video Process Overview` (how-to)
 

--- a/source/educators/how-tos/course_development/configure_resources.rst
+++ b/source/educators/how-tos/course_development/configure_resources.rst
@@ -111,7 +111,7 @@ to manually edit each individual problem.
 To learn about Flexible Peer Grading and the course override setting, see  :ref:`Flexible Peer Grade Averaging`
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Adding Pages to a Course` (how to)
 

--- a/source/educators/how-tos/course_development/course_wiki_tasks.rst
+++ b/source/educators/how-tos/course_development/course_wiki_tasks.rst
@@ -151,7 +151,7 @@ Combine a Current Version with a Previous Version
    selected versions.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Create Course Wiki` (how to)
 

--- a/source/educators/how-tos/course_development/create_course_wiki.rst
+++ b/source/educators/how-tos/course_development/create_course_wiki.rst
@@ -193,7 +193,7 @@ To restore a deleted article, select the link to the article and select
 **Restore**.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`About Course Wiki` (reference)
 

--- a/source/educators/how-tos/course_development/create_discussion.rst
+++ b/source/educators/how-tos/course_development/create_discussion.rst
@@ -70,7 +70,7 @@ Create a Discussion Component
    topics are visible, see :ref:`Visibility of Discussion Topics`.
 
 .. seealso::
- :class:dropdown
+ 
 
  :ref:`Discussions` (concept)
  

--- a/source/educators/how-tos/course_development/create_edit_publish_subsections.rst
+++ b/source/educators/how-tos/course_development/create_edit_publish_subsections.rst
@@ -126,7 +126,7 @@ To delete a subsection, follow these steps.
    subsection**.
 
 .. seealso::
- :class: dropdown
+ 
  
  :ref:`Getting Started with Course Content Development` (reference)
  

--- a/source/educators/how-tos/course_development/create_hide_delete_sections.rst
+++ b/source/educators/how-tos/course_development/create_hide_delete_sections.rst
@@ -193,7 +193,7 @@ You can then create Subsections within the section.
 .. END CREATE A SECTION VIDEO
 
 .. seealso::
- :class: dropdown
+ 
  
  :ref:`Getting Started with Course Content Development` (reference)
  

--- a/source/educators/how-tos/course_development/create_library.rst
+++ b/source/educators/how-tos/course_development/create_library.rst
@@ -60,7 +60,7 @@ you create it, see :ref:`Give Other Users Access to Your Library`.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :doc:`/community/release_notes/sumac/content_libraries_redesign_beta`
  

--- a/source/educators/how-tos/course_development/delete_component.rst
+++ b/source/educators/how-tos/course_development/delete_component.rst
@@ -20,7 +20,7 @@ After you delete a component in Studio, the component remains visible to
 learners until you :ref:`publish the unit<Publish a Unit>`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Add a Component` (how-to)
 

--- a/source/educators/how-tos/course_development/delete_library.rst
+++ b/source/educators/how-tos/course_development/delete_library.rst
@@ -19,7 +19,7 @@ assignment content in courses.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :doc:`/community/release_notes/sumac/content_libraries_redesign_beta`
  

--- a/source/educators/how-tos/course_development/duplicate_component.rst
+++ b/source/educators/how-tos/course_development/duplicate_component.rst
@@ -24,7 +24,7 @@ until you :ref:`publish the unit<Publish a Unit>`.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Add a Component` (how-to)
 

--- a/source/educators/how-tos/course_development/edit_component.rst
+++ b/source/educators/how-tos/course_development/edit_component.rst
@@ -57,7 +57,7 @@ Different types of components have different fields in the **Settings** dialog
 box, but all of them have a **Display Name** field.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Add a Component` (how-to)
 

--- a/source/educators/how-tos/course_development/edit_components_library.rst
+++ b/source/educators/how-tos/course_development/edit_components_library.rst
@@ -24,7 +24,7 @@ refer to the following topics.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :doc:`/community/release_notes/sumac/content_libraries_redesign_beta`
  

--- a/source/educators/how-tos/course_development/edit_library.rst
+++ b/source/educators/how-tos/course_development/edit_library.rst
@@ -35,7 +35,7 @@ Other Users Access to Your Library`.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :doc:`/community/release_notes/sumac/content_libraries_redesign_beta`
  

--- a/source/educators/how-tos/course_development/enable_calculator.rst
+++ b/source/educators/how-tos/course_development/enable_calculator.rst
@@ -19,7 +19,7 @@ To disable or enable the Calculator resource, follow these steps.
 #. Select **Apply** to save your configuration changes.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Adding Pages to a Course` (how to)
 

--- a/source/educators/how-tos/course_development/enable_notes.rst
+++ b/source/educators/how-tos/course_development/enable_notes.rst
@@ -20,7 +20,7 @@ To disable or enable the Notes application, follow these steps.
 #. Select **Apply** to save your configuration changes.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Adding Pages to a Course` (how to)
 

--- a/source/educators/how-tos/course_development/enable_teams.rst
+++ b/source/educators/how-tos/course_development/enable_teams.rst
@@ -22,7 +22,7 @@ Additional configuration for the Teams application can be found at :ref:`Teams C
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Adding Pages to a Course` (how to)
 

--- a/source/educators/how-tos/course_development/enable_textbook.rst
+++ b/source/educators/how-tos/course_development/enable_textbook.rst
@@ -30,7 +30,7 @@ the close icon to the right of each listed chapter.
 .. note:: After you delete your textbook on the Textbooks page, it is strongly recommended that you :ref:`lock <Lock a File>` or :ref:`delete <Delete a File>` the PDF files for the textbook on the Files & Uploads page to avoid copyright issues.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Adding Pages to a Course` (how to)
 

--- a/source/educators/how-tos/course_development/enable_wiki.rst
+++ b/source/educators/how-tos/course_development/enable_wiki.rst
@@ -22,7 +22,7 @@ When you disable the wiki application in your course, any existing articles rema
 Additional details for configuring the wiki application can be found at :ref:`Wiki Configuration`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Adding Pages to a Course` (how to)
 

--- a/source/educators/how-tos/course_development/exercise_tools/CreateORAAssignment.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/CreateORAAssignment.rst
@@ -630,7 +630,7 @@ understand or if they had any problems with the assignment.
 For more information about beta testing, see :ref:`Beta_Testing`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Open Response Assessments` (concept)
 

--- a/source/educators/how-tos/course_development/exercise_tools/Manage_ORA_Assignment.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/Manage_ORA_Assignment.rst
@@ -464,7 +464,7 @@ grading>`, locate the specific submission by following these steps.
    response from peer grading<Remove a learner response from peer grading>`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Open Response Assessments` (concept)
 

--- a/source/educators/how-tos/course_development/exercise_tools/add_annotation.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/add_annotation.rst
@@ -94,7 +94,7 @@ To add the **Annotation problem** segment of the problem, follow these steps.
 #. Select **Save**.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Calculator` (how-to)
 

--- a/source/educators/how-tos/course_development/exercise_tools/add_calculator.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/add_calculator.rst
@@ -57,7 +57,7 @@ To enable the calculator tool, follow these steps.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Chemical Equation` (how-to)
 

--- a/source/educators/how-tos/course_development/exercise_tools/add_chemical_equation.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/add_chemical_equation.rst
@@ -79,6 +79,6 @@ Sample Chemical Equation Problem Code
   </problem>
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Chemical Equation Problem XML` (reference)

--- a/source/educators/how-tos/course_development/exercise_tools/add_google_drive.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/add_google_drive.rst
@@ -69,7 +69,7 @@ The value of the ``embed_code`` attribute is the embed code you copied in the
   changes.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Google Drive Files Tool` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/add_hints_advanced_editor.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/add_hints_advanced_editor.rst
@@ -43,7 +43,7 @@ For example, the following OLX for a single select problem shows two hints.
 
 
   .. seealso::
- :class: dropdown
+ 
 
  :ref:`Dropdown` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/add_multi_select_partial_credit.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/add_multi_select_partial_credit.rst
@@ -275,7 +275,7 @@ halves.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Multi select` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/add_numerical_input_problem.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/add_numerical_input_problem.rst
@@ -130,7 +130,7 @@ advanced editor. For an overview of hints in problems, see
 :ref:`Adding Feedback and Hints to a Problem`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Numerical Input` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/add_peer_instruction_tool.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/add_peer_instruction_tool.rst
@@ -166,6 +166,6 @@ The **Studio URL** for the image can then be added to the question or
 answer choice in the peer instruction component.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`UBC Peer Instruction` (concept)

--- a/source/educators/how-tos/course_development/exercise_tools/add_poll_question.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/add_poll_question.rst
@@ -101,7 +101,7 @@ poll inside the course.
     :width: 400
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Poll Tool` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/add_recommenderXBlock.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/add_recommenderXBlock.rst
@@ -98,7 +98,7 @@ To add a recommender to a course, follow these steps.
 #. Optionally, open the unit in the LMS and suggest some resources.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Notes Tool` (how-to)
 

--- a/source/educators/how-tos/course_development/exercise_tools/add_scorm_xblock.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/add_scorm_xblock.rst
@@ -71,7 +71,7 @@ Uploading the SCORM content
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`SCORM Overview` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/add_single_select.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/add_single_select.rst
@@ -75,7 +75,7 @@ You can add hints to a single select problem . For an overview of hints in
 problems, see :ref:`Adding Feedback and Hints to a Problem`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Single Select Overview` (concept)
 

--- a/source/educators/how-tos/course_development/exercise_tools/add_single_select_num_input.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/add_single_select_num_input.rst
@@ -52,7 +52,7 @@ Single Select and Numerical Input Problem Code
   </problem>
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Numerical Input` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/add_survey.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/add_survey.rst
@@ -174,6 +174,6 @@ The results of the survey are then displayed.
     :width: 600
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Enable Survey OLX` (reference)

--- a/source/educators/how-tos/course_development/exercise_tools/add_text_input.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/add_text_input.rst
@@ -66,7 +66,7 @@ advanced editor. For an overview of hints in problems, see
 :ref:`Adding Feedback and Hints to a Problem`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Text Input` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/add_unsupported_problem_types.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/add_unsupported_problem_types.rst
@@ -28,7 +28,7 @@ in Studio.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Create Exercises` (concept)
 

--- a/source/educators/how-tos/course_development/exercise_tools/add_word_cloud.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/add_word_cloud.rst
@@ -81,6 +81,6 @@ To create a word cloud, follow these steps.
 #. Select **Save**.
 
 .. seealso::
- :class:dropdown
+ 
 
  :ref:`Create Exercises` (concepts)

--- a/source/educators/how-tos/course_development/exercise_tools/adding_dropdown.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/adding_dropdown.rst
@@ -63,7 +63,7 @@ You can see the OLX for the example problem from the Overview section below.
   switch back to the simple editor.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Dropdown` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/adding_math_expression_problem.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/adding_math_expression_problem.rst
@@ -29,7 +29,7 @@ To create a math expression input problem, follow these steps.
 #. Select **Save**.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Math Expression Input` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/adding_mathjax.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/adding_mathjax.rst
@@ -36,6 +36,6 @@ appears on its own line (display).
 .. _Tree of Math: http://www.onemathematicalcat.org/MathJaxDocumentation/TeXSyntax.htm
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`MathJax in Studio` (reference)

--- a/source/educators/how-tos/course_development/exercise_tools/adding_multi_select.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/adding_multi_select.rst
@@ -120,7 +120,7 @@ You can add hints to a multi-select problem. For an overview of hints in problem
 :ref:`Adding Feedback and Hints to a Problem`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Multi select` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/adding_text.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/adding_text.rst
@@ -24,6 +24,6 @@ Add Text
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Embed an iframe in the Text Editor` (how-to)

--- a/source/educators/how-tos/course_development/exercise_tools/adding_text_in_numeric_response_field.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/adding_text_in_numeric_response_field.rst
@@ -51,7 +51,7 @@ questions that use this attribute.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Numerical Input` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/award_partial_credit.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/award_partial_credit.rst
@@ -115,7 +115,7 @@ This example illustrates the following points.
 You can enhance and apply this example for your own partial credit problems.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Write Your Own Grader` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/award_partial_credit_multiple_choice.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/award_partial_credit_multiple_choice.rst
@@ -194,7 +194,7 @@ explanation ID.
   </problem>
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Single Select Overview` (concept)
 

--- a/source/educators/how-tos/course_development/exercise_tools/award_partial_credit_numerical_input.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/award_partial_credit_numerical_input.rst
@@ -127,7 +127,7 @@ updated to provide partial credit for a different answer.
   </problem>
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Numerical Input` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/create_custom_javascript.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/create_custom_javascript.rst
@@ -43,6 +43,6 @@ Create a Custom JavaScript Display and Grading Problem
    or on `Wikipedia <https://en.wikipedia.org/wiki/Same_origin_policy>`_.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Custom JavaScript` (reference)

--- a/source/educators/how-tos/course_development/exercise_tools/create_custom_python_problem.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/create_custom_python_problem.rst
@@ -20,7 +20,7 @@ You can also use :ref:`Script Tag Format` or answer tag format to create these p
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Write Your Own Grader` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/create_custom_python_problem_script_tag.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/create_custom_python_problem_script_tag.rst
@@ -120,7 +120,7 @@ sure to set **Show Answer** to **Never** in the problem component.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Write Your Own Grader` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/create_external_grader.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/create_external_grader.rst
@@ -28,7 +28,7 @@ To create a code response problem in Studio, follow these steps.
    you receive an “Error: No grader has been set up for this problem” message.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`External Grader` (concept)
 

--- a/source/educators/how-tos/course_development/exercise_tools/create_full_screen_image.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/create_full_screen_image.rst
@@ -84,7 +84,7 @@ Create a Full Screen Image
 #. Select **Save**.
 
 .. seealso::
- :class:dropdown
+ 
  
  :ref:`Working with Text Components` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/create_iframe.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/create_iframe.rst
@@ -120,7 +120,7 @@ For more information about iframe attributes, see
 `iframe: The Inline Frame element <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe>`_.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`IFrame` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/create_image_mapped_input.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/create_image_mapped_input.rst
@@ -211,7 +211,7 @@ For example, the following ``regions`` attribute creates a pentagon.
  </problem>
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Image Mapped Input` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/create_periodic_table.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/create_periodic_table.rst
@@ -44,6 +44,6 @@ To create the periodic table, you need a Text component.
 #. Click **Save**.
 
 .. seealso::
- :class:dropdown
+ 
 
  :ref:`Working with Problem Components`

--- a/source/educators/how-tos/course_development/exercise_tools/create_poll_olx.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/create_poll_olx.rst
@@ -101,7 +101,7 @@ Create a Poll for OLX
     the problem.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Poll Tool for OLX` (reference)
  

--- a/source/educators/how-tos/course_development/exercise_tools/create_problem_in_latex.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/create_problem_in_latex.rst
@@ -48,7 +48,7 @@ To create a problem written in LaTeX, follow these steps.
    Compile to Open edX XML**.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Numerical Input` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/create_problem_with_hint.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/create_problem_with_hint.rst
@@ -61,6 +61,6 @@ To create the problem illustrated above, follow these steps.
 	</problem>
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Problem with Adaptive Hint XML` (reference)

--- a/source/educators/how-tos/course_development/exercise_tools/create_protein_builder.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/create_protein_builder.rst
@@ -101,7 +101,7 @@ In this code:
        - V
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Chemical Equation` (how-to)
 

--- a/source/educators/how-tos/course_development/exercise_tools/create_staffgraded.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/create_staffgraded.rst
@@ -51,7 +51,7 @@ Staff Graded Assignment Settings
      - Enter the number of points possible for this component. The default value is 1.0.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`StaffGraded Grading` (concept)
 

--- a/source/educators/how-tos/course_development/exercise_tools/create_zooming_image.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/create_zooming_image.rst
@@ -76,7 +76,7 @@ Create a Zooming Image Tool
 #. Select **Save**.
 
 .. seealso::
- :class:dropdown
+ 
 
  :ref:`Add Files to a Course` (how-to)
 

--- a/source/educators/how-tos/course_development/exercise_tools/creating_a_drag_and_drop_problem.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/creating_a_drag_and_drop_problem.rst
@@ -76,7 +76,7 @@ site. For more information, see :ref:`Styling Drag and Drop Problems`.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Drag and Drop Problem <drag_and_drop_problem>` (concept)
 

--- a/source/educators/how-tos/course_development/exercise_tools/edit_multi_select_using_advanced_editor.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/edit_multi_select_using_advanced_editor.rst
@@ -147,7 +147,7 @@ Adding Hints
 See :ref:`Adding Feedback and Hints to a Problem` for more information on adding hints to a problem.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Multi select` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/edit_numerical_input_advanced.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/edit_numerical_input_advanced.rst
@@ -160,7 +160,7 @@ attribute: ``<numericalresponse answer="[5,8)">`` or
 ``<numericalresponse answer="(5,8]">``.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Numerical Input` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/edit_single_select_advanced.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/edit_single_select_advanced.rst
@@ -179,7 +179,7 @@ You can add hints to a single select problem . For an overview of hints in
 problems, see :ref:`Adding Feedback and Hints to a Problem`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Single Select Overview` (concept)
 

--- a/source/educators/how-tos/course_development/exercise_tools/edit_text_input_advanced.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/edit_text_input_advanced.rst
@@ -265,7 +265,7 @@ inside this tag will be ignored by MathJax processor. An example follows.
    </problem>
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Text Input` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/embed_google_calendar.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/embed_google_calendar.rst
@@ -188,7 +188,7 @@ in the :ref:`Obtain the Google Calendar ID` task.
   changes.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Google Calendar Tool` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/embed_google_drive.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/embed_google_drive.rst
@@ -81,7 +81,7 @@ file to the web and obtain the embed code for the file.
    You use that string to configure the Google Drive file component.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Google Drive Files Tool` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/enable_completion.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/enable_completion.rst
@@ -32,7 +32,7 @@ component to a unit in a course, follow these steps.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Completion` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/enable_exercises_tools.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/enable_exercises_tools.rst
@@ -67,7 +67,7 @@ To enable an advanced exercise or tool, follow these steps.
    saved successfully.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Core Problem Types` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/enable_lti_component.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/enable_lti_component.rst
@@ -23,7 +23,7 @@ information, see :ref:`Enable Additional Exercises and Tools`.
   ``lti`` module is no longer present in the **Advanced Module List**.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`LTI Component` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/enable_notes.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/enable_notes.rst
@@ -38,7 +38,7 @@ tool, follow these steps.
 #. Select **Apply** to save your configuration changes.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`RecommenderXBlock` (how-to)
 

--- a/source/educators/how-tos/course_development/exercise_tools/enable_olx_completion.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/enable_olx_completion.rst
@@ -22,7 +22,7 @@ the associated problems is lost each time a new ``url_name`` value is assigned.
     <done url_name="video_3_completion"/>
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Enable Completion` (how to)
 

--- a/source/educators/how-tos/course_development/exercise_tools/generate_ORA_report.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/generate_ORA_report.rst
@@ -105,7 +105,7 @@ The .csv file contains one row of data for each response from a learner.
   Assessments** column.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Open Response Assessments` (concept)
 

--- a/source/educators/how-tos/course_development/exercise_tools/generate_report_ORA_submissions_attachments.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/generate_report_ORA_submissions_attachments.rst
@@ -63,7 +63,7 @@ include the original filename.
 Example: ``[1] - john_doe - prompt_0.txt``.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Open Response Assessments` (concept)
 

--- a/source/educators/how-tos/course_development/exercise_tools/list_manage_students_waiting_peer_step.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/list_manage_students_waiting_peer_step.rst
@@ -38,7 +38,7 @@ the same manner as :ref:`Access Information for a Specific Learner`.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Open Response Assessments` (concept)
 

--- a/source/educators/how-tos/course_development/exercise_tools/randomized_custom_python_problem.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/randomized_custom_python_problem.rst
@@ -58,7 +58,7 @@ input problem.
   </problem>
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Write Your Own Grader` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/setting_up_lti_1_1_component.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/setting_up_lti_1_1_component.rst
@@ -132,7 +132,7 @@ To test an LTI component, use the **Preview** feature or view the live version
 in the LMS. For more information, see :ref:`Testing Your Course Content`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`LTI Component` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/setting_up_lti_1_3_component.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/setting_up_lti_1_3_component.rst
@@ -66,7 +66,7 @@ To add an LTI 1.3 component to a course unit, follow these steps.
      is published before doing a launch.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`LTI Component` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/use_dropdown_feedback.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/use_dropdown_feedback.rst
@@ -113,7 +113,7 @@ a custom label.
   them to all learners. They are not translated into different languages.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Dropdown` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/use_dropdown_hints.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/use_dropdown_hints.rst
@@ -22,7 +22,7 @@ you've added, click the trash can icon next to its respective hint field.
   and views the next one by selecting **Hint** again.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Adding Feedback and Hints to a Problem` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/use_randomized_content_blocks.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/use_randomized_content_blocks.rst
@@ -264,6 +264,6 @@ the learner's submission, reset attempts, or delete the learner's state for a
 problem.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Randomized Content Blocks` (reference)

--- a/source/educators/how-tos/course_development/exercise_tools/using_lti_advantage_features.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/using_lti_advantage_features.rst
@@ -117,7 +117,7 @@ To set up LTI-NRPS services on a component, follow these steps.
           this limit using the `LTI_NRPS_ACTIVE_ENROLLMENT_LIMIT setting`_.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`LTI Component` (reference)
 

--- a/source/educators/how-tos/course_development/exercise_tools/view_metrics_ORA_assignments.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/view_metrics_ORA_assignments.rst
@@ -27,7 +27,7 @@ assignments.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Open Response Assessments` (concept)
 

--- a/source/educators/how-tos/course_development/exercise_tools/view_statistics_single_ORA_assignment.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/view_statistics_single_ORA_assignment.rst
@@ -47,7 +47,7 @@ for each step in the assignment are shown.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Open Response Assessments` (concept)
  

--- a/source/educators/how-tos/course_development/export_import_library.rst
+++ b/source/educators/how-tos/course_development/export_import_library.rst
@@ -106,7 +106,7 @@ To import a library, follow these steps.
    Content`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :doc:`/community/release_notes/sumac/content_libraries_redesign_beta`
 

--- a/source/educators/how-tos/course_development/hide_subsections.rst
+++ b/source/educators/how-tos/course_development/hide_subsections.rst
@@ -115,7 +115,7 @@ end date" message under the subsection's display name.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Course Outline` (concept)
 

--- a/source/educators/how-tos/course_development/hide_units.rst
+++ b/source/educators/how-tos/course_development/hide_units.rst
@@ -63,7 +63,7 @@ check box.
 You are prompted to confirm that you want to make the unit visible to learners.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Set Access Restrictions For a Unit` (how-to)
 

--- a/source/educators/how-tos/course_development/library_access.rst
+++ b/source/educators/how-tos/course_development/library_access.rst
@@ -149,7 +149,7 @@ steps.
    
 
 .. seealso::
- :class: dropdown
+ 
 
  :doc:`/community/release_notes/sumac/content_libraries_redesign_beta`
 

--- a/source/educators/how-tos/course_development/reorder_deleting_custom_pages.rst
+++ b/source/educators/how-tos/course_development/reorder_deleting_custom_pages.rst
@@ -22,7 +22,7 @@ You can also delete a custom page from your course using the delete icon shown o
 If you delete a page after the course start date, note that the visibility of the page in the learner experience changes immediately.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Adding Pages to a Course` (how to)
 

--- a/source/educators/how-tos/course_development/reorganize_components.rst
+++ b/source/educators/how-tos/course_development/reorganize_components.rst
@@ -75,7 +75,7 @@ Follow these steps to move components to another unit in the course outline.
        view of the course until you republish the affected units.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Add a Component` (how-to)
 

--- a/source/educators/how-tos/course_development/set_course_highlights.rst
+++ b/source/educators/how-tos/course_development/set_course_highlights.rst
@@ -78,7 +78,7 @@ Enable Highlight Emails
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`juniper_educator` (reference)
 

--- a/source/educators/how-tos/course_development/set_restrictions_unit.rst
+++ b/source/educators/how-tos/course_development/set_restrictions_unit.rst
@@ -78,7 +78,7 @@ Tp specify a unit's access settings, follow these steps.
     :width: 500
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Hide a Unit from Students` (how-to)
 

--- a/source/educators/how-tos/course_development/set_subsection_problem_date.rst
+++ b/source/educators/how-tos/course_development/set_subsection_problem_date.rst
@@ -117,7 +117,7 @@ To change the results visibility for your subsection, follow these steps.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Create an Open Response Assessment Assignment <PA Create an ORA Assignment>` (how-to)
 

--- a/source/educators/how-tos/course_development/text_components/add_image.rst
+++ b/source/educators/how-tos/course_development/text_components/add_image.rst
@@ -99,7 +99,7 @@ Select a Previously Uploaded Image
 #. Save the Text component and test the image.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Working with Text Components` (reference)
 

--- a/source/educators/how-tos/course_development/text_components/add_link_website_unit_file.rst
+++ b/source/educators/how-tos/course_development/text_components/add_link_website_unit_file.rst
@@ -145,7 +145,7 @@ Course`.
 #. Save the Text component and test the link.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Working with Text Components` (reference)
 

--- a/source/educators/how-tos/course_development/text_components/create_text_component.rst
+++ b/source/educators/how-tos/course_development/text_components/create_text_component.rst
@@ -58,7 +58,7 @@ options use the visual editor by default. There is no way to switch between
 Visual and Raw editor types once selected.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Working with Text Components` (reference)
 

--- a/source/educators/how-tos/course_development/text_components/format_image.rst
+++ b/source/educators/how-tos/course_development/text_components/format_image.rst
@@ -49,7 +49,7 @@ If you want to change the image back to the original size, clear the values in
 the **Width** and **Height** fields.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Add an Image to a Text Component` (how-to)
 

--- a/source/educators/how-tos/course_development/text_components/paste_without_formatting.rst
+++ b/source/educators/how-tos/course_development/text_components/paste_without_formatting.rst
@@ -39,7 +39,7 @@ However, if you select “Remove formatting”, this is what Studio and LMS will
   :width: 600
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Working with Text Components` (reference)
 

--- a/source/educators/how-tos/course_development/text_components/work_with_html.rst
+++ b/source/educators/how-tos/course_development/text_components/work_with_html.rst
@@ -65,7 +65,7 @@ the HTML content in your course.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Working with Text Components` (reference)
 

--- a/source/educators/how-tos/course_development/text_components/work_with_latex.rst
+++ b/source/educators/how-tos/course_development/text_components/work_with_latex.rst
@@ -79,7 +79,7 @@ Work with LaTeX Code
 ..    the tool, make sure you work with your partner manager.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Working with Text Components` (reference)
 

--- a/source/educators/how-tos/course_development/video_process_overview.rst
+++ b/source/educators/how-tos/course_development/video_process_overview.rst
@@ -29,7 +29,7 @@ The following diagram outlines the general process for adding videos to a course
    the video component. 
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Introduction to Video` (reference)
 

--- a/source/educators/how-tos/course_development/view_content_legacy_library.rst
+++ b/source/educators/how-tos/course_development/view_content_legacy_library.rst
@@ -44,7 +44,7 @@ To view the randomized content that was assigned to a specific learner, see
 :ref:`Specific Student View`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :doc:`/community/release_notes/sumac/content_libraries_redesign_beta`
  

--- a/source/educators/how-tos/course_rerun.rst
+++ b/source/educators/how-tos/course_rerun.rst
@@ -67,7 +67,7 @@ steps.
   dashboard in Studio when configuration is complete.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Re-running a Course <Rerun a Course>` (reference)
 

--- a/source/educators/how-tos/course_reruns.rst
+++ b/source/educators/how-tos/course_reruns.rst
@@ -11,7 +11,7 @@ It is possible to schedule a re-run of an existing course, as described in the f
 .. youtube:: jLa3DsHm_Vk
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Re-running a Course <Rerun a Course>` (reference)
 

--- a/source/educators/how-tos/create_course.rst
+++ b/source/educators/how-tos/create_course.rst
@@ -9,7 +9,7 @@ Create a Course
 .. thumbnail:: /_images/Educators_create_course.png
 
 .. Note::
- :class: dropdown
+ 
 
   The Organization, Course Number, and Course run values you enter when creating a course are part of the learner-visible course URL and cannot be changed. The base URL for the new course is in the format:
 
@@ -37,7 +37,7 @@ You are then taken to the empty Outline page in Studio.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Course Outline` (concept)
 

--- a/source/educators/how-tos/create_course_about_page.rst
+++ b/source/educators/how-tos/create_course_about_page.rst
@@ -13,7 +13,7 @@ Watch this video to understand how to create a course description:
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Course Outline` (concept)
 

--- a/source/educators/how-tos/create_video.rst
+++ b/source/educators/how-tos/create_video.rst
@@ -11,7 +11,7 @@ This is how you can add a video to a course:
 .. youtube:: 9C8YTP75HpA
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Video Process Overview` (how-to)
 

--- a/source/educators/how-tos/data/access_anonymized_data.rst
+++ b/source/educators/how-tos/data/access_anonymized_data.rst
@@ -31,7 +31,7 @@ the ``{course_id}_student_profile_info_{date}.csv`` file of learner data or the
 ``{course_id}_grade_report_{date}.csv`` file of grades.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Learner Data` (concept)
 

--- a/source/educators/how-tos/data/certificate_data.rst
+++ b/source/educators/how-tos/data/certificate_data.rst
@@ -45,7 +45,7 @@ To download certificate data, follow these steps.
    Certificate Report`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Setting Up Certificates`
 

--- a/source/educators/how-tos/data/course_answers.rst
+++ b/source/educators/how-tos/data/course_answers.rst
@@ -496,7 +496,7 @@ learners in this example selected the correct answer, the number of incorrect
 answer(s) can guide future changes to the course content.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Answer_Report_FAQ` (reference)
 

--- a/source/educators/how-tos/data/manage_course_grades.rst
+++ b/source/educators/how-tos/data/manage_course_grades.rst
@@ -132,7 +132,7 @@ follow these steps.
    necessary, refresh the page to generate new links.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Interpret the Grade Report` (reference)
 
@@ -189,7 +189,7 @@ ever enrolled in your course, follow these steps.
    than 5 minutes. If necessary, refresh the page to generate new links.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Interpret the Problem Grade Report` (reference)
 
@@ -913,7 +913,7 @@ viewer.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Understanding the Progress Page` (reference)
 

--- a/source/educators/how-tos/data/view_course_information.rst
+++ b/source/educators/how-tos/data/view_course_information.rst
@@ -58,6 +58,6 @@ Additional data about the course and its learners is available from other pages
 in the instructor dashboard.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Manage_Course_Enrollments` (how-to)

--- a/source/educators/how-tos/data/view_download_learner_data.rst
+++ b/source/educators/how-tos/data/view_download_learner_data.rst
@@ -58,7 +58,7 @@ To view learner data, follow these steps.
    :ref:`Columns in the Student Profile Report`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Learner Data` (concept)
 

--- a/source/educators/how-tos/export_import_course.rst
+++ b/source/educators/how-tos/export_import_course.rst
@@ -21,6 +21,6 @@ To use the import and export options to re-run a course, follow these steps.
    and content <Update the New Course>` for the new course.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Updating a New Course after an Import <Update the New Course>` (how-to)

--- a/source/educators/how-tos/grading/set_grace_period.rst
+++ b/source/educators/how-tos/grading/set_grace_period.rst
@@ -29,7 +29,7 @@ the **Grace Period on Deadline** field. Enter the value in ``HH:MM`` format.
   :width: 600
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Graded Subsections` (concept)
 

--- a/source/educators/how-tos/grading/set_grade_range.rst
+++ b/source/educators/how-tos/grading/set_grade_range.rst
@@ -67,7 +67,7 @@ This is true regardless of how many grade levels you add in the grade range.
 For more information, see :ref:`Setting Up Certificates`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Graded Subsections` (concept)
 

--- a/source/educators/how-tos/import_scorm_content.rst
+++ b/source/educators/how-tos/import_scorm_content.rst
@@ -11,7 +11,7 @@ If you have the need to import SCORM content into your course, watch this video:
 .. youtube:: 32LgmaDhu6o
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`SCORM Overview` (reference)
 

--- a/source/educators/how-tos/issue_certificates.rst
+++ b/source/educators/how-tos/issue_certificates.rst
@@ -93,7 +93,7 @@ To allow learners to download early certificates, you modify the
 #. Select **Save Changes**.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Setting Up Certificates` (reference)
 

--- a/source/educators/how-tos/manage_files.rst
+++ b/source/educators/how-tos/manage_files.rst
@@ -10,7 +10,7 @@ Did you know you can add files to your course and make them available to learner
 .. youtube:: CaSbi09YpJU
 
 .. seealso::
- :class:dropdown
+ 
 
  :ref:`Add Files to a Course` (how-to)
 

--- a/source/educators/how-tos/preview_content.rst
+++ b/source/educators/how-tos/preview_content.rst
@@ -26,7 +26,7 @@ configured in Studio, and as a learner in the selected group would see it.
    live course, see :ref:`Specific Student View`.
 
 .. seealso::
- :class:dropdown
+ 
 
  :ref:`Testing Your Course Content` (reference)
 

--- a/source/educators/how-tos/proctored_exams/allow_opt_out_proctored_exam.rst
+++ b/source/educators/how-tos/proctored_exams/allow_opt_out_proctored_exam.rst
@@ -29,7 +29,7 @@ follow these steps.
 #. Select **Submit**.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`ProctoredExams_Overview` (concept)
 

--- a/source/educators/how-tos/proctored_exams/create_proctored_exam_pt.rst
+++ b/source/educators/how-tos/proctored_exams/create_proctored_exam_pt.rst
@@ -130,7 +130,7 @@ steps.
    to the exam reviewers along with the learner's attempt.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`ProctoredExams_Overview` (concept)
 

--- a/source/educators/how-tos/proctored_exams/create_proctored_exam_rpnow.rst
+++ b/source/educators/how-tos/proctored_exams/create_proctored_exam_rpnow.rst
@@ -98,7 +98,7 @@ To specify custom proctored exam rules, follow these steps.
 #. Select **Save**.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`ProctoredExams_Overview` (concept)
 

--- a/source/educators/how-tos/proctored_exams/enable_proctored_exams.rst
+++ b/source/educators/how-tos/proctored_exams/enable_proctored_exams.rst
@@ -47,7 +47,7 @@ proctoring provider, you can create a proctored exam or a practice
 proctored/onboarding exam.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`ProctoredExams_Overview` (concept)
 

--- a/source/educators/how-tos/proctored_exams/manage_proctored_exams.rst
+++ b/source/educators/how-tos/proctored_exams/manage_proctored_exams.rst
@@ -129,7 +129,7 @@ To view learners' onboarding status for your course, follow these steps.
       and their attempt must be reset.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`ProctoredExams_Overview` (concept)
 

--- a/source/educators/how-tos/proctored_exams/review_pt_results.rst
+++ b/source/educators/how-tos/proctored_exams/review_pt_results.rst
@@ -133,7 +133,7 @@ On the page, the learner's status is visible as "Pending", "Satisfactory", or
 "Unsatisfactory".
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`ProctoredExams_Overview` (concept)
 

--- a/source/educators/how-tos/proctored_exams/review_rpnow_results.rst
+++ b/source/educators/how-tos/proctored_exams/review_rpnow_results.rst
@@ -108,7 +108,7 @@ On the page, the learner's status is visible as "Pending", "Satisfactory", or
 "Unsatisfactory".
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`ProctoredExams_Overview` (concept)
 

--- a/source/educators/how-tos/publish_units.rst
+++ b/source/educators/how-tos/publish_units.rst
@@ -14,7 +14,7 @@ After you have added content, you must publish it to make it available to learne
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Controlling Content Visibility` (reference)
 

--- a/source/educators/how-tos/releasing-course/add_beta_testers.rst
+++ b/source/educators/how-tos/releasing-course/add_beta_testers.rst
@@ -134,6 +134,6 @@ problems, questions, and issues can occur while a course is running.
   in the course welcome message, or post it in a discussion.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Beta_Testing` (reference)

--- a/source/educators/how-tos/releasing-course/export_course.rst
+++ b/source/educators/how-tos/releasing-course/export_course.rst
@@ -67,7 +67,7 @@ computer.
   edit them outside of Studio.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Import a Course` (how-to)
 

--- a/source/educators/how-tos/releasing-course/import_course.rst
+++ b/source/educators/how-tos/releasing-course/import_course.rst
@@ -71,7 +71,7 @@ To import a course, follow these steps.
  :ref:`Scheduling Your Course`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Export a Course` (how-to)
 

--- a/source/educators/how-tos/reusable_content/add_html.txt
+++ b/source/educators/how-tos/reusable_content/add_html.txt
@@ -26,7 +26,7 @@
 
 
 .. seealso::
- :class: dropdown
+ 
 
  Add a Link in a Text Component (task)
 

--- a/source/educators/how-tos/reusable_content/add_multiple_choice.txt
+++ b/source/educators/how-tos/reusable_content/add_multiple_choice.txt
@@ -33,7 +33,7 @@
 #. Click :guilabel:`Save` to save the problem in the unit.
 
 .. seealso::
- :class: dropdown
+ 
  
  :ref:`Overview` (concept)
 

--- a/source/educators/how-tos/reusable_content/add_video.txt
+++ b/source/educators/how-tos/reusable_content/add_video.txt
@@ -8,7 +8,7 @@
    .. thumbnail:: /_images/Educators_video_edit.png
 
 .. note::
-  :class: dropdown
+  
 
   These instructions assume you have uploaded the video to YouTube.
 
@@ -24,7 +24,7 @@
 #. In the **Component Display Name** field, enter the name that you want learners to see for this video.
 
    .. note::
-    :class: dropdown
+    
 
     This name appears as a heading above the video in the LMS, and it identifies the video for you in reports and analytics. If you do not enter a display name, the platform specifies “video” for you.
 
@@ -34,7 +34,7 @@
 
 
 .. seealso::
- :class: dropdown
+ 
 
  Preparing a video (task)
 

--- a/source/educators/how-tos/reusable_content/create_course.txt
+++ b/source/educators/how-tos/reusable_content/create_course.txt
@@ -3,7 +3,7 @@
   .. thumbnail:: /_images/Educators_create_course.png
 
 .. Note::
-  :class: dropdown
+  
 
   The Organization, Course Number, and Course run values you enter when creating a course are part of the learner-visible course URL and cannot be changed. The base URL for the new course is in the format:
 

--- a/source/educators/how-tos/reusable_content/publish_course.txt
+++ b/source/educators/how-tos/reusable_content/publish_course.txt
@@ -12,12 +12,12 @@ After you have added content, you must publish it to make it available to learne
 #. For the section, click the Publish icon (|Publish Icon|).
 
    .. note::
-      :class: dropdown
+      
 
       The Publish icon appears only when there is new or changed content within the section.
 
 .. seealso::
- :class: dropdown
+ 
 
  Set Content Release Dates (task)
 

--- a/source/educators/how-tos/reusable_content/schedule_course.txt
+++ b/source/educators/how-tos/reusable_content/schedule_course.txt
@@ -19,7 +19,7 @@
 #. At the bottom of the screen, click :guilabel:`Save Changes`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :doc:`/educators/references/course_pacing` (reference)
 

--- a/source/educators/how-tos/reusable_content/view_as_learner.txt
+++ b/source/educators/how-tos/reusable_content/view_as_learner.txt
@@ -16,7 +16,7 @@ After you have published content, you should view it in the LMS, as a learner wi
 #. Go through the content you created and check for accuracy.  You can edit the content in Studio, then publish your changes, to fix any issues.
 
 .. seealso::
- :class: dropdown
+ 
 
  Beta Test Your Course (task)
 

--- a/source/educators/how-tos/set_licensing.rst
+++ b/source/educators/how-tos/set_licensing.rst
@@ -61,7 +61,7 @@ If a video is to have the same license as the course as a whole, you do not
 need to set the license for the video.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Licensing a Course` (reference)
 

--- a/source/educators/how-tos/set_up_certificates.rst
+++ b/source/educators/how-tos/set_up_certificates.rst
@@ -11,7 +11,7 @@ You can use the following video for help in setting up certificates:
 .. youtube:: 5Ys-E5K0_NY
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Setting Up Certificates` (reference)
 

--- a/source/educators/how-tos/set_up_content_groups.rst
+++ b/source/educators/how-tos/set_up_content_groups.rst
@@ -10,7 +10,7 @@ To set up cohorts and content groups, see this video:
 .. youtube:: rp7st8yxC5E
 
 .. seealso::
- :class:dropdown
+ 
 
  :ref:`Offering Differentiated Content` (concept)
 

--- a/source/educators/how-tos/set_up_course/add_course_staff.rst
+++ b/source/educators/how-tos/set_up_course/add_course_staff.rst
@@ -75,7 +75,7 @@ To remove an assigned role, view the list of users and then select **Revoke
 access**.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Planning Course Staff <Course_Staffing>` (reference)
 

--- a/source/educators/how-tos/set_up_course/add_metadata.rst
+++ b/source/educators/how-tos/set_up_course/add_metadata.rst
@@ -20,7 +20,7 @@ Add Course Metadata
   under ``FEATURES`` in ``/edx/etc/studio.yml`` and restart Studio...
 
 .. seealso::
- :class: dropdown
+ 
  
  :ref:`Getting Started with Course Content Development` (reference)
  

--- a/source/educators/how-tos/set_up_course/create_certificates.rst
+++ b/source/educators/how-tos/set_up_course/create_certificates.rst
@@ -165,7 +165,7 @@ manually remove unused images. For information, see
 
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Setting Up Certificates` (reference)
 

--- a/source/educators/how-tos/set_up_course/creating_new_course.rst
+++ b/source/educators/how-tos/set_up_course/creating_new_course.rst
@@ -70,7 +70,7 @@ To create a course, follow these steps.
    :ref:`Getting Started with Course Content Development <Getting Started with Course Content Development>`.
 
 .. seealso::
- :class: dropdown
+ 
  
  :ref:`Getting Started with Course Content Development` (reference)
 

--- a/source/educators/how-tos/set_up_course/describe_course.rst
+++ b/source/educators/how-tos/set_up_course/describe_course.rst
@@ -140,7 +140,7 @@ To set the hours per week week estimate in Studio, follow these steps.
 
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Creating a Course About Page` (reference)
 

--- a/source/educators/how-tos/set_up_course/edit_certificate.rst
+++ b/source/educators/how-tos/set_up_course/edit_certificate.rst
@@ -126,7 +126,7 @@ To delete a certificate, follow these steps.
 #. In the confirmation dialog, confirm that you want to delete the certificate.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Setting Up Certificates` (reference)
 

--- a/source/educators/how-tos/set_up_course/edit_course_about.rst
+++ b/source/educators/how-tos/set_up_course/edit_course_about.rst
@@ -81,7 +81,7 @@ change.
 
 
 .. seealso::
- :class: dropdown
+ 
  
  :ref:`Getting Started with Course Content Development` (reference)
 

--- a/source/educators/how-tos/set_up_course/enable_badges.rst
+++ b/source/educators/how-tos/set_up_course/enable_badges.rst
@@ -32,7 +32,7 @@ To enable badging for your course if it was previously disabled, change the
 value of the key to ``True``.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Setting Up Certificates` (reference)
 

--- a/source/educators/how-tos/set_up_course/require_entrance_exam.rst
+++ b/source/educators/how-tos/set_up_course/require_entrance_exam.rst
@@ -56,7 +56,7 @@ a record of all the operations that have run for the entrance exam, select
 **Show Background Task History for Student**.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Specify Prerequisite Courses and Exams` (how-to)
 

--- a/source/educators/how-tos/set_up_course/set_prerequisites.rst
+++ b/source/educators/how-tos/set_up_course/set_prerequisites.rst
@@ -36,7 +36,7 @@ For more information about prerequisite courses, see :ref:`Prerequisite
 Courses`.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Require an Entrance Exam` (how-to)
 

--- a/source/educators/how-tos/set_up_course/set_schedule.rst
+++ b/source/educators/how-tos/set_up_course/set_schedule.rst
@@ -113,7 +113,7 @@ To set the pacing for your course, follow these steps.
 
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Course Dates` (reference)
 

--- a/source/educators/how-tos/share_courses_social_media.rst
+++ b/source/educators/how-tos/share_courses_social_media.rst
@@ -33,7 +33,7 @@ media sites such as Facebook and Twitter.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`What is the Course Dashboard` (concept)
 

--- a/source/educators/how-tos/sidebar_collapse_expand.rst
+++ b/source/educators/how-tos/sidebar_collapse_expand.rst
@@ -20,7 +20,7 @@ of the page:
     state of the sidebar remains consistent.
 
 .. seealso::
- :class:dropdown
+ 
 
  :ref:`What is LMS` (concept)
 

--- a/source/educators/how-tos/sidebar_view_course_section.rst
+++ b/source/educators/how-tos/sidebar_view_course_section.rst
@@ -21,7 +21,7 @@ are in the course at the moment:
    .. image:: /_images/educator_how_tos/LSN_view_sections_step2b.png
 
 .. seealso::
- :class:dropdown
+ 
 
  :ref:`What is LMS` (concept)
 

--- a/source/educators/how-tos/student_management/manage_course_enrollments.rst
+++ b/source/educators/how-tos/student_management/manage_course_enrollments.rst
@@ -165,6 +165,6 @@ To unenroll learners, you supply the email addresses of enrolled learners.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Enrollment_Requirements` (reference)

--- a/source/educators/how-tos/update_course_specific_settings.rst
+++ b/source/educators/how-tos/update_course_specific_settings.rst
@@ -34,7 +34,7 @@ To subscribe or unsubscribe to emails from a course, follow these steps.
         learners in the course.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`What is the Course Dashboard` (concept)
 

--- a/source/educators/how-tos/update_rerun_course.rst
+++ b/source/educators/how-tos/update_rerun_course.rst
@@ -89,7 +89,7 @@ for launch, see :ref:`Launch`.
   Changes you make in the new course have no effect on the original course.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Re-running a Course  <Rerun a Course>` (reference)
 

--- a/source/educators/how-tos/use_section_independently_of_course_outline.rst
+++ b/source/educators/how-tos/use_section_independently_of_course_outline.rst
@@ -49,7 +49,7 @@ Use a Section from a Course independently of the Course Outline
      .. image:: /_images/educator_how_tos/hide_in_outline_learner_view.png
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Add Content Experiments to Your Course` (how-to)
 

--- a/source/educators/how-tos/using_lti.rst
+++ b/source/educators/how-tos/using_lti.rst
@@ -9,6 +9,6 @@ It is possible to use LTI content in a course, too!  See this video for details:
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`juniper_educator` (reference)

--- a/source/educators/how-tos/view_another_learners_profile.rst
+++ b/source/educators/how-tos/view_another_learners_profile.rst
@@ -19,7 +19,7 @@ comments in course discussions.
 The learner's account profile page opens.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`What is the Course Dashboard` (concept)
 

--- a/source/educators/how-tos/view_as_learner.rst
+++ b/source/educators/how-tos/view_as_learner.rst
@@ -13,7 +13,7 @@ After you have published content, you should view it in the LMS, as a learner wi
 #. Go through the content you created and check for accuracy.  You can edit the content in Studio, then publish your changes, to fix any issues.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Controlling Content Visibility` (reference)
 

--- a/source/educators/how-tos/view_published_released_content.rst
+++ b/source/educators/how-tos/view_published_released_content.rst
@@ -27,7 +27,7 @@ cohort-specific course content, see :ref:`Viewing Cohort Specific Courseware`.
 
 
 .. seealso::
- :class:dropdown
+ 
 
  :ref:`Testing Your Course Content` (reference)
 

--- a/source/educators/quickstarts/build_a_course.rst
+++ b/source/educators/quickstarts/build_a_course.rst
@@ -82,7 +82,7 @@ Follow the steps below to build your first course. By the end, you will have a f
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Creating a New Course` (how-to)
 

--- a/source/educators/references/accessibility/accessibility_checker.rst
+++ b/source/educators/references/accessibility/accessibility_checker.rst
@@ -102,7 +102,7 @@ content:
 * Scopes
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Accessibility Guidelines` (concept)
 

--- a/source/educators/references/advanced_features/add_content_experiments.rst
+++ b/source/educators/references/advanced_features/add_content_experiments.rst
@@ -29,7 +29,7 @@ location in the course outline. For information, see :ref:`Reorganizing
 Components`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Offering Differentiated Content` (concept)
 

--- a/source/educators/references/advanced_features/experiment_group_configurations.rst
+++ b/source/educators/references/advanced_features/experiment_group_configurations.rst
@@ -32,7 +32,7 @@ Experiment group assignments have the following characteristics.
   content experiments you set up that use the same group configuration.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Offering Differentiated Content` (concept)
 

--- a/source/educators/references/advanced_features/managing_teams_via_csv.rst
+++ b/source/educators/references/advanced_features/managing_teams_via_csv.rst
@@ -223,7 +223,7 @@ Error Conditions
     Increase the team-set size or redistribute users to different/more teams and re-upload.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Teams Overview <CA_Teams_Overview>` (concept)
 

--- a/source/educators/references/advanced_features/planning_content_reuse.rst
+++ b/source/educators/references/advanced_features/planning_content_reuse.rst
@@ -105,7 +105,7 @@ policy key. For more information, see :ref:`Create CourseWide Discussion
 Topics`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Using Open edX as an LTI Tool Provider` (concept)
 

--- a/source/educators/references/advanced_features/teams_configuration_options.rst
+++ b/source/educators/references/advanced_features/teams_configuration_options.rst
@@ -61,7 +61,7 @@ Separate from the team maximum size setting, it is possible to override the spec
 a given team group, allowing you to adjust team sizes to fit your course needs.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Teams Overview <CA_Teams_Overview>` (concept)
 

--- a/source/educators/references/communication/automatic_email.rst
+++ b/source/educators/references/communication/automatic_email.rst
@@ -187,7 +187,7 @@ After a learner or course team member creates a post in the course discussions, 
 The message also contains a View discussion option that takes the learner to the discussion post. An Open edX intance does not send individual messages for any additional replies on the post.
 
 .. seealso::
- :class:dropdown
+ 
 
  :ref:`Bulk Email` (reference)
 

--- a/source/educators/references/communication/bulk_email.rst
+++ b/source/educators/references/communication/bulk_email.rst
@@ -227,7 +227,7 @@ the Email Task History report. For more information, see :ref:`Email Task
 History Report`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Send_Bulk_Email` (how-to)
 

--- a/source/educators/references/communication/compose_email_message.rst
+++ b/source/educators/references/communication/compose_email_message.rst
@@ -110,7 +110,7 @@ tags in an email message. An example follows.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Bulk Email` (reference)
 

--- a/source/educators/references/communication/course_updates_handouts.rst
+++ b/source/educators/references/communication/course_updates_handouts.rst
@@ -30,6 +30,6 @@ Learners see the list of course handouts under **Handouts** in the sidebar.
    under the **Course Handouts** heading.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Add a Course Update` (how-to)

--- a/source/educators/references/communication/example_bulk_emails.rst
+++ b/source/educators/references/communication/example_bulk_emails.rst
@@ -439,7 +439,7 @@ When preparing a message from this template, search for values enclosed by
   The {course number} Staff
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Bulk Email` (reference)
 

--- a/source/educators/references/communication/learner_view_discussion.rst
+++ b/source/educators/references/communication/learner_view_discussion.rst
@@ -29,7 +29,7 @@ discussion topics.
  :width: 400
 
 .. seealso::
- :class:dropdown
+ 
 
  :ref:`Discussions` (concept)
 

--- a/source/educators/references/controlling_content_visibility.rst
+++ b/source/educators/references/controlling_content_visibility.rst
@@ -198,6 +198,6 @@ For information about creating differentiated content based on enrollment
 track, see :ref:`Enrollment Track Specific Courseware Overview`.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Prerequisite Course Subsections <configuring_prerequisite_content>` (how-to)

--- a/source/educators/references/course_dates.rst
+++ b/source/educators/references/course_dates.rst
@@ -47,7 +47,7 @@ Enrollment End Date and Time
 The enrollment end date and time specify when learners can no longer enroll in the course. Ensure that the enrollment end date is late enough to allow learners adequate time to enroll. The enrollment end date must be before the course end date.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Scheduling Your Course` (reference)
 

--- a/source/educators/references/course_development/Section_adding_tooltip.rst
+++ b/source/educators/references/course_development/Section_adding_tooltip.rst
@@ -36,7 +36,7 @@ tooltips.
        . . .
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Adding Feedback and Hints to a Problem` (reference)
 

--- a/source/educators/references/course_development/Section_learner_problem_view.rst
+++ b/source/educators/references/course_development/Section_learner_problem_view.rst
@@ -134,7 +134,7 @@ visible. You can set these attributes in Studio.
   :ref:`Randomization`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Working with Problem Components` (reference)
 

--- a/source/educators/references/course_development/about_course_wiki.rst
+++ b/source/educators/references/course_development/about_course_wiki.rst
@@ -76,7 +76,7 @@ the permissions that you set for an article.
 * Search for Wiki Articles
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Course Wiki Tasks <Course Wiki Tasks>` (how to)
 

--- a/source/educators/references/course_development/about_image_guidelines.rst
+++ b/source/educators/references/course_development/about_image_guidelines.rst
@@ -62,7 +62,7 @@ image that you upload maintains the aspect ratio of those dimensions so that
 the image appears correctly on the dashboard.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Course Title Guidelines` (reference)
 

--- a/source/educators/references/course_development/about_video_guidelines.rst
+++ b/source/educators/references/course_development/about_video_guidelines.rst
@@ -39,7 +39,7 @@ For information about how to add an About video to your course About page, see
 :ref:`Add an About Video <Add an About Video>`.
 
 .. seealso::
- :class:dropdown
+ 
 
  :ref:`Introduction to Video` (reference)
 

--- a/source/educators/references/course_development/add_edit_in_outline.rst
+++ b/source/educators/references/course_development/add_edit_in_outline.rst
@@ -124,7 +124,7 @@ You are prompted to confirm the deletion.
  deleted.
 
 .. seealso::
- :class: dropdown
+ 
  
  :ref:`Getting Started with Course Content Development` (reference)
  

--- a/source/educators/references/course_development/add_video_to_course.rst
+++ b/source/educators/references/course_development/add_video_to_course.rst
@@ -77,7 +77,7 @@ that site. Keep the following guidelines in mind.
   than one hosting site, make sure you have the URL for each video location.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Video Process Overview` (how-to)
 

--- a/source/educators/references/course_development/additional_course_information.rst
+++ b/source/educators/references/course_development/additional_course_information.rst
@@ -222,7 +222,7 @@ information, see :ref:`Add Course Metadata <Add Course Metadata>`.
 
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Course Title Guidelines` (reference)
 

--- a/source/educators/references/course_development/advanced_problem_editor.rst
+++ b/source/educators/references/course_development/advanced_problem_editor.rst
@@ -254,7 +254,7 @@ Creating randomized problems by exporting your course and editing some of your
 course's XML files is no longer supported.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Working with Problem Components` (reference)
 

--- a/source/educators/references/course_development/course_about_page.rst
+++ b/source/educators/references/course_development/course_about_page.rst
@@ -19,7 +19,7 @@ You add the contents of your course About page in Studio.
 
 
 .. seealso::
- :class: dropdown
+ 
  
  :ref:`Getting Started with Course Content Development` (reference)
 

--- a/source/educators/references/course_development/course_export_terminology.rst
+++ b/source/educators/references/course_development/course_export_terminology.rst
@@ -31,7 +31,7 @@ open the list of files that your course contains, look in the **Chapter**
 directory. To find a unit, look in the **Vertical** directory.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Export a Course` (how-to)
 

--- a/source/educators/references/course_development/course_number_guidelines.rst
+++ b/source/educators/references/course_development/course_number_guidelines.rst
@@ -32,7 +32,7 @@ Example Course Numbers
 * 6.002.1x and 6.002.2x
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Course Title Guidelines` (reference)
 

--- a/source/educators/references/course_development/course_outline.rst
+++ b/source/educators/references/course_development/course_outline.rst
@@ -46,7 +46,7 @@ following message is visible.
 To add content, you :ref:`create a section<Create a Section>`.
 
 .. seealso::
- :class: dropdown
+ 
  
  :ref:`Getting Started with Course Content Development` (reference)
  

--- a/source/educators/references/course_development/course_staff.rst
+++ b/source/educators/references/course_development/course_staff.rst
@@ -149,7 +149,7 @@ complete the following tasks.
 
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Add Course Staff` (how-to)
 

--- a/source/educators/references/course_development/course_subsections.rst
+++ b/source/educators/references/course_development/course_subsections.rst
@@ -181,7 +181,7 @@ display name.
 
 
 .. seealso::
- :class: dropdown
+ 
  
  :ref:`Getting Started with Course Content Development` (reference)
  

--- a/source/educators/references/course_development/course_title_guidelines.rst
+++ b/source/educators/references/course_development/course_title_guidelines.rst
@@ -49,7 +49,7 @@ as an XSeries.
 * Circuits and Electronics 3: Applications
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Creating Number Guidelines` (reference)
 

--- a/source/educators/references/course_development/course_units.rst
+++ b/source/educators/references/course_development/course_units.rst
@@ -83,7 +83,7 @@ following actions.
 * Viewed all HTML content for at least five seconds.
 
 .. seealso::
- :class: dropdown
+ 
  
  :ref:`Create a Unit` (how-to)
 

--- a/source/educators/references/course_development/create_problem.rst
+++ b/source/educators/references/course_development/create_problem.rst
@@ -253,7 +253,7 @@ can be most easily realized through Power Paste. To learn how to use Power
 Paste, see :ref:`Paste without Formatting in a Text Component`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Modifying a Released Problem` (reference)
 

--- a/source/educators/references/course_development/description_guidelines.rst
+++ b/source/educators/references/course_development/description_guidelines.rst
@@ -147,7 +147,7 @@ Use the following guidelines to select the level for your course.
   year university students or master's degree students.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Course Title Guidelines` (reference)
 

--- a/source/educators/references/course_development/develop_course_sections.rst
+++ b/source/educators/references/course_development/develop_course_sections.rst
@@ -106,7 +106,7 @@ regardless of the release date of the section or subsection.
 
 
 .. seealso::
- :class: dropdown
+ 
  
  :ref:`Getting Started with Course Content Development` (reference)
  

--- a/source/educators/references/course_development/exercise_tools/Access_ORA_Info.rst
+++ b/source/educators/references/course_development/exercise_tools/Access_ORA_Info.rst
@@ -22,7 +22,7 @@ learner's submission<Remove a learner response from peer grading>`, see
 :ref:`Managing ORA Assignments`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Open Response Assessments` (concept)
 

--- a/source/educators/references/course_development/exercise_tools/ORA_Staff_Grading.rst
+++ b/source/educators/references/course_development/exercise_tools/ORA_Staff_Grading.rst
@@ -173,7 +173,7 @@ by clicking the X at the top right of the application bar. **This will also rele
 grading claim on any submissions the staff member currently has open, but ungraded.**
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Open Response Assessments` (concept)
 

--- a/source/educators/references/course_development/exercise_tools/SCORM_overview.rst
+++ b/source/educators/references/course_development/exercise_tools/SCORM_overview.rst
@@ -44,6 +44,6 @@ There are 2 events a SCORM package can emit in order to communicate with the Ope
     * **value**: A number that reflects the performance of the learner relative to the range bounded by the values of min and max [e.g. if the quiz is out of 10, a number between 0 and 10. The maximum being the ``Weight`` you set in for the SCORM settings above.]
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`SCORM XBlock` (how to)

--- a/source/educators/references/course_development/exercise_tools/Section_adding_hints.rst
+++ b/source/educators/references/course_development/exercise_tools/Section_adding_hints.rst
@@ -137,7 +137,7 @@ hints for learners.
  :width: 300
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Adding Hints via the Advanced Editor` (how-to)
  

--- a/source/educators/references/course_development/exercise_tools/chemical_equation_xml.rst
+++ b/source/educators/references/course_development/exercise_tools/chemical_equation_xml.rst
@@ -101,6 +101,6 @@ Contains the Python script that grades the problem.
   (none)
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Chemical Equation` (how to) 

--- a/source/educators/references/course_development/exercise_tools/completion.rst
+++ b/source/educators/references/course_development/exercise_tools/completion.rst
@@ -63,7 +63,7 @@ select this control as many times as needed.
   :alt: The completion component in a complete state.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Enable Completion` (how to)
 

--- a/source/educators/references/course_development/exercise_tools/create_exercises_and_tools.rst
+++ b/source/educators/references/course_development/exercise_tools/create_exercises_and_tools.rst
@@ -356,7 +356,7 @@ in a web browser.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Create Exercises` (concept)
 

--- a/source/educators/references/course_development/exercise_tools/custom_javascript.rst
+++ b/source/educators/references/course_development/exercise_tools/custom_javascript.rst
@@ -273,6 +273,6 @@ Optional Attributes
   defaults to ``300`` and ``400`` for **height** and **width**, respectively.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Create Custom Javascript` (how to)

--- a/source/educators/references/course_development/exercise_tools/custom_python.rst
+++ b/source/educators/references/course_development/exercise_tools/custom_python.rst
@@ -24,7 +24,7 @@ Learn here how to :ref:`Create a Custom Python Evaluated Input Problem in Studio
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Create a Custom Python Evaluated Input Problem in Studio` (how to)
 

--- a/source/educators/references/course_development/exercise_tools/drag_and_drop.rst
+++ b/source/educators/references/course_development/exercise_tools/drag_and_drop.rst
@@ -324,7 +324,7 @@ The following table explains the controls in the **Editing** dialog box.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Drag and Drop Problem <drag_and_drop_problem>` (concept)
 

--- a/source/educators/references/course_development/exercise_tools/dropdown.rst
+++ b/source/educators/references/course_development/exercise_tools/dropdown.rst
@@ -43,7 +43,7 @@ problem. An example of a dropdown problem from the learner's perspective follows
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Adding Dropdown` (how to)
 

--- a/source/educators/references/course_development/exercise_tools/dropdown_problem_xml.rst
+++ b/source/educators/references/course_development/exercise_tools/dropdown_problem_xml.rst
@@ -216,7 +216,7 @@ None.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Dropdown` (reference)
 

--- a/source/educators/references/course_development/exercise_tools/enable_poll_OLX.rst
+++ b/source/educators/references/course_development/exercise_tools/enable_poll_OLX.rst
@@ -114,7 +114,7 @@ The following table describes the attributes of the ``poll`` element.
          Each answer must have a value for ``img`` or ``label``, or both.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Poll Tool` (reference)
 

--- a/source/educators/references/course_development/exercise_tools/enable_survey_olx.rst
+++ b/source/educators/references/course_development/exercise_tools/enable_survey_olx.rst
@@ -116,6 +116,6 @@ The following table describes the attribute of the ``survey`` element.
          change their responses after seeing others' responses.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Survey Tool` (how to)

--- a/source/educators/references/course_development/exercise_tools/external_grader_requirements.rst
+++ b/source/educators/references/course_development/exercise_tools/external_grader_requirements.rst
@@ -213,7 +213,7 @@ external grader.
   </problem>
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`External Grader` (concept)
 

--- a/source/educators/references/course_development/exercise_tools/gene_explorer.rst
+++ b/source/educators/references/course_development/exercise_tools/gene_explorer.rst
@@ -64,7 +64,7 @@ In this code:
 
 .. seealso::
 
- :class: dropdown
+ 
 
  :ref:`Create Custom Javascript` (how to) 
 

--- a/source/educators/references/course_development/exercise_tools/google_calendar.rst
+++ b/source/educators/references/course_development/exercise_tools/google_calendar.rst
@@ -45,6 +45,6 @@ learners see the updates immediately. You make changes to calendars with the
 Google user interface. You do not need to edit the Google Calendar component.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Embed Google Calendar` (how to)

--- a/source/educators/references/course_development/exercise_tools/google_docs.rst
+++ b/source/educators/references/course_development/exercise_tools/google_docs.rst
@@ -51,7 +51,7 @@ learners see the updates immediately. You make changes to files with the
 Google user interface. You do not need to edit the Google Document component.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Embed Google Drive Files` (how to)
 

--- a/source/educators/references/course_development/exercise_tools/iframe.rst
+++ b/source/educators/references/course_development/exercise_tools/iframe.rst
@@ -32,6 +32,6 @@ For more information about iframes, see the `iframe: The Inline Frame element
 <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe>`_.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Create IFrame` (how to)

--- a/source/educators/references/course_development/exercise_tools/image_mapped_input.rst
+++ b/source/educators/references/course_development/exercise_tools/image_mapped_input.rst
@@ -28,7 +28,7 @@ You can specify the following types of regions.
  about alt text, see :ref:`Best Practices for Describing Images`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Create Image Mapped Input Problem` (how to)
 

--- a/source/educators/references/course_development/exercise_tools/image_mapped_input_xml.rst
+++ b/source/educators/references/course_development/exercise_tools/image_mapped_input_xml.rst
@@ -73,7 +73,7 @@ Specifies the image file and the region in the file where learners must click.
   (none)
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Create Image Mapped Input Problem` (how to)
 

--- a/source/educators/references/course_development/exercise_tools/lti_component.rst
+++ b/source/educators/references/course_development/exercise_tools/lti_component.rst
@@ -65,7 +65,7 @@ For more information about how to use Studio as an LTI tool provider, see
 .. note the slightly different destination links ^. Alison 23 Nov 2015
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Enable_LTI_Components` (how to)
 

--- a/source/educators/references/course_development/exercise_tools/lti_component_settings.rst
+++ b/source/educators/references/course_development/exercise_tools/lti_component_settings.rst
@@ -191,7 +191,7 @@ LTI Component Settings
         enable the setting in the Django administration console.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Enable_LTI_Components` (how to)
 

--- a/source/educators/references/course_development/exercise_tools/math_expression_input.rst
+++ b/source/educators/references/course_development/exercise_tools/math_expression_input.rst
@@ -107,7 +107,7 @@ problem follows.
   </problem>
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Adding Math Expression Problem` (how to)
 

--- a/source/educators/references/course_development/exercise_tools/math_expression_input_xml.rst
+++ b/source/educators/references/course_development/exercise_tools/math_expression_input_xml.rst
@@ -260,7 +260,7 @@ This element contains an HTML division ``<div>``. The division contains one or
 more paragraphs ``<p>`` of explanatory text.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Math Expression Input` (reference)
 

--- a/source/educators/references/course_development/exercise_tools/mathjax_studio.rst
+++ b/source/educators/references/course_development/exercise_tools/mathjax_studio.rst
@@ -42,7 +42,7 @@ For display equations, you can do either of the following.
     ``[mathjax] equation [/mathjax]``
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Adding MathJax` (reference)
 

--- a/source/educators/references/course_development/exercise_tools/multi_select.rst
+++ b/source/educators/references/course_development/exercise_tools/multi_select.rst
@@ -50,7 +50,7 @@ the three required answer options. This example also shows that the learner
 selected **Show Answer** to reveal the correct answer and an explanation.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Add a Multi Select Problem` (how-to)
 

--- a/source/educators/references/course_development/exercise_tools/multi_select_xml.rst
+++ b/source/educators/references/course_development/exercise_tools/multi_select_xml.rst
@@ -333,7 +333,7 @@ correctness.
   line.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Multi select` (reference)
 

--- a/source/educators/references/course_development/exercise_tools/multiple_choice.rst
+++ b/source/educators/references/course_development/exercise_tools/multiple_choice.rst
@@ -13,7 +13,7 @@ To learn more about the different types of Multiple-Choice Questions, please vis
 * :ref:`Multi select`
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Single Select` (reference)
 

--- a/source/educators/references/course_development/exercise_tools/numerical_input.rst
+++ b/source/educators/references/course_development/exercise_tools/numerical_input.rst
@@ -62,7 +62,7 @@ numerical input problem. An example of a completed numerical input problem follo
  :alt: A problem with one question, answered correctly, in the LMS.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Editing Numerical Input Problems using the Advanced Editor` (how to)
 

--- a/source/educators/references/course_development/exercise_tools/numerical_input_xml.rst
+++ b/source/educators/references/course_development/exercise_tools/numerical_input_xml.rst
@@ -368,7 +368,7 @@ Children
 None.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Numerical Input` (reference)
 

--- a/source/educators/references/course_development/exercise_tools/poll_olx.rst
+++ b/source/educators/references/course_development/exercise_tools/poll_olx.rst
@@ -113,7 +113,7 @@ Example of poll with unable reset functionality
     </poll_question>
 
 .. seealso::
- :class: dropdown
+ 
  
  :ref:`Create a Poll` (how to)
  

--- a/source/educators/references/course_development/exercise_tools/poll_tool.rst
+++ b/source/educators/references/course_development/exercise_tools/poll_tool.rst
@@ -47,7 +47,7 @@ quotation marks around the key value.) For more information, see
 :ref:`Enable Additional Exercises and Tools`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Add Poll` (how to)
 

--- a/source/educators/references/course_development/exercise_tools/problem_hint_xml.rst
+++ b/source/educators/references/course_development/exercise_tools/problem_hint_xml.rst
@@ -108,6 +108,6 @@ Tags
          ``<hintgroup hintfn="hint_fn"/>``).
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Problem with Adaptive Hint` (how to)

--- a/source/educators/references/course_development/exercise_tools/script_tag_format.rst
+++ b/source/educators/references/course_development/exercise_tools/script_tag_format.rst
@@ -171,7 +171,7 @@ preceding example.
        attributes. The ``correct_answer`` attribute is optional.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Write Your Own Grader` (reference)
 

--- a/source/educators/references/course_development/exercise_tools/single_select_xml.rst
+++ b/source/educators/references/course_development/exercise_tools/single_select_xml.rst
@@ -430,7 +430,7 @@ correctness.
   line.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Single Select Overview` (concept)
 

--- a/source/educators/references/course_development/exercise_tools/text_input.rst
+++ b/source/educators/references/course_development/exercise_tools/text_input.rst
@@ -42,7 +42,7 @@ input problem. An example of a completed text input problem follows.
   which appear below the response along with the explanation.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Add Text Input Problem` (how to)
 

--- a/source/educators/references/course_development/exercise_tools/text_input_xml.rst
+++ b/source/educators/references/course_development/exercise_tools/text_input_xml.rst
@@ -299,7 +299,7 @@ Children
 None.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Text Input` (reference)
 

--- a/source/educators/references/course_development/files_page.rst
+++ b/source/educators/references/course_development/files_page.rst
@@ -136,7 +136,7 @@ To reset the list and view files of all types, clear all checkboxes.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Add Files to a Course` (how-to)
 

--- a/source/educators/references/course_development/modify_outline_settings.rst
+++ b/source/educators/references/course_development/modify_outline_settings.rst
@@ -27,7 +27,7 @@ circled for a section, a subsection, and two units.
 For more information, see the links above.
 
 .. seealso::
- :class: dropdown
+ 
  
  :ref:`Getting Started with Course Content Development` (reference)
  

--- a/source/educators/references/course_development/modifying_released_problem.rst
+++ b/source/educators/references/course_development/modifying_released_problem.rst
@@ -55,7 +55,7 @@ For information about how to review and adjust learner grades in the LMS, see
 :ref:`Adjust_grades`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Working with Problem Components` (reference)
 

--- a/source/educators/references/course_development/parent_child_components.rst
+++ b/source/educators/references/course_development/parent_child_components.rst
@@ -149,7 +149,7 @@ The following example shows the learner view of the unit described above.
  :width: 400
 
 .. seealso::
- :class:dropdown
+ 
 
  :ref:`Unit States and Visibility to Students` (reference)
 

--- a/source/educators/references/course_development/problem_settings.rst
+++ b/source/educators/references/course_development/problem_settings.rst
@@ -169,7 +169,7 @@ been used, the **Hint** or **Next Hint** option is no longer available.
  :width: 600
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Configure Hint` (how-to)
 
@@ -290,7 +290,7 @@ Problems** advanced setting.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Working with Problem Components` (reference)
 

--- a/source/educators/references/course_development/publish_from_outline.rst
+++ b/source/educators/references/course_development/publish_from_outline.rst
@@ -28,7 +28,7 @@ For more information, see the following topics.
 * :ref:`Publish a Unit`
 
 .. seealso::
- :class: dropdown
+ 
  
  :ref:`Getting Started with Course Content Development` (reference)
  

--- a/source/educators/references/course_development/rerunning_course.rst
+++ b/source/educators/references/course_development/rerunning_course.rst
@@ -69,7 +69,7 @@ other course. Therefore, you should ensure that the original course content is
 as complete as possible before you re-run the course.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Course re-runs <Course reruns>` (how-to)
 

--- a/source/educators/references/course_development/text_components/text_components.rst
+++ b/source/educators/references/course_development/text_components/text_components.rst
@@ -171,7 +171,7 @@ descriptions.
   Updates and Handouts>`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Create a Text Component` (how-to)
 

--- a/source/educators/references/course_development/troubleshoot_video.rst
+++ b/source/educators/references/course_development/troubleshoot_video.rst
@@ -33,7 +33,7 @@ When you use video, you might experience one of the following problems.
   settings.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Video Process Overview` (how-to)
 

--- a/source/educators/references/course_development/understanding_course_outline.rst
+++ b/source/educators/references/course_development/understanding_course_outline.rst
@@ -38,7 +38,7 @@ Units>`.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Getting Started with Course Content Development` (reference)
  

--- a/source/educators/references/course_development/unit_workflow_and_status.rst
+++ b/source/educators/references/course_development/unit_workflow_and_status.rst
@@ -197,7 +197,7 @@ The **Release** section applies only to instructor-paced courses. It does not
 appear for units in self-paced courses.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Create a Unit` (how-to)
 

--- a/source/educators/references/course_development/video_guidelines.rst
+++ b/source/educators/references/course_development/video_guidelines.rst
@@ -112,7 +112,7 @@ not required.
      - :ref:`AAC<AAC>` 44.1 / 192 kbps
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Video Process Overview` (how-to)
 

--- a/source/educators/references/course_development/what_is_a_component.rst
+++ b/source/educators/references/course_development/what_is_a_component.rst
@@ -24,7 +24,7 @@ your course.
   course.
 
 .. seealso::
- :class: dropdown
+ 
  
  :ref:`Add a Component` (how-to)
 

--- a/source/educators/references/course_development/work_with_targz_file.rst
+++ b/source/educators/references/course_development/work_with_targz_file.rst
@@ -33,7 +33,7 @@ For more, see the following resources:
 .. _TarTool: https://github.com/senthilrajasek/tartool
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Export a Course` (how-to)
 

--- a/source/educators/references/course_pacing.rst
+++ b/source/educators/references/course_pacing.rst
@@ -32,7 +32,7 @@ Self-Paced Courses
 Courses that allow learners to work at their own pace, as long as they are finished by the time the course ends, are known as self-paced courses. These courses offer learners flexibility to modify the assignment dates as needed. Select :guilabel:`Self-Paced` in the Course Schedule and Details screen.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Scheduling Your Course` (reference)
 

--- a/source/educators/references/creating_certificates.rst
+++ b/source/educators/references/creating_certificates.rst
@@ -72,7 +72,7 @@ logo, are configured on your instance. For more information, see
        Start and End Dates>`.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Enable a Certificate` (how-to)
 

--- a/source/educators/references/dashboard_profile.rst
+++ b/source/educators/references/dashboard_profile.rst
@@ -27,7 +27,7 @@ menu options.
   address and set your Time Zones.
 
 .. seealso::
- :class:dropdown
+ 
 
  :ref:`Course Outline` (concept)
 

--- a/source/educators/references/data/certificate_report_columns.rst
+++ b/source/educators/references/data/certificate_report_columns.rst
@@ -26,7 +26,7 @@ the course.
      - The date the report was created.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Access Certificate Data` (how-to)
 

--- a/source/educators/references/data/interpreting_grade_report.rst
+++ b/source/educators/references/data/interpreting_grade_report.rst
@@ -131,7 +131,7 @@ columns that provide the following information.
   enrolled or unenrolled in the course.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Learner Data` (concept)
   

--- a/source/educators/references/data/interpreting_problem_grade_report.rst
+++ b/source/educators/references/data/interpreting_problem_grade_report.rst
@@ -45,7 +45,7 @@ provide the following information.
   this column is "Not Available".
 
 .. seealso::
- :class: dropdown
+ 
 
   :ref:`Learner Data` (concept)
 

--- a/source/educators/references/data/staff_debug_info.rst
+++ b/source/educators/references/data/staff_debug_info.rst
@@ -43,6 +43,6 @@ but for the sake of clarity, some of these fields are documented here.
   contains this problem.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Learner Data` (concept)  

--- a/source/educators/references/data/student_profile_report.rst
+++ b/source/educators/references/data/student_profile_report.rst
@@ -117,7 +117,7 @@ in this report) are configurable in the Open edX site configuration.
        value can be updated or set on the **Account Settings** page.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Learner Data` (concept)
 

--- a/source/educators/references/data/understanding_progress_page.rst
+++ b/source/educators/references/data/understanding_progress_page.rst
@@ -108,7 +108,7 @@ If your course is eligible, this feature will describe which of the following st
      :alt: Certificate Status feature describing the learner has passed and can view their certificate.
 
 .. seealso::
- :class: dropdown
+ 
 
   :ref:`Learner Data` (concept)
 

--- a/source/educators/references/grading/gradebook_assignment_types.rst
+++ b/source/educators/references/grading/gradebook_assignment_types.rst
@@ -83,7 +83,7 @@ You configure the following fields for each assignment type.
   :width: 600
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Graded Subsections` (concept)
 

--- a/source/educators/references/grading/learner_view_of_grades.rst
+++ b/source/educators/references/grading/learner_view_of_grades.rst
@@ -33,7 +33,7 @@ together, followed by labs, then exams.
  dropped when you :ref:`configure assignment types <Gradebook Assignment Types>`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Graded Subsections` (concept)
 

--- a/source/educators/references/licensing_course.rst
+++ b/source/educators/references/licensing_course.rst
@@ -106,6 +106,6 @@ allowed combination of options, learners see **Some Rights Reserved** and can
 select the link to see details.
 
 .. seealso::
-  :class: dropdown
+  
 
   :ref:`Set Course Content Licensing` (how-to)

--- a/source/educators/references/proctored_exams/online_proctoring_rules.rst
+++ b/source/educators/references/proctored_exams/online_proctoring_rules.rst
@@ -125,7 +125,7 @@ team before you make any choices on the exam page. The course team must approve
 your request and make any adjustments before you start your exam.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`ProctoredExams_Overview` (concept)
 

--- a/source/educators/references/proctored_exams/pt_proctored_exam_report.rst
+++ b/source/educators/references/proctored_exams/pt_proctored_exam_report.rst
@@ -207,7 +207,7 @@ column.
        credit.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`ProctoredExams_Overview` (concept)
 

--- a/source/educators/references/proctored_exams/rpnow_proctored_exam_report.rst
+++ b/source/educators/references/proctored_exams/rpnow_proctored_exam_report.rst
@@ -200,7 +200,7 @@ column.
        the learner is no longer eligible for academic credit.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`ProctoredExams_Overview` (concept)
 

--- a/source/educators/references/resources_for_course_teams.rst
+++ b/source/educators/references/resources_for_course_teams.rst
@@ -48,7 +48,7 @@ The Open edX product team maintains public product roadmaps at this `public road
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Course Outline` (concept)
 

--- a/source/educators/references/resources_for_open_edx.rst
+++ b/source/educators/references/resources_for_open_edx.rst
@@ -13,7 +13,7 @@ page for a list of the documentation that is available.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Course Outline` (concept)
 

--- a/source/educators/references/reusable_references/course_highlight_message_text.rst
+++ b/source/educators/references/reusable_references/course_highlight_message_text.rst
@@ -35,6 +35,6 @@ verified enrollment track.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Automatic Email Messages` (reference)

--- a/source/educators/references/roles_for_viewing.rst
+++ b/source/educators/references/roles_for_viewing.rst
@@ -177,7 +177,7 @@ previewing enrollment track based content, see :ref:`About Enrollment Track
 Groups and Access` and :ref:`Enrollment Track Specific Courseware Overview`.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Create Cohort Specific Course Content` (how-to)
 

--- a/source/educators/references/scheduling_course.rst
+++ b/source/educators/references/scheduling_course.rst
@@ -131,7 +131,7 @@ visible.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Course Dates` (reference)
 

--- a/source/educators/references/setting_course_pacing.rst
+++ b/source/educators/references/setting_course_pacing.rst
@@ -116,7 +116,7 @@ The relative due date you saved will now be published for all enrolled learners.
 
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Course Pacing` (how-to)
 

--- a/source/educators/references/student_management/enrollment_requirements.rst
+++ b/source/educators/references/student_management/enrollment_requirements.rst
@@ -43,6 +43,6 @@ either before or after the learners register their user accounts.
    account, and enroll in the course.
 
 .. seealso::
- :class: dropdown
+ 
 
  :ref:`Manage_Course_Enrollments` (how-to)

--- a/source/educators/references/testing_course_content.rst
+++ b/source/educators/references/testing_course_content.rst
@@ -100,7 +100,7 @@ When you use **Staff** view in preview mode, you also see any content that is
 
 
 .. seealso::
- :class:dropdown
+ 
 
  :ref:`Roles for Viewing Course Content` (reference)
 

--- a/source/educators/references/workflow.rst
+++ b/source/educators/references/workflow.rst
@@ -155,7 +155,7 @@ more information, see :ref:`Designing for Mobile`.
 
 
 .. seealso::
- :class: dropdown
+ 
  
  :ref:`Course Outline` (concept)
  


### PR DESCRIPTION
The `:class: dropdown` is unneeded in seealso tables, and often causes rendering issues. And note: those tables don't even render as dropdowns!

See https://docs.openedx.org/en/latest/community/release_notes/sumac/customizing_header.html for an example of a seealso table that does not define `:class: dropdown` and renders fine.

An example of a rendering issue:

<img width="262" alt="image" src="https://github.com/user-attachments/assets/2154435f-4263-4ba0-b665-1050fb75d43f" />
