### PR TITLE
build: Update review team name

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -17,7 +17,7 @@ jobs:
       branch: ${{ github.event.inputs.branch || 'main' }}
       # optional parameters below; fill in if you'd like github or email notifications
       # user_reviewers: "feanil"
-      team_reviewers: "docs-openedx-org-maintainers"
+      team_reviewers: "wg-maintenance-docs.openedx.org"
       # email_address: ""
       # send_success_notification: false
       python_version: "3.12"


### PR DESCRIPTION
We were tagging the old team name and now that we've changed the team name to follow the current convention, we needed to upload this file as well.