### PR TITLE
chore: Add Aspects references to docs to make relative, not direct, references

### DIFF
--- a/source/community/how-tos/read_the_roadmap.rst
+++ b/source/community/how-tos/read_the_roadmap.rst
@@ -52,7 +52,7 @@ Platform Core roadmap items relate to enhancements and improvements within core 
 Data and Analytics
 ===================
 
-Roadmap items relating to advancing the state of data analytics within the platform. These items generally focus on efforts within the :doc:`openedx-aspects:index` project.
+Roadmap items relating to advancing the state of data analytics within the platform. These items generally focus on efforts within the :ref:`openedx-aspects:Aspects Home` project.
 
 Maintenance
 ============

--- a/source/community/release_notes/redwood/aspects.rst
+++ b/source/community/release_notes/redwood/aspects.rst
@@ -24,7 +24,7 @@ How can I find Aspects Reports?
 Accessing course-level dashboards from the LMS
 ==============================================
 
-Once Aspects has been installed, users can easily :doc:`openedx-aspects:course_team/how-tos/access_aspects` for a
+Once Aspects has been installed, users can easily :ref:`openedx-aspects:Course Team Access Aspects` for a
 course directly from the Open edX LMS by clicking on a new Reports link on the
 Instructor Dashboard. There's no need to navigate elsewhere to gain valuable
 insight into exactly what's going on in a course:
@@ -32,7 +32,8 @@ insight into exactly what's going on in a course:
    .. image:: /_images/release_notes/redwood/aspects_screenshot2.png
 
 On the Reports tab in the LMS, users can navigate between three new dashboards:
-a :doc:`openedx-aspects:reference/course_overview_dashboard`, :doc:`openedx-aspects:reference/learner_groups_dashboard`, and :doc:`openedx-aspects:reference/individual_learner_dashboard`. These dashboards were
+a :ref:`openedx-aspects:Course Dashboard Reports`, :ref:`openedx-aspects:At-Risk Learner Dashboard Reports`,
+and :ref:`openedx-aspects:Individual Learner Dashboard Reports`. These dashboards were
 designed specifically for course authors and course teams looking to access
 quick and easy-to-glean engagement, enrollment, and performance data from their
 courses:
@@ -43,7 +44,7 @@ Accessing all Aspects has to offer from Superset
 ================================================
 
 Course delivery team members who plan to view information for one course and
-then another may chose to :doc:`openedx-aspects:course_team/how-tos/access_aspects`, a third-party data
+then another may chose to :ref:`openedx-aspects:Course Team Access Aspects`, a third-party data
 visualization tool used to create and display Aspects dashboards and charts.
 This will allow these users to easily view the three out-of-the-box course-level
 dashboards for one of their courses and followed by another and another.
@@ -51,7 +52,7 @@ dashboards for one of their courses and followed by another and another.
 Site operators and superusers can view data about any course on their Open edX
 instance or their whole Open edX instance in Superset. 
 Users can access Superset directly via a link from the Aspects Reports in the LMS 
-(:doc:`openedx-aspects:course_team/how-tos/access_aspects`) using single sign-on authorization via their LMS account credentials:
+(:ref:`openedx-aspects:Course Team Access Aspects`) using single sign-on authorization via their LMS account credentials:
 
    .. image:: /_images/release_notes/redwood/aspects_screenshot4.png
 
@@ -94,7 +95,7 @@ course where learner engagement drops off:
 
    .. image:: /_images/release_notes/redwood/aspects_screenshot8.png
 
-When cross filtered (:doc:`openedx-aspects:course_team/how-tos/cross_filter`) by a single
+When cross filtered (:ref:`openedx-aspects:Cross-filters`) by a single
 course video, the Watched Video Segment graphs can help course authors and teams
 pinpoint potentially unclear video timestamp ranges:
 
@@ -111,9 +112,9 @@ Individual and At-Risk Learner Dashboards
 =========================================
 
 In addition to course-wide data, Aspects Reports surface course activity data
-for individual learners (:doc:`openedx-aspects:reference/individual_learner_dashboard`) and
+for individual learners (:ref:`openedx-aspects:Individual Learner Dashboard Reports`) and
 learners that may be at risk of not completing the course 
-(:doc:`openedx-aspects:reference/learner_groups_dashboard`) based on a set of predefined
+(:ref:`openedx-aspects:At-Risk Learner Dashboard Reports`) based on a set of predefined
 risk factors. The at-risk learner group is made up of learners that have
 enrolled in the course, done something in the course other than visit the course
 outline page, have not yet passed the course, and have not visited the course in
@@ -122,7 +123,7 @@ seven or more days.
 When installing the plugin, site operators can choose whether or not to show
 limited personally identifiable information (PII) to course delivery teams. On
 Open edX instances that show limited PII to course delivery teams, staff and
-admin users can see and :doc:`openedx-aspects:course_team/how-tos/download_reports` the names, usernames, and email
+admin users can see and :ref:`openedx-aspects:Downloading Reports` the names, usernames, and email
 addresses of individual and at-risk learners making targeted communication and
 learner intervention possible.
 
@@ -140,7 +141,7 @@ view detailed information:
 Add filters to a dashboard
 ==========================
 
