### PR TITLE
Update or remove outdated/broken links

### DIFF
--- a/source/community/release_notes/ironwood.rst
+++ b/source/community/release_notes/ironwood.rst
@@ -53,10 +53,7 @@ Video Status Indicators
 For Open edX instances using the video uploads page, this view now conveys the
 status of each video as it relates to its transcoding (through edx-VEDA) and
 transcription (3rd party configuration). The status column is listed in the
-Previous Uploads table. More details around the status messages are `available
-in our documentation`__.
-
-.. __: https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/video/upload_video.html#video-processing-statuses
+Previous Uploads table.
 
 Gradebook Application
 =====================
@@ -65,10 +62,6 @@ The gradebook will give you a central location where you can view and manage
 grades for all learners in a course. It will provide you with improved search
 which you can use to find specific learners and override assignment-specific
 grades. In addition, you can filter by cohort, track, or assignment type.
-
-You can read more about this in the documentation for the `Gradebook Application`__.
-
-.. __: https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/student_progress/course_grades.html#review-learner-grades-on-the-instructor-dashboard
 
 .. note:: This application is available in devstack, but is not yet supported
           in production installations.

--- a/source/community/release_notes/juniper_learner.rst
+++ b/source/community/release_notes/juniper_learner.rst
@@ -29,12 +29,10 @@ Learning Sequence Experience
 ----------------------------
 
 **New Course MFE:** A major platform change for the learner experiences comes
-in the form of a new `micro-frontend application`__ to modernize the course
+in the form of a new micro-frontend application to modernize the course
 learning experience. The primary Juniper focus of this application is an
 overhaul of the learning sequence experience, though we anticipate other views
 like Course Home will eventually also make their way into this new application.
-
-.. __: https://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/juniper.html
 
 **Content iFrames & Security:** This new micro-frontend is easier to update
 and configure than our previous experience, helping support lower development

--- a/source/community/release_notes/lilac.rst
+++ b/source/community/release_notes/lilac.rst
@@ -126,7 +126,7 @@ Special Exams Experience
 Credentials (for Programs)
 ==========================
 
-Program Completion Emails: Added `ProgramCompletionEmailConfiguration`_ that enables an email to be customized and sent to learners when triggered by the generation of a program certificate. These email messages are especially useful to remind a learner of their accomplishment at the appropriate time if a course in the program has a `certificate availability date`_ set in the future. These messages can be customized on a per program basis.
+Program Completion Emails: Added `ProgramCompletionEmailConfiguration`_ that enables an email to be customized and sent to learners when triggered by the generation of a program certificate. These email messages are especially useful to remind a learner of their accomplishment at the appropriate time if a course in the program has a certificate availability date set in the future. These messages can be customized on a per program basis.
 
 Administrator Experiences
 *************************
@@ -254,8 +254,6 @@ Developer Experiences
 
 
 .. _ProgramCompletionEmailConfiguration: https://github.com/openedx/credentials/blob/27fbfe88a91e5111595655f3dfab3ce493958a4f/credentials/apps/credentials/models.py#L306-L322
-
-.. _certificate availability date: https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/set_up_course/studio_add_course_information/studio_creating_certificates.html#specify-a-different-certificates-available-date
 
 .. _fake the migration: https://docs.djangoproject.com/en/2.2/ref/django-admin/#cmdoption-migrate-fake
 

--- a/source/community/release_notes/palm.rst
+++ b/source/community/release_notes/palm.rst
@@ -101,7 +101,7 @@ OLX XML.
 
 The Open edX wiki page `[2U] New Visual Problem Editor <https://openedx.atlassian.net/wiki/spaces/OEPM/blog/2023/04/07/3724312593/2U+New+Visual+Problem+Editor>`_
 provides a brief explanation of what has changed in the problem editor. Updated detailed instructions on writing
