### PR TITLE
Convert as many direct references to docs.oe.org, and :doc:, to :refs: 

### DIFF
--- a/source/community/release_notes/index.rst
+++ b/source/community/release_notes/index.rst
@@ -25,7 +25,7 @@ migrations, and other changes and updates to the Open edX platform.
 Release Version Info
 ====================
 
-The :doc:`named_release_branches_and_tags` page is a quick reference for site
+The :ref:`Named Release Branches and Tags` page is a quick reference for site
 operators that details installation information for the current and previous
 releases. Note that the latest release is the only supported release. We
 currently do not have the ability to support more than one release at a time.

--- a/source/community/release_notes/juniper.rst
+++ b/source/community/release_notes/juniper.rst
@@ -6,11 +6,11 @@ Open edX Juniper Release
 The Juniper release is the 10th named release of the Open edX Platform and our
 largest yet. Our previous release (Ironwood) was released in January 2019, so
 Juniper spans January 2019 through May 2020. You can also review details about
-`earlier releases`_ or learn more about the `Open edX Platform`_ if you are new to
+:ref:`Open edX Release Notes` or learn more about the `Open edX Platform`_ if you are new to
 Open edX. Below is a summary of the changes for each of the main platform
 areas, along with a way to jump down to each section of the release notes.
 
-.. _earlier releases: https://docs.openedx.org/en/latest/community/release_notes/index.html
+
 .. _Open edX Platform: https://open.edx.org
 
 .. toctree::

--- a/source/community/release_notes/koa.rst
+++ b/source/community/release_notes/koa.rst
@@ -3,9 +3,9 @@
 Open edX Koa Release
 ####################
 
-These are the release notes for the Koa release, the 11th community release of the Open edX Platform, spanning changes from May 23 to November 12 2020.  You can also review details about `earlier releases`_ or learn more about the `Open edX Platform`_ if you are new to Open edX.
+These are the release notes for the Koa release, the 11th community release of the Open edX Platform, spanning changes from May 23 to November 12 2020.  You can also review details about :ref:`Open edX Release Notes` or learn more about the `Open edX Platform`_ if you are new to Open edX.
 
-.. _earlier releases: https://docs.openedx.org/en/latest/community/release_notes/index.html
+
 .. _Open edX Platform: https://open.edx.org
 
 .. contents::

--- a/source/community/release_notes/lilac.rst
+++ b/source/community/release_notes/lilac.rst
@@ -3,9 +3,9 @@
 Open edX Lilac Release
 ######################
 
-These are the release notes for the Lilac release, the 12th community release of the Open edX Platform, spanning changes from November 12 2020 to April 9 2021.  You can also review details about `earlier releases`_ or learn more about the `Open edX Platform`_.
+These are the release notes for the Lilac release, the 12th community release of the Open edX Platform, spanning changes from November 12 2020 to April 9 2021.  You can also review details about :ref:`Open edX Release Notes` or learn more about the `Open edX Platform`_.
 
-.. _earlier releases: https://docs.openedx.org/en/latest/community/release_notes/index.html
+
 .. _Open edX Platform: https://open.edx.org
 
 .. contents::
@@ -59,7 +59,7 @@ When a learner reaches the end of the course, they will see a new navigation but
 
 The 3-day Streak Milestone is live and celebrates learners who engage with their course on 3 consecutive days. It also provides normative insights into how learners’ behavior connects to successful course outcomes. (TBD Image)
 
-See https://docs.openedx.org/projects/edx-platform/en/latest/featuretoggles.html#featuretoggle-FEATURES['ENABLE_MILESTONES_APP'] for information on how to turn on and configure these Milestones features.
+See :ref:`edx-platform:featuretoggles` ['ENABLE_MILESTONES_APP'] for information on how to turn on and configure these Milestones features.
 
 Mobile Experience
 =================
@@ -154,7 +154,7 @@ Course Upsell Messaging and Payment
 Settings and Toggles Documentation
 ==================================
 
-Documentation for settings and toggles is much improved, but still incomplete. See https://docs.openedx.org/projects/edx-platform/en/latest/index.html
+Documentation for settings and toggles is much improved, but still incomplete. See :ref:`edx-platform:featuretoggles`.
 
 New settings introduced in Lilac include:
 

--- a/source/community/release_notes/maple.rst
+++ b/source/community/release_notes/maple.rst
@@ -3,9 +3,9 @@
 Open edX Maple Release
 ######################
 
-These are the release notes for the Maple release, the 13th community release of the Open edX Platform, spanning changes from April 9 2021 to October 15 2021.  You can also review details about `earlier releases`_ or learn more about the `Open edX Platform`_.
+These are the release notes for the Maple release, the 13th community release of the Open edX Platform, spanning changes from April 9 2021 to October 15 2021.  You can also review details about :ref:`Open edX Release Notes` or learn more about the `Open edX Platform`_.
 
-.. _earlier releases: https://docs.openedx.org/en/latest/community/release_notes/index.html
+
 .. _Open edX Platform: https://open.edx.org
 
 .. contents::
@@ -36,13 +36,12 @@ Studio login changed to OAuth
 
 In versions prior to Maple, Studio (CMS) shared a session cookie with the LMS, and redirected to the LMS for login.
 Studio is changing to become an OAuth client of the LMS, using the same SSO configuration that other IDAs use. (See
-`ARCHBOM-1860`_; `OEP-42`_) This is a breaking change. Follow the `Studio OAuth migration runbook`_ as part of
+`ARCHBOM-1860`_; :doc:`openedx-proposals:best-practices/oep-0042-bp-authentication`) This is a breaking change. Follow the `Studio OAuth migration runbook`_ as part of
 upgrading to Maple. For devstack, run::
 
     ./provision-ida-user.sh studio studio 18010
 
 .. _ARCHBOM-1860: https://openedx.atlassian.net/browse/ARCHBOM-1860
