### PR TITLE
build: Don't branch or tag this in the named release

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,6 +8,15 @@ metadata:
       title: "Production Site"
       icon: "Web"
   annotations:
+    # NAMED RELEASE NOTE:
+    # This repository gets marked for named releases in a non-standard way!
+    # Standard repsitories get branch `release/X` on the cut date, and tags `release/X.1`,
+    # `release/X.2`, and `release/X.3`on the release dates.
+    # This repo, on the other hand, just gets a `release/X` branch on the X.1 release date.
+    # This is because a lot of documentation happens between the cut date and the X.1 release date;
+    # rather than backporting all those docs, we'd rather just make the branch late.
+    # So, we do not delcare a `openedx.org/release:` key here, because that would confuse the release script.
+    # Instead, the community Release Manager will manually create the `release/X` branch at the right time.
     openedx.org/arch-interest-groups: "feanil"
 spec:
   owner: group:wg-maintenance-docs.openedx.org


### PR DESCRIPTION
@sarina , from https://discuss.openedx.org/t/git-checkout-release-ulmo/17466 :
> we don't want a release branch made on the docs repo, because so much documentation happens between the cut and the release and backporting so many docs changes is a big cognitive overhead

Is it fair to then remove this line from catalog-info so that it's not auto-tagged in the future?