### PR TITLE
Draft Product Marketing release notes (alt)

### DIFF
--- a/source/community/release_notes/teak.rst
+++ b/source/community/release_notes/teak.rst
@@ -16,7 +16,7 @@ about :ref:`Open edX Release Notes` or learn more about the `Open edX Platform`_
 
 .. highlights::
 
-   What's new in Teak? Operators and developers, click to read about new
+   Operators and developers, click to read about new
    updates, patches, and configuration options.
    
    :ref:`Teak Dev Notes`.

--- a/source/community/release_notes/teak.rst
+++ b/source/community/release_notes/teak.rst
@@ -9,7 +9,9 @@ about :ref:`Open edX Release Notes` or learn more about the `Open edX Platform`_
 
    What's new in Teak? Click to read about new features:
 
-   :ref:`Teak Product Notes`.
+   :ref:`Teak Product Marketing Notes`
+
+   And for more detail on individual products, refer to :ref:`Teak Product Notes`.
 
 
 .. highlights::

--- a/source/community/release_notes/teak/feature_release_notes.rst
+++ b/source/community/release_notes/teak/feature_release_notes.rst
@@ -5,6 +5,8 @@ Open edX Teak Release - Product Release Notes
 
 The Open edX Teak Release was released on June 9, 2025.
 
+:ref:`What's New? <Teak Product Marketing Notes>`
+
 .. toctree::
    :maxdepth: 1
 

--- a/source/community/release_notes/teak/smaller_changes.rst
+++ b/source/community/release_notes/teak/smaller_changes.rst
@@ -7,6 +7,9 @@ Smaller Changes (Potpourri)
   :local:
   :depth: 1
 
+
+.. _Preview Button (Teak):
+
 Preview Button Improvement
 ****************************
 
@@ -37,6 +40,8 @@ Studio UI Modernization
   ``legacy_studio.problem_editor``. In Ulmo, this option will be removed: only
   the new editor will be available.
 
+.. _Problem Editor (Teak):
+
 Problem Editor Improvements
 ****************************
 
@@ -44,6 +49,7 @@ The new (React-based) editor now supports Markdown by default via course
 waffle flag. Instance administrators can disable the Markdown editor by
 creating a flag, ``contentstore.use_react_markdown_editor``, with the value "No".
 
+.. _cc2olx (Teak):
 
 Improvements to Common Cartridge Support
 *****************************************

