### PR TITLE
chore: Update OEP :doc: directives to :ref:s

### DIFF
--- a/source/community/release_notes/maple.rst
+++ b/source/community/release_notes/maple.rst
@@ -36,7 +36,7 @@ Studio login changed to OAuth
 
 In versions prior to Maple, Studio (CMS) shared a session cookie with the LMS, and redirected to the LMS for login.
 Studio is changing to become an OAuth client of the LMS, using the same SSO configuration that other IDAs use. (See
-`ARCHBOM-1860`_; :doc:`openedx-proposals:best-practices/oep-0042-bp-authentication`) This is a breaking change. Follow the `Studio OAuth migration runbook`_ as part of
+`ARCHBOM-1860`_; :ref:`openedx-proposals:OEP-42 Authentication`) This is a breaking change. Follow the `Studio OAuth migration runbook`_ as part of
 upgrading to Maple. For devstack, run::
 
     ./provision-ida-user.sh studio studio 18010

--- a/source/developers/concepts/hooks_extension_framework.rst
+++ b/source/developers/concepts/hooks_extension_framework.rst
@@ -19,7 +19,7 @@ Hooks can be of two types: events and filters. Events are signals sent in specif
 
 The framework's main goal is to empower developers to change the platform's functionality as needed while allowing them to migrate to newer Open edX releases with little to no development effort. The framework is designed with stability in mind, meaning it is versioned and backward compatible as much as possible.
 
-A longer description of the framework and its history can be found in :doc:`openedx-proposals:architectural-decisions/oep-0050-hooks-extension-framework`.
+A longer description of the framework and its history can be found in :ref:`openedx-proposals:OEP-50 Hooks extension framework`.
 
 Why Adopt the Hooks Extension Framework?
 ****************************************

--- a/source/developers/how-tos/enable-translations-new-repo.rst
+++ b/source/developers/how-tos/enable-translations-new-repo.rst
@@ -8,7 +8,7 @@ Enabling Translations on a New Repo
 Quickstart
 **********
 
-To enable translations on a new repository according to the :doc:`openedx-proposals:architectural-decisions/oep-0058-arch-translations-management`
+To enable translations on a new repository according to the :ref:`openedx-proposals:OEP-58 Translations Management`:
 
 - Start from an up-to-date cookiecutter (`frontend-template-application`_ for Micro-frontends, `edx-cookiecutters`_
   for Python)

--- a/source/developers/how-tos/get-ready-for-python-dev.rst
+++ b/source/developers/how-tos/get-ready-for-python-dev.rst
@@ -77,7 +77,7 @@ Working on a Repo
      git switch -c <your_github_username>/<short_descriptive_label>
 
 #. As you change code and add tests, you can use ``make test`` to check if tests are still passing.
-#. Run ``make test`` one more time and commit your changes with ``git add`` and ``git commit``. Follow :doc:`openedx-proposals:best-practices/oep-0051-bp-conventional-commits` documentation. Make sure your commit message is informative and describes why the change is being made. While the first line of the message should be terse, the body of the message has plenty of room for details.
+#. Run ``make test`` one more time and commit your changes with ``git add`` and ``git commit``. Follow :ref:`openedx-proposals:OEP-51 Conventional Commits` documentation. Make sure your commit message is informative and describes why the change is being made. While the first line of the message should be terse, the body of the message has plenty of room for details.
 #. Push your changes to GitHub with ``git push``.
 #. In GitHub, open a pull request (PR). In the PR description, include anything that could help reviewers understand and test your change.
 

--- a/source/developers/maintainers_home.rst
+++ b/source/developers/maintainers_home.rst
@@ -30,7 +30,7 @@ Maintainers Home
 Concepts Documentation
 **********************
 
-* :doc:`openedx-proposals:processes/oep-0055-proc-project-maintainers` - The
+* :ref:`openedx-proposals:OEP-55 Project Maintainers` - The
   OEP that kicked off the maintainership program.
 
 * `Community Contributions Project Manager`_ - The role definition for the

--- a/source/developers/references/developer_guide/process/code-considerations.rst
+++ b/source/developers/references/developer_guide/process/code-considerations.rst
@@ -43,7 +43,7 @@ Feature Documentation
 Documentation can occur in multiple places - in code, in decision records, or in
 formal feature documentation.
 
