### PR TITLE
build: Tag a team with write access for reviews.

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -17,7 +17,7 @@ jobs:
       branch: ${{ github.event.inputs.branch || 'main' }}
       # optional parameters below; fill in if you'd like github or email notifications
       # user_reviewers: "feanil"
-      team_reviewers: "wg-maintenance-docs.openedx.org"
+      team_reviewers: "committers-docs-openedx-org"
       # email_address: ""
       # send_success_notification: false
       python_version: "3.12"


### PR DESCRIPTION
According to https://github.com/openedx/repo-tools/blob/master/edx_repo_tools/pull_request_creator/__init__.py#L52-L54

The team we tag has to have write access to the repo.

This is to fix https://github.com/openedx/docs.openedx.org/actions/runs/20402238194/job/58626285114