-problems can be found in section `8.4. Working with Problem Components <https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_components/create_problem.html#working-with-problem-components>`_ of the Building and Running an edX Course documentation.
+problems can be found in section :ref:`Working with Problem Components` of the Building and Running an Open edX Course documentation.
 
 The Visual Problem Editor is hosted in the existing Course Authoring Micro-frontend. To enable the Visual Problem Editor, add the waffle flag
 :code:`new_core_editors.use_new_problem_editor` and set the value to “Yes” for all users.
@@ -110,9 +110,7 @@ New ORA Grading Experience
 ==========================
 
 In this new on-platform grading experience one can easily preview common file types, assign rubric values, provide
-comments, and coordinate grading with all members of the course teams. Complete documentation is in section
-`10.26.4. Staff Grading for Open Response Assignments
-<https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/open_response_assessments/ORA_Staff_Grading.html#staff-grading-for-open-response-assignments>`_  of the Building and Running an edX Course documentation.
+comments, and coordinate grading with all members of the course teams. Complete documentation is at :ref:`ORA Staff Grading`  of the Building and Running an Open edX Course documentation.
 
 The new ORA grading experience depends on the ORA Grading Micro-frontend, which was included as an experimental
 feature in Olive. To turn on the feature, add the feature flag :code:`openresponseassessment.enhanced_staff_grader`.

--- a/source/community/release_notes/palm/ora_improvements.rst
+++ b/source/community/release_notes/palm/ora_improvements.rst
@@ -57,9 +57,7 @@ to make sure that is understood.
 Where can I go for more information?
 ************************************
 
-For more information about how this feature works, see the `Staff Grading for
-Open Response Assignments documentation
-<https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/open_response_assessments/ORA_Staff_Grading.html#ora-staff-grading>`_.
+For more information about how this feature works, see :ref:`ORA Staff Grading`.
 
 How can I get this?
 *******************

--- a/source/developers/references/developer_guide/process/code-considerations.rst
+++ b/source/developers/references/developer_guide/process/code-considerations.rst
@@ -17,11 +17,10 @@ As described in :doc:`overview`, your code should meet basic Open edX project
 standards: it should be accessible, internationalized, and meet the concerns of
 analytics.
 
-* `Internationalization Coding Guidelines`_
+* :ref:`i18n`
 * `RTL UI Best Practices`_
 * :ref:`Accessibility Guidelines`
-* `Analytics Guidelines`_
-* `Eventing Design and Review Process`_
+* :ref:`analytics`
 
 .. _Contributing to the Documentation for your Open Source Feature:
 

--- a/source/developers/references/developer_guide/process/contributor.rst
+++ b/source/developers/references/developer_guide/process/contributor.rst
@@ -59,6 +59,7 @@ Progress), and start the pull request as a draft on GitHub.
 Please include a link to your roadmap ticket in the PR description, and add a
 link to a WIP pull request in any discussion threads you start.
 
-.. _Product Review Process: https://openedx.atlassian.net/wiki/spaces/COMM/pages/3875962884/DRAFT+How+to+submit+an+open+source+contribution+for+Product+Review
 .. _Open edX Product Working Group: https://openedx.atlassian.net/wiki/spaces/COMM/pages/3449028609/Product+Working+Group
 .. _Product Roadmap: https://github.com/orgs/openedx/projects/4
+
+.. include:: ../links.rst

--- a/source/developers/references/developer_guide/process/overview.rst
+++ b/source/developers/references/developer_guide/process/overview.rst
@@ -30,10 +30,9 @@ questions or concerns.
 
 * For new features, or any changes affecting user behavior, please follow the
   `Product Review Process`_
-* `Internationalization Coding Guidelines`_
+* :ref:`i18n`
 * `RTL UI Best Practices`_
 * :ref:`Accessibility Guidelines`
-* `Analytics Guidelines`_
-* `Eventing Design and Review Process`_
+* :ref:`analytics`
 
 .. include:: ../links.rst

