### PR TITLE
Update LTI how-tos to separate site ops from educators docs

### DIFF
--- a/source/educators/how-tos/course_development/exercise_tools/setup_lti_reusable_consumer.rst
+++ b/source/educators/how-tos/course_development/exercise_tools/setup_lti_reusable_consumer.rst
@@ -13,12 +13,17 @@ Overview
 Reusable LTI configurations are created once by an administrator in Django Admin (LTI Store) and identified by a filter key.  
 In Studio, you can point an LTI Consumer component to that reusable configuration, avoiding repeated copy/paste of credentials.
 
+.. note::
+
+   In order to set up an LTI Consumer with Reusable LTI configuration, a site administrator will need to create the configuration
+   in the backend. Site administrators can see :ref:`Create a Reusable LTI 1.3 Configuration` for more detail.
+
 
 Before you start
 ****************
 
 * An administrator has created a reusable LTI 1.3 configuration in Django Admin.  
-* You have the reusable configuration’s filter key. It may be shared as a value like ``lti_store:reference_tool``  
+* You have the reusable configuration's filter key. It may be shared as a value like ``lti_store:reference_tool``  
 * You have edit access to the course in Studio.
 
 .. note::
@@ -69,6 +74,8 @@ What changes compared to on-block configuration
 
  :ref:`Set up a Reusable LTI Store` (how-to)
 
+ :ref:`Create a Reusable LTI 1.3 Configuration` (site operator how-to)
+
  :ref:`LTI Component Settings` (reference)
 
  :ref:`Set up an LTI 1_3 component` (how-to)
@@ -81,5 +88,5 @@ What changes compared to on-block configuration
 +--------------+-------------------------------+----------------+--------------------------------+
 | Review Date  | Working Group Reviewer        | Release        | Test situation                 |
 +--------------+-------------------------------+----------------+--------------------------------+
-|              |                               | Ulmo           | Draft                          |
+| 2025-12-05   | LTI WG                        | Ulmo           | Pass                           |
 +--------------+-------------------------------+----------------+--------------------------------+

--- a/source/educators/navigation/components_activities.rst
+++ b/source/educators/navigation/components_activities.rst
@@ -163,7 +163,6 @@ LTI Component
    ../how-tos/course_development/exercise_tools/set_up_lti_1_1_component.rst
    ../how-tos/course_development/exercise_tools/set_up_lti_1_3_component.rst
    ../how-tos/course_development/exercise_tools/use_lti_advantage_features.rst
-   ../how-tos/course_development/exercise_tools/setup_lti_store.rst
    ../how-tos/course_development/exercise_tools/setup_lti_reusable_consumer.rst
 
 

--- a/source/site_ops/how-tos/setup_lti_store.rst
+++ b/source/site_ops/how-tos/setup_lti_store.rst
@@ -4,12 +4,15 @@
 Set up a Reusable LTI Store
 ###########################
 
-.. tags:: educator, how-to
+.. tags:: site operator, how-to
 
 The Reusable LTI Store centralizes LTI configuration in Django Admin.  
 Course authors then reference a single reusable configuration in Studio (via the LTI Consumer component).  
 A single configuration can be referenced multiple times, eliminating repeated copy/paste of tool credentials.
 
+.. contents::
+   :local:
+   :depth: 1
 
 Overview
 ********
@@ -64,6 +67,8 @@ To create and manage reusable configurations:
 * Assign permissions for the LTI Store models only (no superuser needed).
 * This limits access to just the LTI Store configuration screens.
 
+
+.. _Create a Reusable LTI 1.3 Configuration:
 
 Create a reusable LTI configuration
 ***********************************
@@ -143,6 +148,8 @@ Next steps
 
 .. seealso::
 
+ :ref:`Create a Reusable LTI 1.3 Configuration` (how-to)
+
  :ref:`Set up an LTI Consumer with Reusable LTI Configuration` (how-to) 
 
  :ref:`LTI Component Settings` (reference)
@@ -165,5 +172,5 @@ Next steps
 +--------------+-------------------------------+----------------+--------------------------------+
 | Review Date  | Working Group Reviewer        | Release        | Test situation                 |
 +--------------+-------------------------------+----------------+--------------------------------+
-|              |                               | Ulmo           | Draft                          |
+| 2025-12-05   | LTI WG                        | Ulmo           | Pass                           |
 +--------------+-------------------------------+----------------+--------------------------------+


### PR DESCRIPTION
Hi @feanil @usmanpm

In reviewing these docs introduced in https://github.com/openedx/docs.openedx.org/pull/1288 i felt that some of the instructions were more suited to a Site Ops how-to.
