### PR TITLE
Fix some outdated ref links

### DIFF
--- a/source/community/release_notes/juniper.rst
+++ b/source/community/release_notes/juniper.rst
@@ -10,7 +10,7 @@ Juniper spans January 2019 through May 2020. You can also review details about
 Open edX. Below is a summary of the changes for each of the main platform
 areas, along with a way to jump down to each section of the release notes.
 
-.. _earlier releases: https://edx.readthedocs.io/projects/edx-developer-docs/en/latest/named_releases.html
+.. _earlier releases: https://docs.openedx.org/en/latest/community/release_notes/index.html
 .. _Open edX Platform: https://open.edx.org
 
 .. toctree::

--- a/source/community/release_notes/koa.rst
+++ b/source/community/release_notes/koa.rst
@@ -5,7 +5,7 @@ Open edX Koa Release
 
 These are the release notes for the Koa release, the 11th community release of the Open edX Platform, spanning changes from May 23 to November 12 2020.  You can also review details about `earlier releases`_ or learn more about the `Open edX Platform`_ if you are new to Open edX.
 
-.. _earlier releases: https://edx.readthedocs.io/projects/edx-developer-docs/en/latest/named_releases.html
+.. _earlier releases: https://docs.openedx.org/en/latest/community/release_notes/index.html
 .. _Open edX Platform: https://open.edx.org
 
 .. contents::

--- a/source/community/release_notes/lilac.rst
+++ b/source/community/release_notes/lilac.rst
@@ -59,7 +59,7 @@ When a learner reaches the end of the course, they will see a new navigation but
 
 The 3-day Streak Milestone is live and celebrates learners who engage with their course on 3 consecutive days. It also provides normative insights into how learners’ behavior connects to successful course outcomes. (TBD Image)
 
-See https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-FEATURES['ENABLE_MILESTONES_APP'] for information on how to turn on and configure these Milestones features.
+See https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-FEATURES['ENABLE_MILESTONES_APP'] for information on how to turn on and configure these Milestones features.
 
 Mobile Experience
 =================
@@ -154,7 +154,7 @@ Course Upsell Messaging and Payment
 Settings and Toggles Documentation
 ==================================
 
-Documentation for settings and toggles is much improved, but still incomplete. See https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/index.html
+Documentation for settings and toggles is much improved, but still incomplete. See https://docs.openedx.org/projects/edx-platform/en/latest/index.html
 
 New settings introduced in Lilac include:
 

--- a/source/community/release_notes/lilac.rst
+++ b/source/community/release_notes/lilac.rst
@@ -5,7 +5,7 @@ Open edX Lilac Release
 
 These are the release notes for the Lilac release, the 12th community release of the Open edX Platform, spanning changes from November 12 2020 to April 9 2021.  You can also review details about `earlier releases`_ or learn more about the `Open edX Platform`_.
 
-.. _earlier releases: https://edx.readthedocs.io/projects/edx-developer-docs/en/latest/named_releases.html
+.. _earlier releases: https://docs.openedx.org/en/latest/community/release_notes/index.html
 .. _Open edX Platform: https://open.edx.org
 
 .. contents::

--- a/source/community/release_notes/maple.rst
+++ b/source/community/release_notes/maple.rst
@@ -352,7 +352,7 @@ See the sections above on OAuth and Certificates.
 Settings and Toggles
 ====================
 
-Documentation for settings and toggles is much improved, but still incomplete. See https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/index.html
+Documentation for settings and toggles is much improved, but still incomplete. See https://docs.openedx.org/projects/edx-platform/en/latest/index.html
 
 
 Dependency updates

--- a/source/community/release_notes/maple.rst
+++ b/source/community/release_notes/maple.rst
@@ -5,7 +5,7 @@ Open edX Maple Release
 
 These are the release notes for the Maple release, the 13th community release of the Open edX Platform, spanning changes from April 9 2021 to October 15 2021.  You can also review details about `earlier releases`_ or learn more about the `Open edX Platform`_.
 
