### PR TITLE
build: Add sphinx-notfound-page extension

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -12,3 +12,4 @@ sphinxcontrib-images
 sphinxcontrib-contentui
 sphinxext-rediraffe
 sphinx-tags
+sphinx-notfound-page

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -75,6 +75,7 @@ sphinx==7.4.7
     #   sphinx-book-theme
     #   sphinx-copybutton
     #   sphinx-design
+    #   sphinx-notfound-page
     #   sphinx-tags
     #   sphinxcontrib-contentui
     #   sphinxcontrib-images
@@ -88,6 +89,8 @@ sphinx-book-theme==1.1.4
 sphinx-copybutton==0.5.2
     # via -r requirements/base.in
 sphinx-design==0.6.1
+    # via -r requirements/base.in
+sphinx-notfound-page==1.1.0
     # via -r requirements/base.in
 sphinx-tags==0.4
     # via -r requirements/base.in

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.45.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==25.0.1
     # via -r requirements/pip.in
-setuptools==75.8.0
+setuptools==75.8.2
     # via -r requirements/pip.in

--- a/source/conf.py
+++ b/source/conf.py
@@ -47,6 +47,7 @@ extensions = [
     "sphinxcontrib.mermaid",
     "sphinx.ext.intersphinx",
     "sphinxext.rediraffe",
+    "notfound.extension",
     "sphinx_tags"
 ]
 


### PR DESCRIPTION
Adds a nicer 404 page to our docs

Rather than a generic 404 page without nav context, https://docs.openedx.org/en/latest/community/release_notes/verawood.html

<img width="1229" alt="image" src="https://github.com/user-attachments/assets/a5aacb15-0da9-43b4-adce-f3d929b2ea61" />


See https://docsopenedxorg--850.org.readthedocs.build/en/850/community/release_notes/verawood.html

![image](https://github.com/user-attachments/assets/8fb4759c-e095-435b-b9ac-007781f80c63)