-.. _OEP-42: https://docs.openedx.org/projects/openedx-proposals/en/latest/best-practices/oep-0042-bp-authentication.html
 .. _Studio OAuth migration runbook: https://github.com/openedx/edx-platform/blob/open-release/maple.master/docs/guides/studio_oauth.rst
 
 django-cors-headers version updgraded
@@ -352,7 +351,7 @@ See the sections above on OAuth and Certificates.
 Settings and Toggles
 ====================
 
-Documentation for settings and toggles is much improved, but still incomplete. See https://docs.openedx.org/projects/edx-platform/en/latest/index.html
+Documentation for settings and toggles is much improved, but still incomplete. See :ref:`edx-platform:featuretoggles`.
 
 
 Dependency updates

--- a/source/community/release_notes/named_release_branches_and_tags.rst
+++ b/source/community/release_notes/named_release_branches_and_tags.rst
@@ -1,3 +1,5 @@
+.. _Named Release Branches and Tags:
+
 Site Operators: Named Release Branches and Tags
 ###############################################
 

--- a/source/community/release_notes/nutmeg.rst
+++ b/source/community/release_notes/nutmeg.rst
@@ -3,9 +3,9 @@
 Open edX Nutmeg Release
 #######################
 
-These are the release notes for the Nutmeg release, the 14th community release of the Open edX Platform, spanning changes from October 15 2021 to April 11 2022.  You can also review details about `earlier releases`_ or learn more about the `Open edX Platform`_.
+These are the release notes for the Nutmeg release, the 14th community release of the Open edX Platform, spanning changes from October 15 2021 to April 11 2022.  You can also review details about :ref:`Open edX Release Notes` or learn more about the `Open edX Platform`_.
 
-.. _earlier releases: https://docs.openedx.org/en/latest/community/release_notes/index.html
+
 .. _Open edX Platform: https://openedx.org
 
 .. contents::

--- a/source/community/release_notes/olive.rst
+++ b/source/community/release_notes/olive.rst
@@ -3,9 +3,9 @@
 Open edX Olive Release
 ######################
 
-These are the release notes for the Olive release, the 15th community release of the Open edX Platform, spanning changes from April 11 2022 to October 11 2022.  You can also review details about `earlier releases`_ or learn more about the `Open edX Platform`_.
+These are the release notes for the Olive release, the 15th community release of the Open edX Platform, spanning changes from April 11 2022 to October 11 2022.  You can also review details about :ref:`Open edX Release Notes` or learn more about the `Open edX Platform`_.
 
-.. _earlier releases: https://docs.openedx.org/en/latest/community/release_notes/index.html
+
 .. _Open edX Platform: https://openedx.org
 
 .. contents::

--- a/source/community/release_notes/palm.rst
+++ b/source/community/release_notes/palm.rst
@@ -3,9 +3,9 @@
 Open edX Palm Release - Developer & Operator Notes
 ##################################################
 
-These are the release notes for the Palm release, the 16th community release of the Open edX Platform, spanning changes from October 11, 2022, to April 11, 2023.  You can also review details about `earlier releases`_ or learn more about the `Open edX Platform`_.
+These are the release notes for the Palm release, the 16th community release of the Open edX Platform, spanning changes from October 11, 2022, to April 11, 2023.  You can also review details about :ref:`Open edX Release Notes` or learn more about the `Open edX Platform`_.
 
-.. _earlier releases: https://docs.openedx.org/en/latest/community/release_notes/index.html
+
 .. _Open edX Platform: https://openedx.org
 
 .. contents::
@@ -42,8 +42,7 @@ Ecommerce is still officially deprecated and we continue to work on the `Ecommer
 Developer changes
 =================
 
-The old developer documentation site has been deprecated and removed. Please use `Open edX Developers - Latest
-Documentation <https://docs.openedx.org/en/latest/developers/index.html>`_  instead.
+The old developer documentation site has been deprecated and removed. Please use :ref:`Developer's Home`  instead.
 
 The modules :code:`tutor.hooks.actions`, :code:`tutor.hooks.filters`, and :code:`tutor.hooks.contexts` are no longer
 part of the Tutor API. This change should not affect most developers, who only use the :code:`Actions` and

--- a/source/community/release_notes/quince.rst
+++ b/source/community/release_notes/quince.rst
@@ -36,7 +36,7 @@ To learn more about this upgrade, visit the `wiki page <https://openedx.atlassia
 Instructor Experiences
 **********************
 
-* `Copy and Paste For Course Content <https://docs.openedx.org/en/open-release-quince.master/educators/how-tos/copy_paste_course_components.html>`__
+* :ref:`Copy and Paste Course Components`
 
 Administrators & Operators
 **************************