-.. _earlier releases: https://edx.readthedocs.io/projects/edx-developer-docs/en/latest/named_releases.html
+.. _earlier releases: https://docs.openedx.org/en/latest/community/release_notes/index.html
 .. _Open edX Platform: https://open.edx.org
 
 .. contents::

--- a/source/community/release_notes/nutmeg.rst
+++ b/source/community/release_notes/nutmeg.rst
@@ -5,7 +5,7 @@ Open edX Nutmeg Release
 
 These are the release notes for the Nutmeg release, the 14th community release of the Open edX Platform, spanning changes from October 15 2021 to April 11 2022.  You can also review details about `earlier releases`_ or learn more about the `Open edX Platform`_.
 
-.. _earlier releases: https://edx.readthedocs.io/projects/edx-developer-docs/en/latest/named_releases.html
+.. _earlier releases: https://docs.openedx.org/en/latest/community/release_notes/index.html
 .. _Open edX Platform: https://openedx.org
 
 .. contents::

--- a/source/community/release_notes/nutmeg.rst
+++ b/source/community/release_notes/nutmeg.rst
@@ -135,7 +135,7 @@ Administrators & Operators
 
 * It's now possible to add optional fields to the registration form that are always visible and do not require the user to click the checkbox "Support education research by providing additional information." Use the new :code:`optional-exposed` setting in the `REGISTRATION_EXTRA_FIELDS`_ setting.
 
-.. _REGISTRATION_EXTRA_FIELDS: https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/settings.html#setting-REGISTRATION_EXTRA_FIELDS
+.. _REGISTRATION_EXTRA_FIELDS: https://docs.openedx.org/projects/edx-platform/en/latest/settings.html#setting-REGISTRATION_EXTRA_FIELDS
 
 * Added an activation opt in checkbox to the registration form (default checked) so user can agree to receive marketing messages. The field :code:`marketing_emails_opt_in` is now enabled by default in the `REGISTRATION_EXTRA_FIELDS`_ setting.
 
@@ -193,44 +193,44 @@ Settings and Toggles
 
 New settings and toggles added since the Maple release:
 
-* `CELERY_EXTRA_IMPORTS <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/settings.html#setting-CELERY_EXTRA_IMPORTS>`_
-* `DISCUSSIONS_MFE_FEEDBACK_URL <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/settings.html#setting-DISCUSSIONS_MFE_FEEDBACK_URL%20=%20None>`_
-* `ORA_GRADING_MICROFRONTEND_URL <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/settings.html#setting-ORA_GRADING_MICROFRONTEND_URL>`_
+* `CELERY_EXTRA_IMPORTS <https://docs.openedx.org/projects/edx-platform/en/latest/settings.html#setting-CELERY_EXTRA_IMPORTS>`_
+* `DISCUSSIONS_MFE_FEEDBACK_URL <https://docs.openedx.org/projects/edx-platform/en/latest/settings.html#setting-DISCUSSIONS_MFE_FEEDBACK_URL%20=%20None>`_
+* `ORA_GRADING_MICROFRONTEND_URL <https://docs.openedx.org/projects/edx-platform/en/latest/settings.html#setting-ORA_GRADING_MICROFRONTEND_URL>`_
 