--- a/source/documentors/decisions/0001-purpose-of-this-repo.rst
+++ b/source/documentors/decisions/0001-purpose-of-this-repo.rst
@@ -43,8 +43,7 @@ definition of users’ end goals, a number of problems have arisen:
 
 #. Documentation is less developed, or not organized in the most appropriate
    way, for certain types of users, for example faculty/course authors. One
-   Instance administrator noted that some `Open edX Documentation
-   <https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/index.html>`__
+   Instance administrator noted that some Open edX documentation
    is actually a barrier of entry for faculty, rather than a facilitator to
    entry, because 1) the documentation is too dense; 2) there's not a clear path
    through the documentation to connect the faculty with their need; 3) it's

--- a/source/educators/references/course_development/awarding_partial_credit.rst
+++ b/source/educators/references/course_development/awarding_partial_credit.rst
@@ -52,7 +52,7 @@ the following ways.
   problem indicate that the answer was correct. Specifically, the
   ``correctness`` field has a value of ``correct``.
 
-  For more information about events, see :ref:`problem` in the *EdX Research Guide*.
+  For more information about events, see :ref:`problem`.
 
 * The **AnswerValue** in the :ref:`Student_Answer_Distribution` report is
   **1**, for correct.

--- a/source/educators/references/course_development/parent_child_components.rst
+++ b/source/educators/references/course_development/parent_child_components.rst
@@ -86,7 +86,7 @@ You develop parent and child components in XML, then import the XML course into
 Studio to verify that the structure is as you intended.
 
 For more information about working with your course's XML files, including
-information about terminology, see the `EdX Open Learning XML Guide <https://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/index.html>`.
+information about terminology, see :ref:`OLX TOC`.
 
 The following examples show the XML used to create the unit and components
 shown in Studio above.

--- a/source/educators/references/data/student_profile_report.rst
+++ b/source/educators/references/data/student_profile_report.rst
@@ -56,9 +56,7 @@ in this report) are configurable in the Open edX site configuration.
      - This value can be updated on the **Account Settings** page.
    * - level_of_education
      - No
-     - This value can be updated on the **Account Settings** page. For a list
-       of the possible values, see the description of the `auth_userprofile`_
-       table's level_of_education column in the *EdX Research Guide*.
+     - This value can be updated on the **Account Settings** page.
    * - mailing_address
      - No
      - This column is included for backward compatibility only. It is no

--- a/source/links.txt
+++ b/source/links.txt
@@ -36,26 +36,6 @@
 
 .. _Open edX Demo Course GitHub: https://github.com/openedx/openedx-demo-course
 
-.. EDX WIKI LINKS
-
-.. _Open edX Releases Wiki page: https://docs.openedx.org/en/latest/community/release_notes/index.html
-
-.. _Release Pages: https://openedx.atlassian.net/wiki/pages/viewpage.action?pageId=12550314
-
-.. _Open edX Installation options: https://openedx.atlassian.net/wiki/x/wwCXAw
-
-.. _Open edX Native 12.04 Installation: https://openedx.atlassian.net/wiki/x/bgCXAw
-
-.. _Legacy Open edX Native Installation: https://openedx.atlassian.net/wiki/x/g4G6C
-
-.. _Koa Open edX Native Installation: https://openedx.atlassian.net/wiki/x/lIJjdQ
-
-.. _edX Feature Flags: https://openedx.atlassian.net/wiki/spaces/OpenDev/pages/34734726/edX+Feature+Flags
-
-.. _Managing Open edX Tips and Tricks:  https://openedx.atlassian.net/wiki/spaces/OpenOPS/pages/60227913/Managing+Open+edX+Tips+and+Tricks
-
-.. _How to Override Default Configuration Passwords and Verify Exposed Services: https://openedx.atlassian.net/wiki/spaces/OpenOPS/pages/153813109/How+to+Override+Default+Configuration+Passwords+and+Verify+Exposed+Services
-
 .. THIRD PARTY LINKS
 
 .. _Oscar: https://github.com/django-oscar/django-oscar
