### PR TITLE
docs: update the enable_lti_component doc

### DIFF
--- a/source/educators/how-tos/course_development/exercise_tools/enable_lti_component.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/enable_lti_component.rst
@@ -5,11 +5,23 @@ Enable LTI Components for a Course
 
 .. tags:: educator, how-to
 
-Before you can add LTI components to your course, you must enable the LTI tool
-in Studio.
+Studio includes a default set of core problem types that can be added to
+any course. You can expand the types of content you include by enabling
+additional exercises and tools, such as the LTI tool, which allows integration
+with external learning applications.
 
-To enable the LTI tool in Studio, add ``"lti_consumer"`` to the
-**Advanced Module List** on the **Advanced Settings** page. For more
+Enable the LTI Tool
+====================
+
+To enable the LTI tool for your course, follow these steps:
+
+#. In Studio, select **Settings**, and then **Advanced Settings**.
+#. Locate the **Advanced Module List** field. This field lists any advanced exercises and tools added to your course.
+#. Enter ``"lti_consumer"``, ensuring it is enclosed in double quotes. If adding multiple tools, separate them with commas.
+#. Select **Save Changes**.
+
+
+For more
 information, see :ref:`Enable Additional Exercises and Tools`.
 
 .. note::
@@ -39,5 +51,5 @@ information, see :ref:`Enable Additional Exercises and Tools`.
 +--------------+-------------------------------+----------------+--------------------------------+
 | Review Date  | Working Group Reviewer        |   Release      |Test situation                  |
 +--------------+-------------------------------+----------------+--------------------------------+
-|              |                               |                |                                |
+| 2025-03-19   |   Documentation WG            |     Sumac      |      Pass                      |
 +--------------+-------------------------------+----------------+--------------------------------+

--- a/source/educators/how-tos/course_development/exercise_tools/enable_lti_component.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/enable_lti_component.rst
@@ -34,6 +34,10 @@ information, see :ref:`Enable Additional Exercises and Tools`.
   the previous LTI component will continue to work correctly, even if the
   ``lti`` module is no longer present in the **Advanced Module List**.
 
+  Additionally, ``lti_consumer`` supports `LTI 1.3`_ and `LTI Advantage`_,
+  providing enhanced security and interoperability features for integrating
+  external tools with Open edX.
+
 .. seealso::
  
  :ref:`About the LTI Component` (concept)


### PR DESCRIPTION
## Description

I only improved the format of the how-to and added more details.

## How to test

https://docsopenedxorg--961.org.readthedocs.build/en/961/educators/how-tos/course_development/exercise_tools/enable_lti_component.html

## Maintainance checks

- [x]  Audience is defined
- [x]  The Diataxis type is defined
- [x]  RST standards are followed
- [x]  Images are working and current
- [x]  External links are working and accurate
- [x]  See Also table is included
- [x]  While reading the document, consider the standards defined in the [[Open edX Documentation Writing Style Guide](https://docs.openedx.org/en/latest/documentors/references/doc_style_guide.html)](https://docs.openedx.org/en/latest/documentors/references/doc_style_guide.html) (be focused on Grammar, details, etc).
- [x]  Based on the diataxis type, test or validate the document:
    1. If the document is a **how-to** or **quickstart**, complete the steps as instructed and confirm that the outcome in your Open edX instance is the same as what the doc expects.
    2. If the document is a **reference**, confirm that the reference is complete and matches what you observe in your current Open edX version.
    3. If the document is a **concept**, confirm that the information is accurate and up-to-date
- [x]  Complete the maintenance chart


Rendered https://docsopenedxorg--961.org.readthedocs.build/en/961/educators/how-tos/course_development/exercise_tools/enable_lti_component.html