-* `RATELIMIT_RATE <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/settings.html#setting-RATELIMIT_RATE>`_
-* `REGISTRATION_RATELIMIT <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/settings.html#setting-REGISTRATION_RATELIMIT>`_
-* `COURSEGRAPH_CONNECTION <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/settings.html#setting-COURSEGRAPH_CONNECTION>`_
-* `COURSEGRAPH_JOB_QUEUE <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/settings.html#setting-COURSEGRAPH_JOB_QUEUE>`_
-* `PREPEND_LOCALE_PATHS <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/settings.html#setting-PREPEND_LOCALE_PATHS>`_
-* `BULK_EMAIL_SEND_USING_EDX_ACE <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-BULK_EMAIL_SEND_USING_EDX_ACE>`_
-* `COURSEGRAPH_DUMP_COURSE_ON_PUBLISH <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-COURSEGRAPH_DUMP_COURSE_ON_PUBLISH>`_
-* `ENABLE_AUTHN_LOGIN_BLOCK_HIBP_POLICY <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-ENABLE_AUTHN_LOGIN_BLOCK_HIBP_POLICY>`_
-* `ENABLE_AUTHN_LOGIN_NUDGE_HIBP_POLICY <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-ENABLE_AUTHN_LOGIN_NUDGE_HIBP_POLICY>`_
-* `ENABLE_AUTHN_REGISTER_HIBP_POLICY <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-ENABLE_AUTHN_REGISTER_HIBP_POLICY>`_
-* `ENABLE_COPPA_COMPLIANCE <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-ENABLE_COPPA_COMPLIANCE>`_
-* `ENFORCE_SAFE_SESSIONS <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-ENFORCE_SAFE_SESSIONS>`_
-* `FEATURES['ENABLE_AUTOMATED_SIGNUPS_EXTRA_FIELDS'] <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-FEATURES['ENABLE_AUTOMATED_SIGNUPS_EXTRA_FIELDS']>`_
-* `FEATURES['ENABLE_INTEGRITY_SIGNATURE'] <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-FEATURES['ENABLE_INTEGRITY_SIGNATURE']>`_
-* `FEATURES['ENABLE_NEW_BULK_EMAIL_EXPERIENCE'] <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-FEATURES['ENABLE_NEW_BULK_EMAIL_EXPERIENCE']>`_
-* `FEATURES['ENABLE_PASSWORD_RESET_FAILURE_EMAIL'] <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-FEATURES['ENABLE_PASSWORD_RESET_FAILURE_EMAIL']>`_
-* `FEATURES['SHOW_PROGRESS_BAR'] <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-FEATURES['SHOW_PROGRESS_BAR']>`_
-* `LOG_REQUEST_USER_CHANGE_HEADERS <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-LOG_REQUEST_USER_CHANGE_HEADERS>`_
-* `MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW>`_
-* `RATELIMIT_ENABLE <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-RATELIMIT_ENABLE>`_
-* `SEARCH_SKIP_SHOW_IN_CATALOG_FILTERING <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-SEARCH_SKIP_SHOW_IN_CATALOG_FILTERING>`_
-* `course_live.enable_course_live <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-course_live.enable_course_live>`_
-* `courseware.enable_new_financial_assistance_flow <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-courseware.enable_new_financial_assistance_flow>`_
-* `discussions.enable_discussions_mfe <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-discussions.enable_discussions_mfe>`_
-* `discussions.enable_learners_tab_in_discussions_mfe <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-discussions.enable_learners_tab_in_discussions_mfe>`_
-* `discussions.enable_moderation_reason_codes <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-discussions.enable_moderation_reason_codes>`_
-* `discussions.enable_new_structure_discussions <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-discussions.enable_new_structure_discussions>`_
-* `discussions.enable_reported_content_email_notifications <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-discussions.enable_reported_content_email_notifications>`_
-* `learner_dashboard.enable_masters_program_tab_view <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-learner_dashboard.enable_masters_program_tab_view>`_
-* `learner_dashboard.enable_program_tab_view <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-learner_dashboard.enable_program_tab_view>`_
-* `learner_dashboard.enable_program_tab_view <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-learner_dashboard.enable_program_tab_view>`_
-* `new_core_editors.use_new_problem_editor <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-new_core_editors.use_new_problem_editor>`_
-* `new_core_editors.use_new_text_editor <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-new_core_editors.use_new_text_editor>`_
-* `new_core_editors.use_new_video_editor <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-new_core_editors.use_new_video_editor>`_
+* `RATELIMIT_RATE <https://docs.openedx.org/projects/edx-platform/en/latest/settings.html#setting-RATELIMIT_RATE>`_
+* `REGISTRATION_RATELIMIT <https://docs.openedx.org/projects/edx-platform/en/latest/settings.html#setting-REGISTRATION_RATELIMIT>`_
+* `COURSEGRAPH_CONNECTION <https://docs.openedx.org/projects/edx-platform/en/latest/settings.html#setting-COURSEGRAPH_CONNECTION>`_
+* `COURSEGRAPH_JOB_QUEUE <https://docs.openedx.org/projects/edx-platform/en/latest/settings.html#setting-COURSEGRAPH_JOB_QUEUE>`_
+* `PREPEND_LOCALE_PATHS <https://docs.openedx.org/projects/edx-platform/en/latest/settings.html#setting-PREPEND_LOCALE_PATHS>`_
+* `BULK_EMAIL_SEND_USING_EDX_ACE <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-BULK_EMAIL_SEND_USING_EDX_ACE>`_
+* `COURSEGRAPH_DUMP_COURSE_ON_PUBLISH <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-COURSEGRAPH_DUMP_COURSE_ON_PUBLISH>`_
+* `ENABLE_AUTHN_LOGIN_BLOCK_HIBP_POLICY <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-ENABLE_AUTHN_LOGIN_BLOCK_HIBP_POLICY>`_
+* `ENABLE_AUTHN_LOGIN_NUDGE_HIBP_POLICY <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-ENABLE_AUTHN_LOGIN_NUDGE_HIBP_POLICY>`_
+* `ENABLE_AUTHN_REGISTER_HIBP_POLICY <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-ENABLE_AUTHN_REGISTER_HIBP_POLICY>`_
+* `ENABLE_COPPA_COMPLIANCE <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-ENABLE_COPPA_COMPLIANCE>`_
+* `ENFORCE_SAFE_SESSIONS <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-ENFORCE_SAFE_SESSIONS>`_
+* `FEATURES['ENABLE_AUTOMATED_SIGNUPS_EXTRA_FIELDS'] <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-FEATURES['ENABLE_AUTOMATED_SIGNUPS_EXTRA_FIELDS']>`_
+* `FEATURES['ENABLE_INTEGRITY_SIGNATURE'] <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-FEATURES['ENABLE_INTEGRITY_SIGNATURE']>`_
+* `FEATURES['ENABLE_NEW_BULK_EMAIL_EXPERIENCE'] <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-FEATURES['ENABLE_NEW_BULK_EMAIL_EXPERIENCE']>`_
+* `FEATURES['ENABLE_PASSWORD_RESET_FAILURE_EMAIL'] <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-FEATURES['ENABLE_PASSWORD_RESET_FAILURE_EMAIL']>`_
+* `FEATURES['SHOW_PROGRESS_BAR'] <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-FEATURES['SHOW_PROGRESS_BAR']>`_
+* `LOG_REQUEST_USER_CHANGE_HEADERS <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-LOG_REQUEST_USER_CHANGE_HEADERS>`_
+* `MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW>`_
+* `RATELIMIT_ENABLE <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-RATELIMIT_ENABLE>`_
+* `SEARCH_SKIP_SHOW_IN_CATALOG_FILTERING <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-SEARCH_SKIP_SHOW_IN_CATALOG_FILTERING>`_
+* `course_live.enable_course_live <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-course_live.enable_course_live>`_
+* `courseware.enable_new_financial_assistance_flow <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-courseware.enable_new_financial_assistance_flow>`_
+* `discussions.enable_discussions_mfe <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-discussions.enable_discussions_mfe>`_
+* `discussions.enable_learners_tab_in_discussions_mfe <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-discussions.enable_learners_tab_in_discussions_mfe>`_
+* `discussions.enable_moderation_reason_codes <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-discussions.enable_moderation_reason_codes>`_
+* `discussions.enable_new_structure_discussions <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-discussions.enable_new_structure_discussions>`_
+* `discussions.enable_reported_content_email_notifications <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-discussions.enable_reported_content_email_notifications>`_
+* `learner_dashboard.enable_masters_program_tab_view <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-learner_dashboard.enable_masters_program_tab_view>`_
+* `learner_dashboard.enable_program_tab_view <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-learner_dashboard.enable_program_tab_view>`_
+* `learner_dashboard.enable_program_tab_view <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-learner_dashboard.enable_program_tab_view>`_
+* `new_core_editors.use_new_problem_editor <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-new_core_editors.use_new_problem_editor>`_
+* `new_core_editors.use_new_text_editor <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-new_core_editors.use_new_text_editor>`_
+* `new_core_editors.use_new_video_editor <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-new_core_editors.use_new_video_editor>`_
 
 
 