--- a/source/community/release_notes/quince/woocommerce.rst
+++ b/source/community/release_notes/quince/woocommerce.rst
@@ -28,7 +28,7 @@ See a demo of the plugin here:
 
 If you're interested in the WooCommerce integration, you can now activate `this
 plugin`_ in your WordPress site and connect your Open edX instance with your
-WordPress! `Additional documentation can be found here`_.
+WordPress! Additional documentation can be found here: :doc:`wordpress-ecommerce-plugin:index`
 
 This integration can serve as a model for integrating with other ecommerce
 platforms in a standard and supportable way. For further details on the project
@@ -40,7 +40,6 @@ work itself, you can check out:
 .. _deprecation: https://github.com/openedx/public-engineering/issues/22
 .. _ecommerce repo: http://github.com/openedx/ecommerce/
 .. _this plugin: https://edunext-docs-openedx-woocommerce-plugin.readthedocs-hosted.com/en/latest/plugin_quickstart.html#add-the-plugin-settings
-.. _Additional documentation can be found here: https://docs.openedx.org/projects/wordpress-ecommerce-plugin/en/latest/index.html
 .. _#33006: https://github.com/openedx/edx-platform/pull/33006
 .. _#33059: https://github.com/openedx/edx-platform/pull/33059
 .. _Project discovery documentation: https://docs.google.com/document/d/1gImq4DFy3B_JSZlH3tCj5bmPQXji0OCnw1SbGB8bVxw/edit?usp=sharing

--- a/source/community/release_notes/redwood/aspects.rst
+++ b/source/community/release_notes/redwood/aspects.rst
@@ -24,7 +24,7 @@ How can I find Aspects Reports?
 Accessing course-level dashboards from the LMS
 ==============================================
 
-Once Aspects has been installed, users can easily `access Aspects Reports <https://docs.openedx.org/projects/openedx-aspects/en/latest/course_team/how-tos/access_aspects.html>`_ for a
+Once Aspects has been installed, users can easily :doc:`openedx-aspects:course_team/how-tos/access_aspects` for a
 course directly from the Open edX LMS by clicking on a new Reports link on the
 Instructor Dashboard. There's no need to navigate elsewhere to gain valuable
 insight into exactly what's going on in a course:
@@ -32,7 +32,7 @@ insight into exactly what's going on in a course:
    .. image:: /_images/release_notes/redwood/aspects_screenshot2.png
 
 On the Reports tab in the LMS, users can navigate between three new dashboards:
-a `course dashboard <https://docs.openedx.org/projects/openedx-aspects/en/latest/reference/course_overview_dashboard.html>`_, `at risk learners dashboard <https://docs.openedx.org/projects/openedx-aspects/en/latest/reference/learner_groups_dashboard.html>`_, and `individual learner dashboard <https://docs.openedx.org/projects/openedx-aspects/en/latest/reference/individual_learner_dashboard.html>`_. These dashboards were
+a :doc:`openedx-aspects:reference/course_overview_dashboard`, :doc:`openedx-aspects:reference/learner_groups_dashboard`, and :doc:`openedx-aspects:reference/individual_learner_dashboard`. These dashboards were
 designed specifically for course authors and course teams looking to access
 quick and easy-to-glean engagement, enrollment, and performance data from their
 courses:
@@ -43,13 +43,15 @@ Accessing all Aspects has to offer from Superset
 ================================================
 
 Course delivery team members who plan to view information for one course and
-then another may chose to `navigate to Superset <https://docs.openedx.org/projects/openedx-aspects/en/latest/course_team/how-tos/access_aspects.html>`_, a third-party data
+then another may chose to :doc:`openedx-aspects:course_team/how-tos/access_aspects`, a third-party data
 visualization tool used to create and display Aspects dashboards and charts.
 This will allow these users to easily view the three out-of-the-box course-level
 dashboards for one of their courses and followed by another and another.
 
 Site operators and superusers can view data about any course on their Open edX
-instance or their whole Open edX instance in Superset. `Users can access Superset directly via a link from the Aspects Reports in the LMS <https://docs.openedx.org/projects/openedx-aspects/en/latest/course_team/how-tos/access_aspects.html>`_ using single sign-on authorization via their LMS account credentials:
+instance or their whole Open edX instance in Superset. 
+Users can access Superset directly via a link from the Aspects Reports in the LMS 
+(:doc:`openedx-aspects:course_team/how-tos/access_aspects`) using single sign-on authorization via their LMS account credentials:
 
    .. image:: /_images/release_notes/redwood/aspects_screenshot4.png
 
@@ -92,7 +94,7 @@ course where learner engagement drops off:
 
    .. image:: /_images/release_notes/redwood/aspects_screenshot8.png
 
-When `cross filtered <https://docs.openedx.org/projects/openedx-aspects/en/latest/course_team/how-tos/cross_filter.html>`_ by a single
+When cross filtered (:doc:`openedx-aspects:course_team/how-tos/cross_filter`) by a single
 course video, the Watched Video Segment graphs can help course authors and teams
 pinpoint potentially unclear video timestamp ranges:
 
@@ -109,8 +111,9 @@ Individual and At-Risk Learner Dashboards
 =========================================
 
 In addition to course-wide data, Aspects Reports surface course activity data
-for `individual learners <https://docs.openedx.org/projects/openedx-aspects/en/latest/reference/individual_learner_dashboard.html>`_ and
-`learners that may be at risk of not completing the course <https://docs.openedx.org/projects/openedx-aspects/en/latest/reference/learner_groups_dashboard.html>`_ based on a set of predefined
+for individual learners (:doc:`openedx-aspects:reference/individual_learner_dashboard`) and
+learners that may be at risk of not completing the course 
+(:doc:`openedx-aspects:reference/learner_groups_dashboard`) based on a set of predefined
 risk factors. The at-risk learner group is made up of learners that have
 enrolled in the course, done something in the course other than visit the course
 outline page, have not yet passed the course, and have not visited the course in
