### PR TITLE
docs: add openedx-proposals links to developer pages

### DIFF
--- a/source/developers/index.rst
+++ b/source/developers/index.rst
@@ -68,6 +68,7 @@ Open edX Developers
 
       * :doc:`references/running_pr_tests`
       * :doc:`references/developer_guide/index`
+      * :doc:`openedx-proposals:index`
       * :doc:`edx-platform:index`
       * `frontend-platform <https://openedx.github.io/frontend-platform>`_
       * :doc:`references/aspects_home`

--- a/source/developers/references/index.rst
+++ b/source/developers/references/index.rst
@@ -1,6 +1,7 @@
 References Home
 ###############
 
+:doc:`openedx-proposals:index` — Open edX Enhancement Proposals (OEPs) are design documents that describe accepted changes to the Open edX platform. They cover architecture decisions, best practices, and processes that apply across the project.
 
 Per Repo Documentation
 **********************


### PR DESCRIPTION
## Summary

- Adds a link to the [openedx-proposals](https://docs.openedx.org/projects/openedx-proposals/) index on the developers home page References card
- Adds a prominent link with a brief description at the top of the references index page

The openedx-proposals project was previously linked from the docs index but was dropped at some point. This restores visibility for developers who need to find OEPs.