--- a/source/community/release_notes/olive.rst
+++ b/source/community/release_notes/olive.rst
@@ -204,29 +204,29 @@ Settings and Toggles
 
 New settings and toggles added since the Nutmeg release:
 
-* `CUSTOM_RESOURCE_TEMPLATES_DIRECTORY <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/settings.html#setting-CUSTOM_RESOURCE_TEMPLATES_DIRECTORY>`_
-* `LEARNER_RECORD_MFE_URL <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/settings.html#setting-LEARNER_RECORD_MFE_URL>`_
-* `MFE_CONFIG <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/settings.html#setting-MFE_CONFIG>`_
-* `MFE_CONFIG_API_CACHE_TIMEOUT <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/settings.html#setting-MFE_CONFIG_API_CACHE_TIMEOUT>`_
-* `MFE_CONFIG_OVERRIDES <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/settings.html#setting-MFE_CONFIG_OVERRIDES>`_
-* `PREPEND_LOCALE_PATHS <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/settings.html#setting-PREPEND_LOCALE_PATHS>`_
-* `DISABLE_JWT_FOR_MOBILE <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-DISABLE_JWT_FOR_MOBILE>`_
-* `DISABLE_UNENROLLMENT <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-FEATURES['DISABLE_UNENROLLMENT']>`_
-* `ENABLE_DYNAMIC_REGISTRATION_FIELDS <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-ENABLE_DYNAMIC_REGISTRATION_FIELDS>`_
-* `ENABLE_MFE_CONFIG_API <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-ENABLE_MFE_CONFIG_API>`_
-* `ENABLE_CERTIFICATES_IDV_REQUIREMENT <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-FEATURES['ENABLE_CERTIFICATES_IDV_REQUIREMENT']>`_
-* `SEND_CATALOG_INFO_SIGNAL <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-SEND_CATALOG_INFO_SIGNAL>`_
-* `contentstore.bypass_olx_failure <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-contentstore.bypass_olx_failure>`_
-* `contentstore.individualize_anonymous_user_id <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-contentstore.individualize_anonymous_user_id>`_
-* `contentstore.split_library_on_studio_dashboard <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-contentstore.split_library_on_studio_dashboard>`_
-* `course_apps.exams_ida <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-course_apps.exams_ida>`_
-* `course_live.enable_big_blue_button <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-course_live.enable_big_blue_button>`_
-* `credentials.use_learner_record_mfe <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-credentials.use_learner_record_mfe>`_
-* `discussions.enable_learners_stats <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-discussions.enable_learners_stats>`_
-* `discussions.enable_reported_content_email_notifications <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-discussions.enable_reported_content_email_notifications>`_
-* `student.enable_2u_recommendations <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-student.enable_2u_recommendations>`_
-* `student.enable_amplitude_recommendations <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-student.enable_amplitude_recommendations>`_
-* `student.enable_enrollment_confirmation_email <https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html#featuretoggle-student.enable_enrollment_confirmation_email>`_
+* `CUSTOM_RESOURCE_TEMPLATES_DIRECTORY <https://docs.openedx.org/projects/edx-platform/en/latest/settings.html#setting-CUSTOM_RESOURCE_TEMPLATES_DIRECTORY>`_
+* `LEARNER_RECORD_MFE_URL <https://docs.openedx.org/projects/edx-platform/en/latest/settings.html#setting-LEARNER_RECORD_MFE_URL>`_
+* `MFE_CONFIG <https://docs.openedx.org/projects/edx-platform/en/latest/settings.html#setting-MFE_CONFIG>`_
+* `MFE_CONFIG_API_CACHE_TIMEOUT <https://docs.openedx.org/projects/edx-platform/en/latest/settings.html#setting-MFE_CONFIG_API_CACHE_TIMEOUT>`_
+* `MFE_CONFIG_OVERRIDES <https://docs.openedx.org/projects/edx-platform/en/latest/settings.html#setting-MFE_CONFIG_OVERRIDES>`_
+* `PREPEND_LOCALE_PATHS <https://docs.openedx.org/projects/edx-platform/en/latest/settings.html#setting-PREPEND_LOCALE_PATHS>`_
+* `DISABLE_JWT_FOR_MOBILE <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-DISABLE_JWT_FOR_MOBILE>`_
+* `DISABLE_UNENROLLMENT <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-FEATURES['DISABLE_UNENROLLMENT']>`_
+* `ENABLE_DYNAMIC_REGISTRATION_FIELDS <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-ENABLE_DYNAMIC_REGISTRATION_FIELDS>`_
+* `ENABLE_MFE_CONFIG_API <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-ENABLE_MFE_CONFIG_API>`_
+* `ENABLE_CERTIFICATES_IDV_REQUIREMENT <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-FEATURES['ENABLE_CERTIFICATES_IDV_REQUIREMENT']>`_
+* `SEND_CATALOG_INFO_SIGNAL <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-SEND_CATALOG_INFO_SIGNAL>`_
+* `contentstore.bypass_olx_failure <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-contentstore.bypass_olx_failure>`_
+* `contentstore.individualize_anonymous_user_id <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-contentstore.individualize_anonymous_user_id>`_
+* `contentstore.split_library_on_studio_dashboard <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-contentstore.split_library_on_studio_dashboard>`_
+* `course_apps.exams_ida <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-course_apps.exams_ida>`_
+* `course_live.enable_big_blue_button <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-course_live.enable_big_blue_button>`_
+* `credentials.use_learner_record_mfe <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-credentials.use_learner_record_mfe>`_
+* `discussions.enable_learners_stats <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-discussions.enable_learners_stats>`_
+* `discussions.enable_reported_content_email_notifications <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-discussions.enable_reported_content_email_notifications>`_
+* `student.enable_2u_recommendations <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-student.enable_2u_recommendations>`_
+* `student.enable_amplitude_recommendations <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-student.enable_amplitude_recommendations>`_
+* `student.enable_enrollment_confirmation_email <https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-student.enable_enrollment_confirmation_email>`_
 
 The following settings were removed:
 