@@ -119,7 +122,7 @@ seven or more days.
 When installing the plugin, site operators can choose whether or not to show
 limited personally identifiable information (PII) to course delivery teams. On
 Open edX instances that show limited PII to course delivery teams, staff and
-admin users can see and `download <https://docs.openedx.org/projects/openedx-aspects/en/latest/course_team/how-tos/download_reports.html>`_ the names, usernames, and email
+admin users can see and :doc:`openedx-aspects:course_team/how-tos/download_reports` the names, usernames, and email
 addresses of individual and at-risk learners making targeted communication and
 learner intervention possible.
 
@@ -137,7 +140,7 @@ view detailed information:
 Add filters to a dashboard
 ==========================
 
-Users can `add filters <https://docs.openedx.org/projects/openedx-aspects/en/latest/course_team/how-tos/apply_filters_lms.html#>`_ to an
+Users can :doc:`openedx-aspects:course_team/how-tos/apply_filters_lms` to an
 Aspects dashboard using the filters panel on the side of each dashboard. Hover
 over the filter icon on the upper corner of a table or chart to view what
 filters were applied to create the data visualization on any dashboard:
@@ -148,7 +151,7 @@ Dive deeper into the data with interactive charts that can be cross-filtered
 ============================================================================
 
 All Aspects Dashboards allow users to dig deeper into their data through
-`cross filters <https://docs.openedx.org/projects/openedx-aspects/en/latest/course_team/how-tos/cross_filter.html>`_. With
+:doc:`openedx-aspects:course_team/how-tos/cross_filter`. With
 cross-filters, a user can apply the same filter to multiple charts and tables in
 a dashboard at once. For example, if a user adds a cross-filter for a single
 video on the Video Engagement tab of the Course Dashboard, all applicable video
@@ -159,7 +162,9 @@ tables and charts will update to show data only for that video:
 Download tables and images from Aspects dashboards
 ==================================================
 
-Users can easily `download the data used to create any chart or table in an Aspects dashboard in tabular format as a CSV or Excel file <https://docs.openedx.org/projects/openedx-aspects/en/latest/administator/how_to/export_tabular_data.html>`_ or `download the table or chart as an image <https://docs.openedx.org/projects/openedx-aspects/en/latest/course_team/how-tos/download_reports.html>`_ for use in their own
+Users can easily download the data used to create any chart or table in an Aspects dashboard in tabular format as a
+CSV or Excel file (:doc:`openedx-aspects:administrator/how_to/export_tabular_data`) or download the table or chart as
+an image (:doc:`openedx-aspects:course_team/how-tos/download_reports`) for use in their own
 documents, presentations, or reports:
 
    .. image:: /_images/release_notes/redwood/aspects_screenshot14.png

--- a/source/community/release_notes/redwood/dev_op_release_notes.rst
+++ b/source/community/release_notes/redwood/dev_op_release_notes.rst
@@ -3,10 +3,10 @@ Open edX Redwood Release - Developer and Operator Release Notes
 
 These are the Developer and Operator release notes for the Redwood release, the
 18th community release of the Open edX Platform, spanning changes from October
-10 2023 to May 09 2024. You can also review details about `earlier releases`_ or
+10 2023 to May 09 2024. You can also review details about :ref:`Open edX Release Notes` or
 learn more about the `Open edX Platform`_.
 
-.. _earlier releases: https://docs.openedx.org/en/latest/community/release_notes/index.html
+
 .. _Open edX Platform: https://openedx.org
 
 .. contents::
@@ -352,14 +352,14 @@ Developer Experience
 Researcher & Data Experiences
 *****************************
 
-`Aspects <https://docs.openedx.org/projects/openedx-aspects/en/latest/index.html>`_ 
+:doc:`openedx-aspects:index` 
 is an analytics system for the Open edX platform, bringing actionable data
 about course and learner performance to instructors and site operators. It is primarily
 a Tutor plugin that ties together data from the Open edX learning management system
 and Studio using open source tools to aggregate and transform learning traces into data
 visualizations.
 
-See the `Aspects configuration documentation <https://docs.openedx.org/projects/openedx-aspects/en/latest/technical_documentation/how-tos/production_configuration.html>`_
+See the :doc:`openedx-aspects:technical_documentation/how-tos/production_configuration`
 to learn about setting up Aspects for your production environment.
 
 Known Issues

--- a/source/community/release_notes/sumac/content_libraries_redesign_beta.rst
+++ b/source/community/release_notes/sumac/content_libraries_redesign_beta.rst
@@ -1,3 +1,5 @@
+.. _Content Libraries Redesign Beta:
+
 Content Libraries Redesign - Beta
 #################################
 

--- a/source/community/release_notes/sumac/dev_op_release_notes.rst
+++ b/source/community/release_notes/sumac/dev_op_release_notes.rst
@@ -139,7 +139,7 @@ Developer Experience
 Researcher & Data Experiences
 *****************************
 
-Upgrading Aspects to v1.3.1 will get you the latest Aspects functionality with Sumac. `See the upgrade instructions here <https://docs.openedx.org/projects/openedx-aspects/en/latest/technical_documentation/how-tos/upgrade.html>`_.
+Upgrading Aspects to v1.3.1 will get you the latest Aspects functionality with Sumac. See the upgrade instructions here: :doc:`openedx-aspects:technical_documentation/how-tos/upgrade`.
 
 Known Issues
 ************

