### PR TITLE
Configure search result optimizations

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -59,9 +59,14 @@ search:
     # Match all files under the api/v1 directory
     #api/v1/*: -5
     developers/references/developer_guide/*: 5
+    developers/quickstarts/*: 10
+    educators/quickstarts/*: 10
+    site_ops/quickstarts/*: 10
+    documentors/quickstarts/*: 10
+    translators/quickstarts/*: 10
+
 
     # Match all files named guides.html,
     # two patterns are needed to match both the root and nested files.
     #'guides.html': 3
     #'*/guides.html': 3
-    '*/quickstarts/*': 10

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -58,12 +58,12 @@ search:
 
     # Match all files under the api/v1 directory
     #api/v1/*: -5
-    developers/references/developer_guide/*: 5
-    developers/quickstarts/*: 10
-    educators/quickstarts/*: 10
-    site_ops/quickstarts/*: 10
-    documentors/quickstarts/*: 10
-    translators/quickstarts/*: 10
+    developers/references/developer_guide/*.html: 10
+    developers/quickstarts/*.html: 10
+    educators/quickstarts/*.html: 10
+    site_ops/quickstarts/*.html: 10
+    documentors/quickstarts/*.html: 10
+    translators/quickstarts/*.html: 10
 
 
     # Match all files named guides.html,

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -27,3 +27,41 @@ build:
 python:
   install:
     - requirements: requirements/base.txt
+
+# Optimize search results https://docs.readthedocs.com/platform/stable/config-file/v2.html#search-ranking
+
+search:
+  ranking:
+    # The rank can be an integer number between -10 and 10 (inclusive). Pages
+    # with a rank closer to -10 will appear further down the list of results,
+    # and pages with a rank closer to 10 will appear higher in the list of
+    # results. Note that 0 means normal rank, not no rank.
+    
+    # Deprioritize old release pages
+    birch.html: -10
+    cypress.html: -10
+    dogwood.html: -10
+    eucalyptus.html: -10
+    ficus.html: -10
+    ginkgo.html: -10
+    hawthorn.html: -10
+    ironwood.html: -10
+    juniper.html: -10
+    juniper_developer.html: -10
+    juniper_learner.html: -10
+    juniper_educator.html: -10
+    koa.html: -8
+    lilac.html: -8
+    maple.html: -7
+    nutmeg.html: -5
+    palm.html: -5
+
+    # Match all files under the api/v1 directory
+    #api/v1/*: -5
+    developers/references/developer_guide/*: 5
+
+    # Match all files named guides.html,
+    # two patterns are needed to match both the root and nested files.
+    #'guides.html': 3
+    #'*/guides.html': 3
+    '*/quickstarts/*': 10

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -55,6 +55,7 @@ search:
     maple.html: -7
     nutmeg.html: -5
     palm.html: -5
+    glossary.html: -5
 
     # Match all files under the api/v1 directory
     #api/v1/*: -5

--- a/source/community/release_notes/juniper.rst
+++ b/source/community/release_notes/juniper.rst
@@ -14,7 +14,6 @@ areas, along with a way to jump down to each section of the release notes.
 .. _Open edX Platform: https://open.edx.org
 
 .. toctree::
-   :numbered: 3
    :hidden:
 
    juniper_learner

--- a/source/developers/references/developer_guide/index.rst
+++ b/source/developers/references/developer_guide/index.rst
@@ -1,8 +1,8 @@
 .. _Open edX Developer's Guide:
 
-##########################
-Open edX Developer's Guide
-##########################
+##############################
+Developer's Guide for Open edX
+##############################
 
 Welcome to the Open edX Developer's Guide. This guide should be
 used as a reference manual; it covers everything from high level


### PR DESCRIPTION
Configure search results

- Deprioritize old release pages (Juniper is always a high result for me)
- Priviledge quickstarts
- Bring up Developer's Guide which is currently very low every time I search for it.

https://docs.readthedocs.com/platform/stable/config-file/v2.html#search-ranking