-Users can :doc:`openedx-aspects:course_team/how-tos/apply_filters_lms` to an
+Users can :ref:`openedx-aspects:Apply Filters LMS` to an
 Aspects dashboard using the filters panel on the side of each dashboard. Hover
 over the filter icon on the upper corner of a table or chart to view what
 filters were applied to create the data visualization on any dashboard:
@@ -151,7 +152,7 @@ Dive deeper into the data with interactive charts that can be cross-filtered
 ============================================================================
 
 All Aspects Dashboards allow users to dig deeper into their data through
-:doc:`openedx-aspects:course_team/how-tos/cross_filter`. With
+:ref:`openedx-aspects:Cross-filters`. With
 cross-filters, a user can apply the same filter to multiple charts and tables in
 a dashboard at once. For example, if a user adds a cross-filter for a single
 video on the Video Engagement tab of the Course Dashboard, all applicable video
@@ -163,8 +164,8 @@ Download tables and images from Aspects dashboards
 ==================================================
 
 Users can easily download the data used to create any chart or table in an Aspects dashboard in tabular format as a
-CSV or Excel file (:doc:`openedx-aspects:administrator/how_to/export_tabular_data`) or download the table or chart as
-an image (:doc:`openedx-aspects:course_team/how-tos/download_reports`) for use in their own
+CSV or Excel file (:ref:`openedx-aspects:Export Tabular Data`) or download the table or chart as
+an image (:ref:`openedx-aspects:Downloading Reports`) for use in their own
 documents, presentations, or reports:
 
    .. image:: /_images/release_notes/redwood/aspects_screenshot14.png

--- a/source/community/release_notes/redwood/dev_op_release_notes.rst
+++ b/source/community/release_notes/redwood/dev_op_release_notes.rst
@@ -352,14 +352,14 @@ Developer Experience
 Researcher & Data Experiences
 *****************************
 
-:doc:`openedx-aspects:index` 
+:ref:`openedx-aspects:Aspects Home` 
 is an analytics system for the Open edX platform, bringing actionable data
 about course and learner performance to instructors and site operators. It is primarily
 a Tutor plugin that ties together data from the Open edX learning management system
 and Studio using open source tools to aggregate and transform learning traces into data
 visualizations.
 
-See the :doc:`openedx-aspects:technical_documentation/how-tos/production_configuration`
+See the :ref:`openedx-aspects:production_configuration`
 to learn about setting up Aspects for your production environment.
 
 Known Issues

--- a/source/community/release_notes/sumac/aspects_comp_dashboard.rst
+++ b/source/community/release_notes/sumac/aspects_comp_dashboard.rst
@@ -1,7 +1,7 @@
 Aspects Course Comparison Dashboard
 ###################################
 
-The Product and Engineering Teams from eduNEXT and Axim Collaborative are excited to introduce the :doc:`openedx-aspects:reference/course_comparison_dashboard` for course administrators! We’ve also made improvements to existing course-level dashboards to make them easier to use.
+The Product and Engineering Teams from eduNEXT and Axim Collaborative are excited to introduce the :ref:`openedx-aspects:Course Comparison Dashboard` for course administrators! We’ve also made improvements to existing course-level dashboards to make them easier to use.
 
 Operators can learn more about enabling or updating Aspects on their installations by reviewing :ref:`Sumac Aspects Notes`.
 

--- a/source/community/release_notes/sumac/dev_op_release_notes.rst
+++ b/source/community/release_notes/sumac/dev_op_release_notes.rst
@@ -138,7 +138,7 @@ Developer Experience
 Researcher & Data Experiences
 *****************************
 
-Upgrading Aspects to v1.3.1 will get you the latest Aspects functionality with Sumac. See the upgrade instructions here: :doc:`openedx-aspects:technical_documentation/how-tos/upgrade`.
+Upgrading Aspects to v1.3.1 will get you the latest Aspects functionality with Sumac. See the upgrade instructions here: :ref:`openedx-aspects:upgrade-aspects`.
 
 Known Issues
 ************

--- a/source/developers/references/aspects_home.rst
+++ b/source/developers/references/aspects_home.rst
@@ -3,7 +3,7 @@ Aspects: Learner analytics for the Open edX Platform
 ####################################################
 
 Aspects Homepage
-    :doc:`openedx-aspects:index`
+    :ref:`openedx-aspects:Aspects Home`
 
 LMS Events
     :doc:`event-routing-backends:index`

--- a/source/site_ops/install_configure_run_guide/analytics/index.rst
+++ b/source/site_ops/install_configure_run_guide/analytics/index.rst
@@ -11,7 +11,7 @@ following Analytics solutions:
 Aspects
 *******
 
-:doc:`openedx-aspects:index`
+:ref:`openedx-aspects:Aspects Home`
 is an optional implementation of analytics for the Open edX LMS. It is the combined solution
 of Cairn by Overhang.io and the OARS project developed by Axim Collaborative with a huge amount
 of help from the Open edX community. Primarily it is intended to be a "batteries included" set


### PR DESCRIPTION
This is part of a greater docs cleanup.

Usage of `:doc:` is an antipattern. It is fragile and prone to breaking cross references when docs are moved or renamed.

Replace with usages of `:ref:`. Depends on https://github.com/openedx/openedx-aspects/pull/328