--- a/source/community/release_notes/teak.rst
+++ b/source/community/release_notes/teak.rst
@@ -3,13 +3,13 @@ Open edX Teak - June 2025 Release
 
 These are the release notes for the Teak release, the 20th community release
 of the Open edX Platform, which will be released in June 2025. You can also review details
-about :doc:`index` or learn more about the `Open edX Platform`_.
+about :ref:`Open edX Release Notes` or learn more about the `Open edX Platform`_.
 
 .. highlights::
 
    What's new in Teak? Click to read about new features:
 
-   :doc:`teak/feature_release_notes`.
+   :ref:`Teak Product Notes`.
 
 
 .. highlights::
@@ -17,7 +17,7 @@ about :doc:`index` or learn more about the `Open edX Platform`_.
    What's new in Teak? Operators and developers, click to read about new
    updates, patches, and configuration options.
    
-   :doc:`teak/dev_op_release_notes`.
+   :ref:`Teak Dev Notes`.
 
 .. toctree::
     :maxdepth: 2

--- a/source/community/release_notes/teak/dev_op_release_notes.rst
+++ b/source/community/release_notes/teak/dev_op_release_notes.rst
@@ -1,3 +1,5 @@
+.. _Teak Dev Notes:
+
 Open edX Teak Developer & Operator Release Notes
 ################################################
 
@@ -5,10 +7,10 @@ Open edX Teak Developer & Operator Release Notes
 
 These are the developer & operator release notes for the Teak release, the 20th
 community release of the Open edX Platform, spanning changes from October 24,
-2024 to April 9, 2025. You can also review details about :doc:`../index` or
+2024 to April 9, 2025. You can also review details about :ref:`Open edX Release Notes` or
 learn more about the `Open edX Platform`_.
 
-To view the end-user facing docs, see the :doc:`feature_release_notes`.
+To view the end-user facing docs, see the :ref:`Teak Product Notes`.
 
 .. _Open edX Platform: https://openedx.org
 

--- a/source/community/release_notes/teak/feature_release_notes.rst
+++ b/source/community/release_notes/teak/feature_release_notes.rst
@@ -1,3 +1,5 @@
+.. _Teak Product Notes:
+
 Open edX Teak Release - Product Release Notes
 #############################################
 
@@ -13,4 +15,4 @@ Open edX Teak Release - Product Release Notes
 
 Information for site operators and developers, including information on how to
 enable and/or configure new features that require additional work, can be found
-in the :doc:`dev_op_release_notes`.
+in the :ref:`Teak Dev Notes`.

--- a/source/community/release_notes/teak/libraries_unit_support.rst
+++ b/source/community/release_notes/teak/libraries_unit_support.rst
@@ -1,7 +1,7 @@
 Content Libraries - Unit Support
 ################################
 
-Phase 2 of the :doc:`Content Libraries project<../sumac/content_libraries_redesign_beta>`
+Phase 2 of the :ref:`Content Libraries project<Content Libraries Redesign Beta>`
 will see the addition of Unit Support, that is, the ability to hold full
 learning units within a Library. he ability to create and reuse units,
 subsections, and sections will enable use cases such as having a library of

--- a/source/community/release_notes/ulmo.rst
+++ b/source/community/release_notes/ulmo.rst
@@ -3,13 +3,13 @@ Open edX Ulmo - December 2025 Release
 
 These are the release notes for the Ulmo release, the 21st community release
 of the Open edX Platform, which will be released in December 2025. You can also review details
-about :doc:`index` or learn more about the `Open edX Platform`_.
+about :ref:`Open edX Release Notes` or learn more about the `Open edX Platform`_.
 
 .. highlights::
 
    What's new in Ulmo? Click to read about new features:
 
-   :doc:`ulmo/feature_release_notes`.
+   :ref:`Ulmo Product Notes`.
 
 
 .. highlights::
@@ -17,7 +17,7 @@ about :doc:`index` or learn more about the `Open edX Platform`_.
    What's new in Ulmo? Operators and developers, click to read about new
    updates, patches, and configuration options.
    
-   :doc:`ulmo/dev_op_release_notes`.
+   :ref:`Ulmo Dev Notes`.
 
 .. toctree::
     :maxdepth: 2

--- a/source/community/release_notes/ulmo/dev_op_release_notes.rst
+++ b/source/community/release_notes/ulmo/dev_op_release_notes.rst
@@ -1,3 +1,5 @@
+.. _Ulmo Dev Notes:
+
 Open edX Ulmo Developer & Operator Release Notes
 ################################################
 
@@ -5,10 +7,10 @@ Open edX Ulmo Developer & Operator Release Notes
 
 These are the developer & operator release notes for the Teak release, the 21st
 community release of the Open edX Platform, spanning changes from April 10,
-2025 to December 9, 2025. You can also review details about :doc:`../index` or
+2025 to December 9, 2025. You can also review details about :ref:`Open edX Release Notes` or
 learn more about the `Open edX Platform`_.
 
-To view the end-user facing docs, see the :doc:`feature_release_notes`.
+To view the end-user facing docs, see the :ref:`Ulmo Product Notes`.
 
 .. _Open edX Platform: https://openedx.org
 

--- a/source/community/release_notes/ulmo/feature_release_notes.rst
+++ b/source/community/release_notes/ulmo/feature_release_notes.rst
@@ -1,3 +1,5 @@
+.. _Ulmo Product Notes:
+
 Open edX Ulmo Release - Product Release Notes
 #############################################
 
@@ -9,4 +11,4 @@ Open edX Ulmo Release - Product Release Notes
 
 Information for site operators and developers, including information on how to
 enable and/or configure new features that require additional work, can be found