@@ -233,8 +213,6 @@
 .. _Time and Date Time Zone Converter: http://www.timeanddate.com/worldclock/converter.html
 
 .. _Installing, Configuring, and Running the Open edX Platform: https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/index.html
-
-.. _openedx-studio: http://groups.google.com/forum/#!forum/openedx-studio
 
 .. _Tree of Math: http://www.onemathematicalcat.org/MathJaxDocumentation/TeXSyntax.htm
 

--- a/source/links.txt
+++ b/source/links.txt
@@ -40,8 +40,6 @@
 
 .. _Open edX Releases Wiki page: https://docs.openedx.org/en/latest/community/release_notes/index.html
 
-.. _edX Research Guide: http://edx.readthedocs.io/projects/devdata/en/latest/
-
 .. _Release Pages: https://openedx.atlassian.net/wiki/pages/viewpage.action?pageId=12550314
 
 .. _Open edX Installation options: https://openedx.atlassian.net/wiki/x/wwCXAw
@@ -237,8 +235,6 @@
 .. _Installing, Configuring, and Running the Open edX Platform: https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/index.html
 
 .. _openedx-studio: http://groups.google.com/forum/#!forum/openedx-studio
-
-.. _auth_userprofile: https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/sql_schema.html#auth-userprofile
 
 .. _Tree of Math: http://www.onemathematicalcat.org/MathJaxDocumentation/TeXSyntax.htm
 

--- a/source/links.txt
+++ b/source/links.txt
@@ -34,7 +34,11 @@
 
 .. _course.xml: https://github.com/pmitros/edX-Insider/blob/master/Ongoing/course.xml
 
-.. _Open edX Releases Wiki page: https://openedx.atlassian.net/wiki/spaces/OpenOPS/pages/11108700/Open+edX+Releases
+.. _Open edX Demo Course GitHub: https://github.com/openedx/openedx-demo-course
+
+.. EDX WIKI LINKS
+
+.. _Open edX Releases Wiki page: https://docs.openedx.org/en/latest/community/release_notes/index.html
 
 .. _edX Research Guide: http://edx.readthedocs.io/projects/devdata/en/latest/
 
@@ -132,15 +136,9 @@
 
 .. _Oppia XBlock: https://github.com/oppia/xblock
 
-.. _Internationalization Coding Guidelines: https://openedx.atlassian.net/wiki/edx.readthedocs.io/projects/edx-developer-guide/en/latest/internationalization/i18n.html
+.. _RTL UI Best Practices: https://openedx.atlassian.net/wiki/spaces/LOC/pages/219545811/RTL+Developer+Guide
 
-.. _RTL UI Best Practices: https://github.com/openedx/edx-platform/wiki/RTL-UI-Best-Practices
-
-.. _Analytics Guidelines: http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/analytics.html
-
-.. _Eventing Design and Review Process: https://openedx.atlassian.net/wiki/display/AN/Eventing+Design+and+Review+Process
-
-.. _Product Review Process: https://openedx.atlassian.net/wiki/spaces/COMM/pages/3875962884/DRAFT+How+to+submit+an+open+source+contribution+for+Product+Review
+.. _Product Review Process: https://openedx.atlassian.net/wiki/spaces/COMM/pages/3875962884/How+to+submit+an+open+source+contribution+for+Product+Review
 
 .. _Accept-Language: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4
 
@@ -237,6 +235,8 @@
 .. _Time and Date Time Zone Converter: http://www.timeanddate.com/worldclock/converter.html
 
 .. _Installing, Configuring, and Running the Open edX Platform: https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/index.html
+
+.. _openedx-studio: http://groups.google.com/forum/#!forum/openedx-studio
 
 .. _auth_userprofile: https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/sql_schema.html#auth-userprofile
 


### PR DESCRIPTION
Convert links from edx.readthedocs.io to links on docs.openedx.org

The installing & configuring guide is not yet moved, so those links are currently unchanged. Ref https://github.com/openedx/docs.openedx.org/issues/830