--- a/source/community/release_notes/olive.rst
+++ b/source/community/release_notes/olive.rst
@@ -5,7 +5,7 @@ Open edX Olive Release
 
 These are the release notes for the Olive release, the 15th community release of the Open edX Platform, spanning changes from April 11 2022 to October 11 2022.  You can also review details about `earlier releases`_ or learn more about the `Open edX Platform`_.
 
-.. _earlier releases: https://edx.readthedocs.io/projects/edx-developer-docs/en/latest/named_releases.html
+.. _earlier releases: https://docs.openedx.org/en/latest/community/release_notes/index.html
 .. _Open edX Platform: https://openedx.org
 
 .. contents::

--- a/source/community/release_notes/palm.rst
+++ b/source/community/release_notes/palm.rst
@@ -5,7 +5,7 @@ Open edX Palm Release - Developer & Operator Notes
 
 These are the release notes for the Palm release, the 16th community release of the Open edX Platform, spanning changes from October 11, 2022, to April 11, 2023.  You can also review details about `earlier releases`_ or learn more about the `Open edX Platform`_.
 
-.. _earlier releases: https://edx.readthedocs.io/projects/edx-developer-docs/en/latest/named_releases.html
+.. _earlier releases: https://docs.openedx.org/en/latest/community/release_notes/index.html
 .. _Open edX Platform: https://openedx.org
 
 .. contents::