-:doc:`openedx-proposals:best-practices/oep-0019-bp-developer-documentation` describes the various ways to provide
+:ref:`openedx-proposals:OEP-19 Developer Documentation` describes the various ways to provide
 documentation of your code and features to a developer audience. This includes
 API documentation, decision records (ADRs and OEPs), and README files. Of
 course, you should always provide detailed, informative comments within your
@@ -62,7 +62,7 @@ Feature Rollout Concerns
 ========================
 
 When writing your feature, consider the ways in which your code might be rolled
-out on various Open edX instances. :doc:`openedx-proposals:best-practices/oep-0017-bp-feature-toggles` describes the many
+out on various Open edX instances. :ref:`openedx-proposals:OEP-17` describes the many
 reasons why you might use a feature toggle, including releasing incrementally,
 beta testing, and providing one Open edX release where the feature is optional
 before making it the default. Utilizing various `Waffle`_ flags, you can gate

--- a/source/developers/references/developer_guide/process/landing-your-work.rst
+++ b/source/developers/references/developer_guide/process/landing-your-work.rst
@@ -22,7 +22,7 @@ The code should be clear and understandable. Comments in code, detailed
 docstrings, and good variable naming conventions are expected. See the
 :doc:`../style_guides/index` for more details.
 
-Commit messages should conform to :doc:`openedx-proposals:best-practices/oep-0051-bp-conventional-commits`.
+Commit messages should conform to :ref:`openedx-proposals:OEP-51 Conventional Commits`.
 This style categorizes commits to make them easier to understand.
 
 ****************
@@ -92,7 +92,7 @@ Commit Messages and Rebasing
 ****************************
 
 Be sure your commit messages follow
-:doc:`openedx-proposals:best-practices/oep-0051-bp-conventional-commits`.
+:ref:`openedx-proposals:OEP-51 Conventional Commits`.
 
 Before requesting review, please :ref:`rebase your changes <Rebasing>` atop the latest version of
 the ``master`` or ``main`` branch.

--- a/source/developers/references/developer_guide/process/using-git.rst
+++ b/source/developers/references/developer_guide/process/using-git.rst
@@ -7,7 +7,7 @@ The Open edX project is available on GitHub, which uses the Git system for versi
 
 When contributing to a new repo, contributors should use a `personal fork <Using
 A Personal Fork>`_, follow
-:doc:`openedx-proposals:best-practices/oep-0051-bp-conventional-commits`, squash
+:ref:`openedx-proposals:OEP-51 Conventional Commits`, squash
 changes into logical commits, and rebase branches before requesting reviews.
 This page will describe how to do all of these things!
 

--- a/source/developers/references/developer_guide/testing/github-actions.rst
+++ b/source/developers/references/developer_guide/testing/github-actions.rst
@@ -59,7 +59,7 @@ or have your employer add you to their entity CLA agreement. Please talk to your
 employer for guidance if you're unsure.
 
 If the "Lint Commit Messages" check fails, you need to rewrite your commit
-message using Conventional Commits (see :doc:`openedx-proposals:best-practices/oep-0051-bp-conventional-commits`).
+message using Conventional Commits (see :ref:`openedx-proposals:OEP-51 Conventional Commits`).
 
 Failed Builds
 =============

--- a/source/developers/references/running_pr_tests.rst
+++ b/source/developers/references/running_pr_tests.rst
@@ -39,7 +39,7 @@ team in a comment on your PR for further assistance.
 The “Lint Commit Messages/commitlint” Test Is Failing
 *****************************************************
 
-The Open edX project follows a rule known as Conventional Commits (see :doc:`openedx-proposals:best-practices/oep-0051-bp-conventional-commits`). This is a
+The Open edX project follows a rule known as Conventional Commits (see :ref:`openedx-proposals:OEP-51 Conventional Commits`). This is a
 way of labeling your commit messages so they are extra informative. Please see
 the linked document to learn more about what Conventional Commits are and how we
 use them. If you just need a brief refresher, the types of conventional commits


### PR DESCRIPTION
Usage of `:doc:` is an antipattern. It is fragile and prone to breaking cross references when docs are moved or renamed.

Adding in `.. _reference:` syntax to files and headings means cross-references can instead be made with the `:ref:` directive, which will (presuming the references themselves are not deleted or renamed) be more robust to docs refactorings.

Depends on https://github.com/openedx/open-edx-proposals/pull/716