-in the :doc:`dev_op_release_notes`.
+in the :ref:`Ulmo Dev Notes`.

--- a/source/conf.py
+++ b/source/conf.py
@@ -126,6 +126,10 @@ intersphinx_mapping = {
         f"https://docs.openedx.org/projects/openedx-filters/{rtd_language}/latest",
         None,
     ),
+    "edx-django-utils": (
+        f"https://docs.openedx.org/projects/edx-django-utils/{rtd_language}/latest",
+        None,
+    ),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/source/developers/concepts/hooks_extension_framework.rst
+++ b/source/developers/concepts/hooks_extension_framework.rst
@@ -6,9 +6,9 @@ Hooks Extension Framework
 What is the Hooks Extension Framework?
 **************************************
 
-Based on the :doc:`edx-platform:concepts/extension_points`, this framework aims to extend the Open edX platform in a maintainable way without modifying its core. The main goal is to leverage the existing extension capabilities provided by the `Open edX Django plugins`_ architecture, allowing developers to implement new features while reducing the need for core modifications and minimizing maintenance efforts.
+Based on the :doc:`edx-platform:concepts/extension_points`, this framework aims to extend the Open edX platform in a maintainable way without modifying its core. The main goal is to leverage the existing extension capabilities provided by the :doc:`edx-django-utils:plugins/readme` architecture, allowing developers to implement new features while reducing the need for core modifications and minimizing maintenance efforts.
 
-Hooks are places in the Open edX platform where externally defined functions can take place. These functions may alter what the user sees or experiences on the platform, while in other cases, they are informative only. All hooks are designed to be used along with `Open edX Django plugins`_.
+Hooks are places in the Open edX platform where externally defined functions can take place. These functions may alter what the user sees or experiences on the platform, while in other cases, they are informative only. All hooks are designed to be used along with :doc:`edx-django-utils:plugins/readme`.
 
 Hooks can be of two types: events and filters. Events are signals sent in specific places whose receivers can extend functionality, while filters are functions that can modify the application's behavior. To allow extension developers to use these definitions in their implementations, both kinds of hooks are defined in lightweight external libraries:
 
@@ -232,7 +232,6 @@ By following these steps, you can start contributing to the Hooks Extension Fram
 
 For more specifics about Open edX Events and Filters, please visit the :doc:`openedx-events <openedx-events:index>` and :doc:`openedx-filters <openedx-filters:index>` documentation.
 
-.. _Open edX Django plugins: https://docs.openedx.org/projects/edx-django-utils/en/latest/plugins/readme.html
 .. _openedx-filters: https://github.com/openedx/openedx-filters
 .. _openedx-events: https://github.com/openedx/openedx-events
 .. _Django signals: https://docs.djangoproject.com/en/4.2/topics/signals/

--- a/source/developers/how-tos/enable-translations-new-repo.rst
+++ b/source/developers/how-tos/enable-translations-new-repo.rst
@@ -8,7 +8,7 @@ Enabling Translations on a New Repo
 Quickstart
 **********
 
-To enable translations on a new repository according to the `OEP-58 - Translations Management`_ proposal
+To enable translations on a new repository according to the :doc:`openedx-proposals:architectural-decisions/oep-0058-arch-translations-management`
 
 - Start from an up-to-date cookiecutter (`frontend-template-application`_ for Micro-frontends, `edx-cookiecutters`_
   for Python)
@@ -249,7 +249,6 @@ After adding a repository to the `openedx-translations repo`_ verify the followi
 .. _edx-cookiecutters:  https://github.com/openedx/edx-cookiecutters
 .. _frontend-template-application: https://github.com/openedx/frontend-template-application
 .. _frontend-template-application Makefile: https://github.com/openedx/frontend-template-application/blob/master/Makefile
-.. _OEP-58 - Translations Management: https://docs.openedx.org/projects/openedx-proposals/en/latest/architectural-decisions/oep-0058-arch-translations-management.html
 .. _extract-translation-source-files.yml: https://github.com/openedx/openedx-translations/blob/2566e0c9a30d033e5dd8d05d4c12601c8e37b4ef/.github/workflows/extract-translation-source-files.yml#L36-L43
 .. _Transifex GitHub App sync logs: https://github.apps.transifex.com/projects/o:open-edx:p:openedx-translations/openedx/openedx-translations
 .. _cookiecutter-django-ida: https://github.com/openedx/edx-cookiecutters/tree/master/cookiecutter-django-ida

--- a/source/developers/how-tos/get-ready-for-python-dev.rst
+++ b/source/developers/how-tos/get-ready-for-python-dev.rst
@@ -77,6 +77,6 @@ Working on a Repo
      git switch -c <your_github_username>/<short_descriptive_label>
 
 #. As you change code and add tests, you can use ``make test`` to check if tests are still passing.
-#. Run ``make test`` one more time and commit your changes with ``git add`` and ``git commit``. Follow the `conventional commits`_ documentation. Make sure your commit message is informative and describes why the change is being made. While the first line of the message should be terse, the body of the message has plenty of room for details.
+#. Run ``make test`` one more time and commit your changes with ``git add`` and ``git commit``. Follow :doc:`openedx-proposals:best-practices/oep-0051-bp-conventional-commits` documentation. Make sure your commit message is informative and describes why the change is being made. While the first line of the message should be terse, the body of the message has plenty of room for details.
 #. Push your changes to GitHub with ``git push``.
 #. In GitHub, open a pull request (PR). In the PR description, include anything that could help reviewers understand and test your change.