--- a/source/community/release_notes/redwood/dev_op_release_notes.rst
+++ b/source/community/release_notes/redwood/dev_op_release_notes.rst
@@ -6,7 +6,7 @@ These are the Developer and Operator release notes for the Redwood release, the
 10 2023 to May 09 2024. You can also review details about `earlier releases`_ or
 learn more about the `Open edX Platform`_.
 
-.. _earlier releases: https://edx.readthedocs.io/projects/edx-developer-docs/en/latest/named_releases.html
+.. _earlier releases: https://docs.openedx.org/en/latest/community/release_notes/index.html
 .. _Open edX Platform: https://openedx.org
 
 .. contents::

--- a/source/developers/references/developer_guide/index.rst
+++ b/source/developers/references/developer_guide/index.rst
@@ -1,4 +1,4 @@
-.. _edX Developer's Guide:
+.. _Open edX Developer's Guide:
 
 ##########################
 Open edX Developer's Guide

--- a/source/educators/references/resources_for_course_teams.rst
+++ b/source/educators/references/resources_for_course_teams.rst
@@ -24,13 +24,6 @@ Documentation
 
 Documentation for course teams is available from the docs.openedx.org web page.
 
-* `Building and Running an Open edX Course`_ is a comprehensive guide with
-  concepts and procedures to help you build a course in Studio and then
-  use the Learning Management System (LMS) to run a course.
-
-  You can access this guide by selecting **Help** in Studio or from the
-  instructor dashboard in the LMS.
-
 These guides open in your web browser. The left side of each page includes a
 **Search docs** field and links to the contents of that guide. To open or save
 a PDF version, select **v: latest** at the lower right of the page, then select

