### PR TITLE
docs: Link to the community discussion areas.

### DIFF
--- a/source/community/index.rst
+++ b/source/community/index.rst
@@ -9,3 +9,5 @@ Community Home
    how-tos/read_the_roadmap
    security_policy/index
    how-tos/receive_announcements_by_email
+   Community Discussion Boards <https://discuss.openedx.org>
+   Slack Workspace <https://openedx.org/slack>


### PR DESCRIPTION
Make it easy to find the slack and discourse forums for folks new to the
community.