--- a/source/developers/index.rst
+++ b/source/developers/index.rst
@@ -1,3 +1,5 @@
+.. _Developer's Home:
+
 Open edX Developers
 ###################
 

--- a/source/developers/references/developer_guide/conventions/frontend.rst
+++ b/source/developers/references/developer_guide/conventions/frontend.rst
@@ -6,5 +6,5 @@ Frontend Good Practices
 
 For best practices and standards related to frontend development for the Open edX platform, please see:
 
-* OEP-67: Standard Tools and Technologies: `Frontend Technology Selection <https://docs.openedx.org/projects/openedx-proposals/en/latest/best-practices/oep-0067-bp-tools-and-technology.html#frontend-technology-selection>`_
+* :ref:`openedx-proposals:Frontend Technology Selection`
 * :ref:`Open edX JavaScript Style Guide <javascript_style_guide>`

--- a/source/developers/references/developer_guide/process/code-considerations.rst
+++ b/source/developers/references/developer_guide/process/code-considerations.rst
@@ -31,7 +31,7 @@ Feature Documentation
 Documentation can occur in multiple places - in code, in decision records, or in
 formal feature documentation.
 
-`OEP-19 Developer Documentation`_ describes the various ways to provide
+:doc:`openedx-proposals:best-practices/oep-0019-bp-developer-documentation` describes the various ways to provide
 documentation of your code and features to a developer audience. This includes
 API documentation, decision records (ADRs and OEPs), and README files. Of
 course, you should always provide detailed, informative comments within your
@@ -50,7 +50,7 @@ Feature Rollout Concerns
 ========================
 
 When writing your feature, consider the ways in which your code might be rolled
-out on various Open edX instances. `OEP-17 Feature Toggles`_ describes the many
+out on various Open edX instances. :doc:`openedx-proposals:best-practices/oep-0017-bp-feature-toggles` describes the many
 reasons why you might use a feature toggle, including releasing incrementally,
 beta testing, and providing one Open edX release where the feature is optional
 before making it the default. Utilizing various `Waffle`_ flags, you can gate
@@ -61,7 +61,7 @@ per-course.
 Waffle flags should be well-documented when they are used. Some of the Waffle
 flags used in ``edx-platform``, as well as how they are documented, can be seen
 in the `lms/djangoapps/courseware/toggles.py`_ file. (As a note, you can view
-all Waffle flags in edx-platform here: :doc:`edx-platform:references/featuretoggles`,
+all Waffle flags in edx-platform here: :ref:`edx-platform:featuretoggles`,
 and please be sure to document any Django settings you define as well - those
 are documented here: :doc:`edx-platform:references/settings`.)
 

--- a/source/developers/references/developer_guide/testing/github-actions.rst
+++ b/source/developers/references/developer_guide/testing/github-actions.rst
@@ -59,7 +59,7 @@ or have your employer add you to their entity CLA agreement. Please talk to your
 employer for guidance if you're unsure.
 
 If the "Lint Commit Messages" check fails, you need to rewrite your commit
-message using `Conventional Commits`_.
+message using Conventional Commits (see :doc:`openedx-proposals:best-practices/oep-0051-bp-conventional-commits`).
 
 Failed Builds
 =============

--- a/source/developers/references/running_pr_tests.rst
+++ b/source/developers/references/running_pr_tests.rst
@@ -39,7 +39,7 @@ team in a comment on your PR for further assistance.
 The “Lint Commit Messages/commitlint” Test Is Failing
 *****************************************************
 
-The Open edX project follows a rule known as `Conventional Commits`_. This is a
+The Open edX project follows a rule known as Conventional Commits (see :doc:`openedx-proposals:best-practices/oep-0051-bp-conventional-commits`). This is a
 way of labeling your commit messages so they are extra informative. Please see
 the linked document to learn more about what Conventional Commits are and how we
 use them. If you just need a brief refresher, the types of conventional commits

--- a/source/links.txt
+++ b/source/links.txt
@@ -74,8 +74,6 @@
 
 .. _Jasmine: http://jasmine.github.io/2.3/introduction.html
 
-.. _edX JavaScript Style Guide: https://docs.openedx.org/en/latest/developers/references/developer_guide/style_guides/javascript-guidelines.html#javascript-style-guide
-
 .. _JSHint: http://www.jshint.com/
 
 .. _jscs: https://www.npmjs.org/package/jscs
@@ -83,12 +81,6 @@
 .. _Waffle: http://waffle.readthedocs.io/en/latest
 
 .. _Waffle documentation: http://waffle.readthedocs.io/en/latest
-
-.. _OEP-17 Feature Toggles: https://docs.openedx.org/projects/openedx-proposals/en/latest/best-practices/oep-0017-bp-feature-toggles.html
-
-.. _OEP-19 Developer Documentation: https://docs.openedx.org/projects/openedx-proposals/en/latest/best-practices/oep-0019-bp-developer-documentation.html
-
-.. _Conventional Commits: https://docs.openedx.org/projects/openedx-proposals/en/latest/best-practices/oep-0051-bp-conventional-commits.html
 
 .. _Open edX CLA: https://openedx.org/cla
 
@@ -335,8 +327,6 @@
 .. _spot pricing market: http://aws.amazon.com/ec2/purchasing-options/spot-instances/
 
 .. _edX Managing the Full Stack: https://github.com/openedx/configuration/wiki/edX-Managing-the-Full-Stack
