### PR TITLE
Jswope00/certificates advanced settings fix

### DIFF
--- a/source/educators/how-tos/configure_certificate_timing.rst
+++ b/source/educators/how-tos/configure_certificate_timing.rst
@@ -23,6 +23,8 @@ Earlier Open edX versions had an **Enable Student-Generated
 Certificates** option in the LMS instructor dashboard; this option has
 been removed.
 
+.. _Configure Certificate Display Behavior:
+
 ********************************************
 Configure Certificate Display Behavior
 ********************************************

--- a/source/educators/how-tos/configure_certificate_timing.rst
+++ b/source/educators/how-tos/configure_certificate_timing.rst
@@ -19,60 +19,27 @@ instructor-paced courses. When certificates become available, options for
 learners to view their certificates are available on the learner dashboard,
 the learner **Profile** page, and the course **Progress** page.
 
-You can specify when you want to make certificates available.
-
-* For self-paced courses, by default, certificates are generated for
-  learners when they have completed enough of the course, and with a high
-  enough grade, to qualify for a certificate.
-
-  If you want to generate certificates only after learners have
-  completed the course, you can disable this feature. For more information,
-  see :ref:`Allow Learners to Receive Early Certificates`.
-
-* For instructor-paced courses, three options are available.
-
- * By default, certificates become available to learners 48
-   hours after your course end date. If you change your course end date,
-   Studio automatically adjusts the date for certificates as well.
-
- * You can specify a different date to make certificates available. For more
-   information, see :ref:`Specify an Alternative Certificates Available
-   Date`.
-
- * You can allow learners to receive their certificates when they have
-   completed enough of the course, and with a high enough grade, to qualify
-   for a certificate. For more information, see :ref:`Allow Learners to
-   Receive Early Certificates`.
-
-.. _Issue Certificates on a Specified Date:
-
-**************************************
-Issue Certificates on a Specified Date
-**************************************
-
-If you do not want to generate certificates 48 hours after the course
-end date, you can specify the date when you want the platform to generate
-certificates. You can change this date at any time.
-
-For more information about how to specify a day to issue certificates, see
-:ref:`Specify an Alternative Certificates Available Date`.
-
-.. _Allow Learners to Receive Early Certificates:
-
-********************************************
-Allow Learners to Receive Early Certificates
-********************************************
-
-If the administrator has configured the site correctly (see
-:ref:`Enable Automatic Certificate Generation` in
-*Installing, Configuring, and Running the Open edX Platform*),
-self-paced courses issue certificates to learners as soon as learners
-have completed enough of the course, with a high enough grade, to earn
-a certificate. You do not have to change any settings.
-
 Earlier Open edX versions had an **Enable Student-Generated
 Certificates** option in the LMS instructor dashboard; this option has
 been removed.
+
+********************************************
+Configure Certificate Display Behavior
+********************************************
+
+You can specify when you want to make certificates available.
+
+#. In Studio, on the **Settings** menu, select **Schedule & Details**.
+
+#. From the drop-down menu, select one of the following options:
+
+   * **Immediately upon passing**: Learners can access their certificate as soon as they achieve a passing grade above the course grade threshold. Note: learners can achieve a passing grade before encountering all assignments in some course configurations.
+
+   * **On course end date**: Learners with passing grades can access their certificate once the end date of the course has elapsed.
+   
+   * **A date after the course end date**: Learners with passing grades can access their certificate after the date that you set has elapsed. For more information about how to specify a day to issue certificates, see :ref:`Specify an Alternative Certificates Available Date`.
+
+#. Select **Save Changes**.
 
 .. seealso::
 

--- a/source/educators/how-tos/configure_certificate_timing.rst
+++ b/source/educators/how-tos/configure_certificate_timing.rst
@@ -74,24 +74,6 @@ Earlier Open edX versions had an **Enable Student-Generated
 Certificates** option in the LMS instructor dashboard; this option has
 been removed.
 
-.. _Allow Learners to Download Certificates:
-
-*********************************************
-Allow Learners to Download Early Certificates
-*********************************************
-
-To allow learners to download early certificates, you modify the
-**Certificates Display Behavior** advanced setting in Studio.
-
-#. In Studio, on the **Settings** menu, select **Advanced Settings**.
-
-#. On the **Advanced Settings** page, locate **Certificates Display Behavior**.
-
-#. In the **Certificates Display Behavior** field, enter ``"early_no_info"``.
-   Be sure that you include the double quotation marks.
-
-#. Select **Save Changes**.
-
 .. seealso::
 
   :ref:`About Certificates` (concept)

--- a/source/educators/how-tos/rerun_course.rst
+++ b/source/educators/how-tos/rerun_course.rst
@@ -70,9 +70,7 @@ steps.
 
 #. Sign in to Studio. Your dashboard lists the courses that you have access to as a course team member.
 
-#. Move your cursor over each row in the list of courses. The **Re-Run Course** and **View Live** options appear for each course.
-
-#. Locate the course you want to re-run and select **Re-Run Course**. The **Create a re-run of a course** page opens with values already supplied in the **Course Name**, **Organization**, and **Course Number** fields.
+#. Locate the course you want to re-run and select **Re-Run Course** from the kebab menu. The **Create a re-run of a course** page opens with values already supplied in the **Course Name**, **Organization**, and **Course Number** fields.
 
 #. In the **Course Run** field, indicate when the new course will be offered.
 
@@ -185,6 +183,8 @@ for launch, see :ref:`Course Launch Checklist`.
 
 +--------------+-------------------------------+----------------+--------------------------------------------------------------+
 | Review Date  | Working Group Reviewer        |   Release      |Test situation                                                |
++--------------+-------------------------------+----------------+--------------------------------------------------------------+
+|06/30/2025    | John (Curricu.me)             | Sumac          |Pass                                                          |
 +--------------+-------------------------------+----------------+--------------------------------------------------------------+
 |03/11/2025    | Leira (Curricu.me)            | Sumac          |Fail (https://github.com/openedx/docs.openedx.org/issues/895) |
 +--------------+-------------------------------+----------------+--------------------------------------------------------------+

--- a/source/site_ops/install_configure_run_guide/configuration/enable_certificates.rst
+++ b/source/site_ops/install_configure_run_guide/configuration/enable_certificates.rst
@@ -362,9 +362,7 @@ setting may take several minutes to propagate in a large installation.
 
 In addition to this Waffle switch, automatic certificate generation
 requires certain settings to be defined for the course, by a member of
-the course staff. For more details, see :ref:`Allow
-Learners to Receive Early Certificates` in
-*Building and Running an Open edX Course*.
+the course staff. For more details, see :ref:`Configure Certificate Display Behavior` in *Building and Running an Open edX Course*.
 
 .. _Manually Generate Certificates for a Course:
 

--- a/source/site_ops/install_configure_run_guide/configuration/enable_certificates.rst
+++ b/source/site_ops/install_configure_run_guide/configuration/enable_certificates.rst
@@ -363,8 +363,7 @@ setting may take several minutes to propagate in a large installation.
 In addition to this Waffle switch, automatic certificate generation
 requires certain settings to be defined for the course, by a member of
 the course staff. For more details, see :ref:`Allow
-Learners to Receive Early Certificates` and
-:ref:`Allow Learners to Download Certificates` in
+Learners to Receive Early Certificates` in
 *Building and Running an Open edX Course*.
 
 .. _Manually Generate Certificates for a Course:


### PR DESCRIPTION
Certificates instructions were out of date. Brought up to date with Sumac where the process is basically set the Auto-generate certificate flag and then choose the timing option you want from the Certificate page in studio.