--- a/source/links.txt
+++ b/source/links.txt
@@ -72,7 +72,7 @@
 
 .. _edX pattern library: http://ux.edx.org/design_elements/colors/
 
-.. _Open edX Named Releases page: https://edx.readthedocs.io/projects/edx-developer-docs/en/latest/named_releases.html
+.. _Open edX Named Releases page: https://docs.openedx.org/en/latest/community/release_notes/index.html
 
 .. _Open edX Installation: https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/installation/
 

--- a/source/links.txt
+++ b/source/links.txt
@@ -699,8 +699,6 @@
 
 .. _Mathematics meta: http://meta.math.stackexchange.com/questions/5020/mathjax-basic-tutorial-and-quick-reference
 
-.. _Building and Running an Open edX Course: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/
-
 
 .. ###### WIP MIGRATION LINKS ######
 .. _edX Partner Portal: https://partners.edx.org

--- a/source/links.txt
+++ b/source/links.txt
@@ -16,7 +16,7 @@
 
 .. _Entity Relationship Diagram for ORA Data: https://openedx.atlassian.net/wiki/display/AN/Entity+Relationship+Diagram+for+ORA+Data
 
-.. _edX Enrollment API: http://edx.readthedocs.io/projects/edx-platform-api/en/latest/enrollment/index.html
+.. _edX Enrollment API: https://docs.openedx.org/projects/edx-platform/en/latest/references/lms_apis.html
 
 .. _Course Navigation Changes: https://open.edx.org/announcements/update-course-navigation-changes
 
@@ -248,7 +248,7 @@
 .. _Testing in Django: https://docs.djangoproject.com/en/1.8/topics/testing/
 .. _Django sites framework: https://docs.djangoproject.com/en/1.8/ref/contrib/sites
 .. _Jasmine: http://jasmine.github.io/2.3/introduction.html
-.. _edX JavaScript Style Guide: https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/style_guides/javascript-guidelines.html
+.. _edX JavaScript Style Guide: https://docs.openedx.org/en/latest/developers/references/developer_guide/style_guides/javascript-guidelines.html#javascript-style-guide
 .. _JSHint: http://www.jshint.com/
 .. _jscs: https://www.npmjs.org/package/jscs
 .. _Waffle: http://waffle.readthedocs.io/en/latest


### PR DESCRIPTION
* Fix some outdated ref links
* Swap links to edx.rtd/edx-platform-technical to docs.openedx.org links
* Swap links to edx.rtd/named-releases to docs.openedx.org links
* Swap some edx.rtd links with docs.openedx.org links