--- a/source/community/release_notes/teak/teak_marketing_notes.rst
+++ b/source/community/release_notes/teak/teak_marketing_notes.rst
@@ -1,0 +1,96 @@
+.. _Teak Product Marketing Notes:
+
+Open edX Teak Release (June 2025)
+###################################
+
+Welcome to the Teak release! This release puts powerful new tools in your hands
+while making everyday tasks simpler. Here's what's ready for you now: 
+
+🧑‍🏫 For Course Authors
+********************************
+
+:ref:`Easier Content Reuse with Libraries <Content Libraries Redesign Teak>`: Using
+Libraries, authors can now create modular units that can be
+reused in multiple courses. Updates and changes to content can be managed
+centrally in Libraries, with changes syncing seamlessly. Save hours of content
+creation by leveraging libraries for reuse in your courses.
+
+:ref:`Analytics in Studio <In-Context Analytics (Teak)>`: Studio now includes
+In-Context Analytics, enabling course teams to make data-driven course improvements without switching tools. With a
+new button on Course Outline and Unit pages, authors can view insights like
+problem correctness rates and video rewatch patterns without leaving the Studio
+page. Spot struggling students early and adjust your teaching approach in real
+time. *Note: Requires use of the Aspects analytics system.*
+
+:ref:`More Content Blocks Enabled by Default <Content Blocks (Teak)>`: To reduce
+technical barriers and improve discoverability, a curated list of high-value content blocks (e.g., Google Docs,
+LTI 1.3, Polls, Surveys, Word Cloud) is now enabled by default in Studio. These
+can be accessed via the new “Advanced” tile in the unit editor.
+
+:ref:`Studio UI Modernization <Studio Changes (Teak)>`: Studio now features a
+modern, streamlined interface by default on all sites.
+
+:ref:`Problem Editor Updates <Problem Editor (Teak)>`: Write clearer,
+more flexible problems with Markdown support in the Problem Editor.
+
+:ref:`Improved Preview Experience  <Preview Button (Teak)>`: The “Preview”
+button in Studio now uses the default student experience rather than the legacy experience, letting authors
+see content exactly as learners will, improving content validation during
+authoring.
+
+🎓 For Learners
+*****************
+
+:ref:`Give learners credentials they'll want to share<Badging (Teak)>`: In
+addition to certificates, learners can now earn digital badges — a
+more portable, shareable credential that can be added to social media profiles
+and email signatures. While certificates provide detailed achievement records,
+badges offer quick, visual proof of skills that employers and peers can easily
+recognize. Open edX now integrates directly with Accredible and Credly to issue
+and manage these badges. 
+
+⚙️ For Site Operators 
+**********************
+
+:ref:`More flexibility for your tech team to build custom features <Teak Frontend Plugin Slots>`: More
+plugin slots have been added across the platform to support easier customization and extension by your
+development or operations team.
+
+:ref:`Your site, your brand — now faster than ever <Teak Design Tokens>`: Our
+new theming system takes only seconds to change, switch,
+and deploy your organization's brand themes. Customize your site's look and feel
+consistently across your full site. We encourage operators to test out this
+system in Teak; it will be required for any theming customization with the Ulmo
+upgrade.
+
+🔮 Upcoming in Ulmo (December 2025)
+************************************
+
+We're working hard on even more improvements in our Ulmo release! You can look
+forward to:
+
+**Advanced Libraries**: Build entire course sections once, then reuse them
+everywhere — imagine updating your intro module across 20 courses with one
+click!
+
+**Smart Notifications**: Never let students miss important discussions again!
+Keep learners engaged with timely alerts about new posts and announcements,
+delivered both in-platform and via email.
+
+**Simplified LTI**: Tired of wrestling with LTI integrations? Set up credentials
+once and reuse them across all your tools with our streamlined LTI 1.3 plugin.
+
+**Beautiful Course Pages**: Your course catalog is getting a major glow-up! New,
+customizable pages will help you showcase courses with modern design and full
+theming support.
+
+**Important**: The Ulmo release will require the new theming system. Get ahead
+of the curve and test it now so your upgrade is seamless!
+
+⌚ Ready to upgrade?
+***********************
+
+Have your site operations team check out the `Tutor upgrading guide
+<https://docs.tutor.edly.io/install.html#upgrading>`_ so they can upgrade your
+Open edX instance to the Teak release!
+

--- a/source/index.rst
+++ b/source/index.rst
@@ -4,9 +4,29 @@ Open edX Documentation
 .. The homepages are provided as links in the panels so we don't need to display
    the table of contents for them.
 
-.. grid:: 1 1 1 1
+.. grid:: 1 2 2 2
    :gutter: 3
    :padding: 0
+
+   .. grid-item-card:: 📰 What's New?
+      :class-card: sd-shadow-md sd-p-2
+      :class-footer: sd-border-0
+
+      .. toctree::
+         :maxdepth: 1
+         :hidden:
+
+         📰 What's New? <community/release_notes/teak/teak_marketing_notes>
+
+      The Open edX Teak release is out, featuring:
+
+      💡 Easier Content Reuse with Libraries!
+
+      📈 Analytics in Studio!
+
+      🏅 Badges for Learners!
+
+      ... and lots more! :ref:`Continue reading... <Teak Product Marketing Notes>`
 
    .. grid-item-card::
       :class-card: sd-shadow-md sd-p-2
@@ -16,10 +36,10 @@ Open edX Documentation
          :maxdepth: 1
          :caption: Quick Starts
 
-         Set up Open edX <site_ops/quickstarts/index>
-         Build a Course <educators/quickstarts/build_a_course>
-         Contribute to Open edX Code Base <developers/quickstarts/first_openedx_pr>
-         Update the Documentation <documentors/quickstarts/first_documentation_pr>
+         Set up an Open edX Site <site_ops/quickstarts/index>
+         Build an Open edX Course <educators/quickstarts/build_a_course>
+         Contribute to the Open edX Code Base <developers/quickstarts/so_you_want_to_contribute>
+         Update the Open edX Documentation <documentors/quickstarts/first_documentation_pr>
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Adding product marketing release notes for Teak to the docs site (alt version - version 1 in #1276 ) - agreed upon in Slack.

https://docsopenedxorg--1287.org.readthedocs.build/en/1287/community/release_notes/teak/teak_marketing_notes.html#teak-product-marketing-notes