### PR TITLE
Update embed_google_calendar.rst - This xblock is going to be available by default on Teak

### DIFF
--- a/source/educators/how-tos/course_development/exercise_tools/embed_google_calendar.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/embed_google_calendar.rst
@@ -17,6 +17,7 @@ To embed a Google Calendar in your course, follow these steps.
 ********************************
 Enable the Google Calendars Tool
 ********************************
+**This tool is enabled by default in Teak. For earlier releases, follow the steps below to enable it manually.**
 
 Before you can add Google Calendars to your course, you must enable the Google
 Calendars tool in Studio or OLX (open learning XML).

--- a/source/educators/how-tos/course_development/exercise_tools/embed_google_calendar.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/embed_google_calendar.rst
@@ -17,7 +17,10 @@ To embed a Google Calendar in your course, follow these steps.
 ********************************
 Enable the Google Calendars Tool
 ********************************
-**This tool is enabled by default in Teak. For earlier releases, follow the steps below to enable it manually.**
+
+.. note::
+
+    This tool is enabled by default in Teak. For earlier releases, follow the steps below to enable it manually.
 
 Before you can add Google Calendars to your course, you must enable the Google
 Calendars tool in Studio or OLX (open learning XML).


### PR DESCRIPTION
https://docsopenedxorg--1081.org.readthedocs.build/en/1081/educators/how-tos/course_development/exercise_tools/embed_google_calendar.html