### PR TITLE
chore: Upgrade Sphinx to 8.2.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@
 #
 accessible-pygments==0.0.5
     # via pydata-sphinx-theme
-alabaster==0.7.16
+alabaster==1.0.0
     # via sphinx
 anyio==4.9.0
     # via
@@ -18,7 +18,7 @@ babel==2.17.0
     #   sphinx
 beautifulsoup4==4.13.4
     # via pydata-sphinx-theme
-certifi==2025.4.26
+certifi==2025.6.15
     # via requests
 charset-normalizer==3.4.2
     # via requests
@@ -75,15 +75,16 @@ requests==2.32.4
     #   sphinx
     #   sphinxcontrib-images
     #   sphinxcontrib-youtube
+roman-numerals-py==3.1.0
+    # via sphinx
 sniffio==1.3.1
     # via anyio
 snowballstemmer==3.0.1
     # via sphinx
 soupsieve==2.7
     # via beautifulsoup4
-sphinx==7.4.7
+sphinx==8.2.3
     # via
-    #   -c /home/runner/work/docs.openedx.org/docs.openedx.org/requirements/constraints.txt
     #   -r requirements/base.in
     #   myst-parser
     #   pydata-sphinx-theme
@@ -148,7 +149,7 @@ urllib3==2.2.3
     #   requests
 uvicorn==0.34.3
     # via sphinx-autobuild
-watchfiles==1.0.5
+watchfiles==1.1.0
     # via sphinx-autobuild
 websockets==15.0.1
     # via sphinx-autobuild

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,9 +10,3 @@
 
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-
-# This is needed until https://github.com/sphinx-contrib/images/issues/40 is closed.
-# The current latest version of sphinx-contrib-images is not compatible with Sphinx 8.0.0
-# and doesn't have proper constraining so we need to hold back sphinx here until the above
-# issue is closed.
-sphinx<8.0.0


### PR DESCRIPTION
requirements/constraints.txt specifies an issue that was blocking the Sphinx upgrade. That issue is now closed!

I tested this locally by viewing pages with the following:

* Intersphinx references
* Local cross references
* External links
* Images
* Emoji
* Video
* Diagrams