-
-.. _edX Enrollment API: https://docs.openedx.org/projects/edx-platform/en/latest/references/lms_apis.html#get--enrollment-v1-course-course_id
 
 .. _edx-analytics-configuration: https://github.com/openedx/edx-analytics-configuration
 

--- a/source/site_ops/how-tos/add-waffle-flag-for-user.rst
+++ b/source/site_ops/how-tos/add-waffle-flag-for-user.rst
@@ -8,7 +8,7 @@ Follow these steps to enable a waffle flag for a single user. This may be useful
 #. Get the LMS User ID, via a database query or other methods if you have them.
 #. Login to the appropriate Django Admin Portal.
 #. Navigate to ``DJANGO-WAFFLE > Flags``.
-#. Find and select the appropriate flag using the `Open edX Feature Toggles Guide <https://docs.openedx.org/projects/edx-platform/en/latest/references/featuretoggles.html.>`_
+#. Find and select the appropriate flag using the :ref:`edx-platform:featuretoggles`
 #. Set the ``Everyone`` dropdown to ``Unknown``. This will cause the criterion specified on the page to be evaluated. Setting ``Everyone`` to ``True`` or ``False`` applies the flag globally.
 #. Add the LMS User ID from Step 1 to the ``Users`` textbox at the bottom of the page. To add multiple users, values should be comma-separated with no spaces.
 #. Click the appropriate ``Save`` button.

--- a/source/site_ops/install_configure_run_guide/analytics/index.rst
+++ b/source/site_ops/install_configure_run_guide/analytics/index.rst
@@ -11,7 +11,7 @@ following Analytics solutions:
 Aspects
 *******
 
-`Open edX Aspects <https://docs.openedx.org/projects/openedx-aspects/en/latest/index.html>`_
+:doc:`openedx-aspects:index`
 is an optional implementation of analytics for the Open edX LMS. It is the combined solution
 of Cairn by Overhang.io and the OARS project developed by Axim Collaborative with a huge amount
 of help from the Open edX community. Primarily it is intended to be a "batteries included" set

--- a/source/site_ops/install_configure_run_guide/ecommerce-deprecated/manage_orders.rst
+++ b/source/site_ops/install_configure_run_guide/ecommerce-deprecated/manage_orders.rst
@@ -15,7 +15,7 @@ digital products. Most of the products that edX supports involve modifications
 to enrollments.
 
 The edX framework allows modules that fulfill enrollment-related products to
-interact with the `edX Enrollment API`_, which is a part of the LMS. This
+interact with the :doc:`edx-platform:references/lms_apis`, which is a part of the LMS. This
 process can be either synchronous or asynchronous.
 
 

--- a/source/site_ops/install_configure_run_guide/ecommerce-deprecated/test_ecommerce.rst
+++ b/source/site_ops/install_configure_run_guide/ecommerce-deprecated/test_ecommerce.rst
@@ -113,7 +113,7 @@ these tests, place your tests in the ``ecommerce/static/js/test/specs``
 directory, and add a ``_spec`` suffix. For example, your test name may be
 ``ecommerce/static/js/test/specs/course_list_view_spec.js``.
 
-All JavaScript code must adhere to standards outlined in the `edX JavaScript Style Guide`_.
+All JavaScript code must adhere to standards outlined in the :ref:`javascript_style_guide`.
 These standards are enforced using :ref:`ESLint<javascript_style_guide>`.
 
 * To run all JavaScript unit tests and linting checks, run the following

--- a/source/site_ops/install_configure_run_guide/ecommerce-solutions.rst
+++ b/source/site_ops/install_configure_run_guide/ecommerce-solutions.rst
@@ -17,7 +17,7 @@ Open edX Commerce (WordPress Plugin)
 
 The Open edX WooCommerce Plugin is a free, open-source WordPress plugin that aims to integrate third-party e-commerce, WooCommerce, with your Open edX platform. See the following resources:
 
-* `Open edX Commerce (WordPress Plugin) Quickstart <https://docs.openedx.org/projects/wordpress-ecommerce-plugin/en/latest/plugin_quickstart.html>`_
+* :doc:`wordpress-ecommerce-plugin:plugin_quickstart`
 * `Open edX Commerce (WordPress Plugin) Source <https://github.com/openedx/openedx-wordpress-ecommerce?tab=readme-ov-file#-open-edx-commerce-wordpress-plugin>`_
 
 Open edX Webhook Receiver

--- a/source/site_ops/install_configure_run_guide/feature_flags/feature_flag_index.rst
+++ b/source/site_ops/install_configure_run_guide/feature_flags/feature_flag_index.rst
@@ -6,7 +6,7 @@ Index of Open edX Feature Flags
 
 .. tags:: site operator
 
-For more information abut feature flags, see :doc:`edx-platform:references/featuretoggles`.
+For more information abut feature flags, see :ref:`edx-platform:featuretoggles`.
 
 .. include:: /links.txt
 


### PR DESCRIPTION
Replaces #888 as the rebase was wonky

## Link cleanup:

Change as many direct references to docs.openedx.org to relative refs as possible

Change all references to other projects to intersphinx mapping

Change as many direct :doc: directives to :ref:s as possible

## Leftover links

The following can't be changed:

* in index.html, you can't put a ref or doc directive within a toctree, so there's a direct URL link to the OEP page
* in release note pages that link directly to a specific feature toggle (eg https://docs.openedx.org/projects/edx-platform/en/latest/references/settings.html#setting-CUSTOM_RESOURCE_TEMPLATES_DIRECTORY) because of the way that page is composed there aren't refs per toggle so it would not be possible to link to a specific toggle any other way.