### PR TITLE
Update docs: Adding Custom Fields to the Registration Page

### DIFF
--- a/source/site_ops/install_configure_run_guide/configuration/customize_registration_page.rst
+++ b/source/site_ops/install_configure_run_guide/configuration/customize_registration_page.rst
@@ -1,8 +1,8 @@
 .. _Customize Registration Page:
 
-################################################
+##############################################
 Adding Custom Fields to the Registration Page
-################################################
+##############################################
 
 .. tags:: site operator
 
@@ -49,6 +49,7 @@ Method 1: Redefine constants using Django admin and `Site configurations` API. (
 
             }
         }
+
 
 #. All possible fields can be found in `EXTRA_FIELDS <https://github.com/openedx/edx-platform/blob/a9355852edede9662762847e0d168663083fc816/openedx/core/djangoapps/user_authn/api/helper.py#L20-L39>`_.
 #. REST API gets cached. If you are in a hurry, you can do this command: `tutor local exec redis redis-cli flushall`. Also, you can wait a few minutes until the cache is invalidated.

--- a/source/site_ops/install_configure_run_guide/configuration/customize_registration_page.rst
+++ b/source/site_ops/install_configure_run_guide/configuration/customize_registration_page.rst
@@ -40,11 +40,11 @@ Method 1: Redefine constants using Django admin and `Site configurations` API. (
         {
             "ENABLE_DYNAMIC_REGISTRATION_FIELDS": "true",
             "MFE_CONFIG": {
-                "ENABLE_DYNAMIC_REGISTRATION_FIELDS": "true"
+               "ENABLE_DYNAMIC_REGISTRATION_FIELDS": "true"
             },
             "REGISTRATION_EXTRA_FIELDS": {
-                "country": "required",
-                "gender": "optional"
+               "country": "required",
+               "gender": "optional"
             }
         }
 
@@ -86,9 +86,9 @@ Everything said above in instructions **A** also applies to adding fields that d
 #. Extend user profile model with new fields. An external plugin can be used for this (recommended). Also user profile model can be expanded inside edx-platform code base (not recommended). `New fields must be migrated to the database.`
 #. Create a form with additional user profile fields and pass the path to this form into `settings`. The form can also be created in the Open edX plugin. `Edx-cookiecutters <https://github.com/openedx/edx-cookiecutters>`_ can be used for the plugin creation.
 #. Additional settings can be passed via `Site configurations` in the LMS admin. This is described in instructions **A**. 
-   Example:
+Example:
 
-    .. code-block:: json
+   .. code-block:: json
 
         {
             "REGISTRATION_EXTENSION_FORM": "you_application.form.ExtendedUserProfileForm",
@@ -112,7 +112,7 @@ Everything said above in instructions **A** also applies to adding fields that d
 
 .. note:: Below, you can read in detail how to create a new Application and Form, what happens when you redefine each constant, and how they can be redefined.
 
-
+*******************************************************
 Configuring Custom Registration Fields on the Back-End
 *******************************************************
 To configure dynamic registration fields within Authn, perform the following steps in Open edX LMS settings or your custom form plugin:
@@ -127,6 +127,7 @@ To configure dynamic registration fields within Authn, perform the following ste
 .. warning:: If this step is missed, fields from the extension form will not be saved. For more information, please see the condition in: `helper.py <https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/user_authn/api/helper.py#L97>`_.
 #. After adding all required settings, verify that the context has been properly extended with the new fields by inspecting the networks tab in your browser's developer tools.
 
+************************************************
 Configuring Dynamic Registration Fields in Authn
 ************************************************
 Enable dynamic fields in the MFE. Ensure that `ENABLE_DYNAMIC_REGISTRATION_FIELDS` is enabled for the MFE. This can be configured via env tokens or through site configurations if MFE CONFIG API is enabled.

--- a/source/site_ops/install_configure_run_guide/configuration/customize_registration_page.rst
+++ b/source/site_ops/install_configure_run_guide/configuration/customize_registration_page.rst
@@ -33,25 +33,25 @@ A. Add Fields that Already Exist as Columns in the User Profile Model
 You need to redefine several constants in the settings. You can use various methods for this:
 
 Method 1: Redefine constants using Django admin and ``Site configurations`` API. (recommended)
----------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------
 
 #. Go to ``Site configurations`` in admin: {{LMS}}/admin/site_configuration/siteconfiguration/
 
 #. Add new settings to OrderedDict (create new ``Site configurations`` if it was not before)
    .. code-block:: json
 
-        {
-            "ENABLE_DYNAMIC_REGISTRATION_FIELDS": "true",
-            "MFE_CONFIG": {
-            "ENABLE_DYNAMIC_REGISTRATION_FIELDS": "true"
-            },
+      {
+         "ENABLE_DYNAMIC_REGISTRATION_FIELDS": "true",
+         "MFE_CONFIG": {
+         "ENABLE_DYNAMIC_REGISTRATION_FIELDS": "true"
+         },
 
-            "REGISTRATION_EXTRA_FIELDS": {
-            "country": "required",
-            "gender": "optional"
+         "REGISTRATION_EXTRA_FIELDS": {
+         "country": "required",
+         "gender": "optional"
 
-            }
-        }
+         }
+      }
 
 
 #. All possible fields can be found in `EXTRA_FIELDS <https://github.com/openedx/edx-platform/blob/a9355852edede9662762847e0d168663083fc816/openedx/core/djangoapps/user_authn/api/helper.py#L20-L39>`_.

--- a/source/site_ops/install_configure_run_guide/configuration/customize_registration_page.rst
+++ b/source/site_ops/install_configure_run_guide/configuration/customize_registration_page.rst
@@ -90,7 +90,7 @@ Example:
 
    .. code-block:: json
 
-        {
+         {
             "REGISTRATION_EXTENSION_FORM": "you_application.form.ExtendedUserProfileForm",
 
             "extended_profile_fields": [
@@ -99,7 +99,7 @@ Example:
                 "confirm_age_consent",
                 "something_else"
             ]
-        }
+         }
 
 #. In total, you must migrate to DB new user profile fields and redefine 3 constants using the method that is most preferable for you:
    .. code-block:: python

--- a/source/site_ops/install_configure_run_guide/configuration/customize_registration_page.rst
+++ b/source/site_ops/install_configure_run_guide/configuration/customize_registration_page.rst
@@ -6,8 +6,8 @@ Adding Custom Fields to the Registration Page
 
 .. tags:: site operator
 
-This topic describes how to add custom fields to the registration page for your
-instance of Open edX.
+This topic describes how to add custom fields to the registration page for your Open edX
+instance.
 
 .. contents::
    :local:
@@ -29,12 +29,15 @@ To add fields that already exist in the user model, it is sufficient to redefine
 
 A. Add Fields that Already Exist as Columns in the User Profile Model
 ======================================================================
+
 You need to redefine several constants in the settings. You can use various methods for this:
 
-Method 1: Redefine constants using Django admin and `Site configurations` API. (recommended)
+Method 1: Redefine constants using Django admin and ``Site configurations`` API. (recommended)
 ---------------------------------------------------------------------------------------------
-#. Go to `Site configurations` in admin: {{LMS}}/admin/site_configuration/siteconfiguration/
-#. Add new settings to OrderedDict (create new `Site configurations` if it was not before)
+
+#. Go to ``Site configurations`` in admin: {{LMS}}/admin/site_configuration/siteconfiguration/
+
+#. Add new settings to OrderedDict (create new ``Site configurations`` if it was not before)
    .. code-block:: json
 
         {
@@ -52,7 +55,9 @@ Method 1: Redefine constants using Django admin and `Site configurations` API. (
 
 
 #. All possible fields can be found in `EXTRA_FIELDS <https://github.com/openedx/edx-platform/blob/a9355852edede9662762847e0d168663083fc816/openedx/core/djangoapps/user_authn/api/helper.py#L20-L39>`_.
-#. REST API gets cached. If you are in a hurry, you can do this command: `tutor local exec redis redis-cli flushall`. Also, you can wait a few minutes until the cache is invalidated.
+
+#. REST API gets cached. If you are in a hurry, you can do this command: ``tutor local exec redis redis-cli flushall``. Also, you can wait a few minutes until the cache is invalidated.
+
 #. The new fields should appear on the Auth page. Required fields will appear on the registration form, and optional fields will appear on the progressive profiling form.
 
 Method 2: Redefine Settings Above by Using the Tutor Plugin
@@ -62,7 +67,7 @@ Method 2: Redefine Settings Above by Using the Tutor Plugin
 
 Method 3: For the Local Development or Testing Settings, It Can Be Overridden in Configuration Files
 -----------------------------------------------------------------------------------------------------
-#. Constants can be added here: `env/apps/openedx/settings/lms/development.py`:
+#. Constants can be added here: ``env/apps/openedx/settings/lms/development.py``:
    .. code-block:: python
 
         ENABLE_DYNAMIC_REGISTRATION_FIELDS = "true"
@@ -85,10 +90,10 @@ In total, you must redefine 3 constants using the method that is most preferable
 
 B. Add Fields that Do Not Exist in the User Profile Model
 ==========================================================
-Everything said above in instructions **A** also applies to adding fields that do not exist in the user profile model. This is a more complex task and requires a basic understanding of the Open EdX platform, the concept of plugins, as well as knowledge of the Django framework. However, there are additional actions that you need  to perform:
-#. Extend user profile model with new fields. An external plugin can be used for this (recommended). Also user profile model can be expanded inside edx-platform code base (not recommended). `New fields must be migrated to the database.`
-#. Create a form with additional user profile fields and pass the path to this form into `settings`. The form can also be created in the Open edX plugin. `Edx-cookiecutters <https://github.com/openedx/edx-cookiecutters>`_ can be used for the plugin creation.
-#. Additional settings can be passed via `Site configurations` in the LMS admin. This is described in instructions **A**. 
+Everything said above in instructions **A** also applies to adding fields that do not exist in the user profile model. This is a more complex task and requires a basic understanding of the Open edX platform, the concept of plugins, as well as knowledge of the Django framework. However, there are additional actions that you need  to perform:
+#. Extend user profile model with new fields. An external plugin can be used for this (recommended). Also user profile model can be expanded inside edx-platform code base (not recommended). ``New fields must be migrated to the database.``
+#. Create a form with additional user profile fields and pass the path to this form into ``settings``. The form can also be created in the Open edX plugin. `Edx-cookiecutters <https://github.com/openedx/edx-cookiecutters>`_ can be used for the plugin creation.
+#. Additional settings can be passed via ``Site configurations`` in the LMS admin. This is described in instructions **A**. 
 Example:
 
    .. code-block:: json
@@ -118,22 +123,22 @@ Example:
 *******************************************************
 Configuring Custom Registration Fields on the Back-End
 *******************************************************
-To configure dynamic registration fields within Authn, perform the following steps in Open edX LMS settings or your custom form plugin:
+To configure dynamic registration fields within Authn, perform the following steps in the Open edX LMS settings or your custom form plugin:
 
 #. Install your custom form app and configure it in LMS. Follow the steps outlined in the official Open edX documentation to configure custom registration fields for your instance:
 `Customize the Registration Page <https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/customize_registration_page.html>`_.
-#. Enable dynamic registration fields setting in the Open edX platform. Enable the `ENABLE_DYNAMIC_REGISTRATION_FIELDS` setting in the settings file. This setting should be added to the plugin where the extension form is placed.
+#. Enable dynamic registration fields setting in the Open edX platform. Enable the ``ENABLE_DYNAMIC_REGISTRATION_FIELDS`` setting in the settings file. This setting should be added to the plugin where the extension form is placed.
 
 .. note:: See the context view for the Logistration page: `user_authn API Context View <https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/user_authn/api/views.py#L61>`_.
 
-#. Add fields to the extended profile fields list. Add your `custom field <https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/retrieve_extended_profile_metadata.html>`_ to the `extended_profile_fields` list to ensure it is checked correctly during registration.
+#. Add fields to the extended profile fields list. Add your `custom field <https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/retrieve_extended_profile_metadata.html>`_ to the ``extended_profile_fields`` list to ensure it is checked correctly during registration.
 .. warning:: If this step is missed, fields from the extension form will not be saved. For more information, please see the condition in: `helper.py <https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/user_authn/api/helper.py#L97>`_.
 #. After adding all required settings, verify that the context has been properly extended with the new fields by inspecting the networks tab in your browser's developer tools.
 
 ************************************************
 Configuring Dynamic Registration Fields in Authn
 ************************************************
-Enable dynamic fields in the MFE. Ensure that `ENABLE_DYNAMIC_REGISTRATION_FIELDS` is enabled for the MFE. This can be configured via env tokens or through site configurations if MFE CONFIG API is enabled.
+Enable dynamic fields in the MFE. Ensure that ``ENABLE_DYNAMIC_REGISTRATION_FIELDS`` is enabled for the MFE. This can be configured via env tokens or through site configurations if MFE CONFIG API is enabled.
 
 .. include:: /links.txt
 

--- a/source/site_ops/install_configure_run_guide/configuration/customize_registration_page.rst
+++ b/source/site_ops/install_configure_run_guide/configuration/customize_registration_page.rst
@@ -1,8 +1,8 @@
 .. _Customize Registration Page:
 
-#######################################################
-Adding Custom Fields to the Registration Page in Authn
-#######################################################
+################################################
+Adding Custom Fields to the Registration Page
+################################################
 
 .. tags:: site operator
 
@@ -40,11 +40,13 @@ Method 1: Redefine constants using Django admin and `Site configurations` API. (
         {
             "ENABLE_DYNAMIC_REGISTRATION_FIELDS": "true",
             "MFE_CONFIG": {
-               "ENABLE_DYNAMIC_REGISTRATION_FIELDS": "true"
+            "ENABLE_DYNAMIC_REGISTRATION_FIELDS": "true"
             },
+
             "REGISTRATION_EXTRA_FIELDS": {
-               "country": "required",
-               "gender": "optional"
+            "country": "required",
+            "gender": "optional"
+
             }
         }
 
@@ -132,7 +134,7 @@ Configuring Dynamic Registration Fields in Authn
 ************************************************
 Enable dynamic fields in the MFE. Ensure that `ENABLE_DYNAMIC_REGISTRATION_FIELDS` is enabled for the MFE. This can be configured via env tokens or through site configurations if MFE CONFIG API is enabled.
 
-
+.. include:: /links.txt
 
 **Maintenance chart**
 

--- a/source/site_ops/install_configure_run_guide/configuration/customize_registration_page.rst
+++ b/source/site_ops/install_configure_run_guide/configuration/customize_registration_page.rst
@@ -1,8 +1,8 @@
 .. _Customize Registration Page:
 
-#############################################
-Adding Custom Fields to the Registration Page
-#############################################
+#######################################################
+Adding Custom Fields to the Registration Page in Authn
+#######################################################
 
 .. tags:: site operator
 
@@ -13,60 +13,124 @@ instance of Open edX.
    :local:
    :depth: 1
 
-*********
-Overview
-*********
+*************
+Introduction
+*************
 
-By default, the registration page for each instance of Open edX has fields that
-ask for information such as a user's name, country, and highest level of
-education completed. You can add custom fields to the registration page for
-your own Open edX instance. These fields can be different types, including
-text entry fields and drop-down lists.
+This guide explains how to add custom fields to the registration page of your Open edX instance. To integrate custom fields with the new Authn MFE, additional configuration steps are required. Custom fields can be either required—added directly to the registration page—or optional, and will be added to the progressive profiling page (welcome page) that users can skip.
 
-*********************************************
-Add Custom Fields to the Registration Page
-*********************************************
+**********************************
+Two Main Ways to Add Custom Fields
+**********************************
 
-Before you add a custom field to the registration page, you must make sure that
-the combined sign-in and registration form is enabled for your Open edX
-instance. To do this, open the ``lms.yml`` and ``studio.yml`` files, and
-set the ``ENABLE_COMBINED_LOGIN_REGISTRATION`` feature flag to True. These
-files are located one level above the ``edx- platform`` directory.
+The Open edX platform has default additional fields that can be used in Authn MFE. The fields that are in `EXTRA_FIELDS <https://github.com/openedx/edx-platform/blob/a9355852edede9662762847e0d168663083fc816/openedx/core/djangoapps/user_authn/api/helper.py#L20-L39>`_ are already exist as columns in the user profile model, but are disabled, so when adding other fields that do not exist, a step to do data migration is required.
 
-To add custom fields to the registration page, follow these steps.
+To add fields that already exist in the user model, it is sufficient to redefine several constants. How to do this will be described in instructions **A**. If you need to add fields that are not in the user model by default, use instruction **B**.
 
-#. Start and sign in to your instance of Open edX.
+A. Add Fields that Already Exist as Columns in the User Profile Model
+======================================================================
+You need to redefine several constants in the settings. You can use various methods for this:
 
-#. Use Python to create a Django form that contains the fields that you want to
-   add to the page, and then create a Django model to store the information
-   from the form.
+Method 1: Redefine constants using Django admin and `Site configurations` API. (recommended)
+---------------------------------------------------------------------------------------------
+#. Go to `Site configurations` in admin: {{LMS}}/admin/site_configuration/siteconfiguration/
+#. Add new settings to OrderedDict (create new `Site configurations` if it was not before)
+   .. code-block:: json
 
-   For more information about how to create Django forms, see `Django Forms`_
-   on the `Django website`_.
+        {
+            "ENABLE_DYNAMIC_REGISTRATION_FIELDS": "true",
+            "MFE_CONFIG": {
+                "ENABLE_DYNAMIC_REGISTRATION_FIELDS": "true"
+            },
+            "REGISTRATION_EXTRA_FIELDS": {
+                "country": "required",
+                "gender": "optional"
+            }
+        }
 
-#. In the ``lms.yml`` file, add the app for your model to the
-   ``ADDL_INSTALLED_APPS`` array.
+#. All possible fields can be found in `EXTRA_FIELDS <https://github.com/openedx/edx-platform/blob/a9355852edede9662762847e0d168663083fc816/openedx/core/djangoapps/user_authn/api/helper.py#L20-L39>`_.
+#. REST API gets cached. If you are in a hurry, you can do this command: `tutor local exec redis redis-cli flushall`. Also, you can wait a few minutes until the cache is invalidated.
+#. The new fields should appear on the Auth page. Required fields will appear on the registration form, and optional fields will appear on the progressive profiling form.
 
-#. In the ``lms.yml`` file, set the ``REGISTRATION_EXTENSION_FORM``
-   setting to the path of the Django form that you just created, as a dot-
-   separated Python string.
+Method 2: Redefine Settings Above by Using the Tutor Plugin
+------------------------------------------------------------
+#. There is a tutorial `how Tutor plugin can be created <https://docs.tutor.edly.io/tutorials/plugin.html#creating-a-tutor-plugin>`_.
+#. Settings above should be overridden in the Tutor plugin.
 
-   For example, if your form is named "ExampleExtensionForm" and is located at
-   "path/to/the_form.py", the value of the setting is
-   ``path.to.the_form.ExampleExtensionForm``.
+Method 3: For the Local Development or Testing Settings, It Can Be Overridden in Configuration Files
+-----------------------------------------------------------------------------------------------------
+#. Constants can be added here: `env/apps/openedx/settings/lms/development.py`:
+   .. code-block:: python
 
-#. Run database migrations.
+        ENABLE_DYNAMIC_REGISTRATION_FIELDS = "true"
 
-#. Restart the LMS and verify that the new fields appear on your registration
-   form.
+        MFE_CONFIG["ENABLE_DYNAMIC_REGISTRATION_FIELDS"] = "true"
 
-.. note::
+        REGISTRATION_EXTRA_FIELDS["country"] = "required"
 
-  For an example app for custom forms, see the OpenCraft `custom_form_app`_
-  page in `GitHub`_.
+        REGISTRATION_EXTRA_FIELDS["gender"] = "required"
+
+In total, you must redefine 3 constants using the method that is most preferable for you:
+
+    .. code-block:: python
+
+        ENABLE_DYNAMIC_REGISTRATION_FIELD = True,
+
+        MFE_CONFIG["ENABLE_DYNAMIC_REGISTRATION_FIELDS"] = True,
+
+        REGISTRATION_EXTRA_FIELDS["field_name"] = "required/optionl/hidden"
+
+B. Add Fields that Do Not Exist in the User Profile Model
+==========================================================
+Everything said above in instructions **A** also applies to adding fields that do not exist in the user profile model. This is a more complex task and requires a basic understanding of the Open EdX platform, the concept of plugins, as well as knowledge of the Django framework. However, there are additional actions that you need  to perform:
+#. Extend user profile model with new fields. An external plugin can be used for this (recommended). Also user profile model can be expanded inside edx-platform code base (not recommended). `New fields must be migrated to the database.`
+#. Create a form with additional user profile fields and pass the path to this form into `settings`. The form can also be created in the Open edX plugin. `Edx-cookiecutters <https://github.com/openedx/edx-cookiecutters>`_ can be used for the plugin creation.
+#. Additional settings can be passed via `Site configurations` in the LMS admin. This is described in instructions **A**. 
+   Example:
+
+    .. code-block:: json
+
+        {
+            "REGISTRATION_EXTENSION_FORM": "you_application.form.ExtendedUserProfileForm",
+
+            "extended_profile_fields": [
+                "your_new_field_id",
+                "subscribe_to_emails",
+                "confirm_age_consent",
+                "something_else"
+            ]
+        }
+
+#. In total, you must migrate to DB new user profile fields and redefine 3 constants using the method that is most preferable for you:
+   .. code-block:: python
+
+        ENABLE_DYNAMIC_REGISTRATION_FIELD = True,
+
+        MFE_CONFIG["ENABLE_DYNAMIC_REGISTRATION_FIELDS"] = True,
+
+        REGISTRATION_EXTENSION_FORM = "you_application.form.ExtendedUserProfileForm"
+
+.. note:: Below, you can read in detail how to create a new Application and Form, what happens when you redefine each constant, and how they can be redefined.
 
 
-.. include:: /links.txt
+Configuring Custom Registration Fields on the Back-End
+*******************************************************
+To configure dynamic registration fields within Authn, perform the following steps in Open edX LMS settings or your custom form plugin:
+
+#. Install your custom form app and configure it in LMS. Follow the steps outlined in the official Open edX documentation to configure custom registration fields for your instance:
+`Customize the Registration Page <https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/customize_registration_page.html>`_.
+#. Enable dynamic registration fields setting in the Open edX platform. Enable the `ENABLE_DYNAMIC_REGISTRATION_FIELDS` setting in the settings file. This setting should be added to the plugin where the extension form is placed.
+
+.. note:: See the context view for the Logistration page: `user_authn API Context View <https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/user_authn/api/views.py#L61>`_.
+
+#. Add fields to the extended profile fields list. Add your `custom field <https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/retrieve_extended_profile_metadata.html>`_ to the `extended_profile_fields` list to ensure it is checked correctly during registration.
+.. warning:: If this step is missed, fields from the extension form will not be saved. For more information, please see the condition in: `helper.py <https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/user_authn/api/helper.py#L97>`_.
+#. After adding all required settings, verify that the context has been properly extended with the new fields by inspecting the networks tab in your browser's developer tools.
+
+Configuring Dynamic Registration Fields in Authn
+************************************************
+Enable dynamic fields in the MFE. Ensure that `ENABLE_DYNAMIC_REGISTRATION_FIELDS` is enabled for the MFE. This can be configured via env tokens or through site configurations if MFE CONFIG API is enabled.
+
 
 
 **Maintenance chart**
@@ -74,5 +138,5 @@ To add custom fields to the registration page, follow these steps.
 +--------------+-------------------------------+----------------+--------------------------------+
 | Review Date  | Working Group Reviewer        |   Release      |Test situation                  |
 +--------------+-------------------------------+----------------+--------------------------------+
-|              |                               |                |                                |
+| 15/04/2026   |  edunext                      |   Ulmo         |  Pass                          |
 +--------------+-------------------------------+----------------+--------------------------------+

--- a/source/site_ops/install_configure_run_guide/configuration/customize_registration_page.rst
+++ b/source/site_ops/install_configure_run_guide/configuration/customize_registration_page.rst
@@ -37,7 +37,8 @@ Method 1: Redefine constants using Django admin and ``Site configurations`` API.
 
 #. Go to ``Site configurations`` in admin: {{LMS}}/admin/site_configuration/siteconfiguration/
 
-#. Add new settings to OrderedDict (create new ``Site configurations`` if it was not before)
+#. Add new settings to OrderedDict (create new ``Site configurations`` if it was not before):
+
    .. code-block:: json
 
       {


### PR DESCRIPTION
PR: https://github.com/openedx/frontend-app-authn/pull/1595 Restore "Adding Custom Fields to Registration" How-To Guide Context
This PR restores the documentation guide for adding custom fields to the registration page in the Authn MFE. This guide was previously removed from the repository, but there is no clear trace of when or why it was deleted from the codebase.

The original file is: https://github.com/openedx/frontend-app-authn/blob/63d16364fc2aa6538dd876bd3f6fd5612a20d605/docs/how_tos/adding_custom_fields_to_the_registration.rst#b-add-fields-that-do-not-exist-in-the-user-profile-model

Problem
The documentation for extending registration fields is currently missing from the repository, making it difficult for operators to:

Understand how to add custom fields to the registration page Configure REGISTRATION_EXTRA_FIELDS properly
Extend the UserProfile model with custom fields
Integrate custom forms with the Authn MFE
This documentation is essential for organizations that need to collect additional user information during registration beyond the standard fields (email, username, password, name).

Documentation Location
The restored documentation is located at:

docs/how_tos/adding_custom_fields_to_the_registration.rst

Key Topics Covered
Introduction to custom registration fields
Difference between required and optional fields
Step-by-step configuration for existing fields
Advanced guide for custom UserProfile field extensions Backend and frontend integration requirements
Configuration examples for different deployment methods Testing
I followed up the instructions and everything is working as expected