### PR TITLE
docs: Bring in backup-restore format doc + fixes

### DIFF
--- a/source/educators/how-tos/course_development/backup_restore_library.rst
+++ b/source/educators/how-tos/course_development/backup_restore_library.rst
@@ -10,7 +10,8 @@ Backup and Restore a Library
   :depth: 1
 
 You can :ref:`backup<Backup a Library>` and :ref:`restore<Restore a Library>` a
-content library in Studio.
+content library in Studio. Both operations use the :ref:`Library Archive
+Format`, a portable ZIP format that you can also inspect or edit by hand.
 
 .. _Backup a Library:
 
@@ -103,6 +104,8 @@ To create a library from an archive, follow these steps.
     :ref:`Add a Problem Bank to your course for randomization`
 
     :ref:`Add users to Libraries`
+
+    :ref:`Library Archive Format`
 
 **Maintenance chart**
 

--- a/source/educators/navigation/content_creation_management.rst
+++ b/source/educators/navigation/content_creation_management.rst
@@ -52,6 +52,7 @@ Work with Content Libraries
    ../how-tos/course_development/create_edit_blocks.rst
    ../how-tos/course_development/publish_library_content.rst
    ../how-tos/course_development/backup_restore_library.rst
+   ../references/library_archive_format.rst
    ../how-tos/course_development/add_delete_tags_in_library_content.rst
    ../how-tos/course_development/build_a_collection_in_a_library.rst
    ../how-tos/course_development/search_for_content_in_a_library.rst

--- a/source/educators/references/library_archive_format.rst
+++ b/source/educators/references/library_archive_format.rst
@@ -5,8 +5,8 @@ The Library Archive Format
 
 .. tags:: educator, reference
 
-The Library Archive Format is the ZIP-based format used to back up and restore
-content libraries on the Open edX Platform.
+The Library Archive Format is the ZIP-based format used to
+:ref:`Backup and Restore a Library` on the Open edX platform.
 
 With a library archive, authors can:
 
@@ -18,28 +18,12 @@ Because the archive keeps each component's content as OLX (open learning XML) �
 the same format Studio uses internally — authors already familiar with
 :ref:`OLX <What is Open Learning XML?>` will recognize the XML stored inside.
 
-.. note::
-
-   This page documents the *format* of a library archive. For step-by-step
-   instructions on creating and restoring one in Studio, see
-   :ref:`Backup and Restore a Library`.
-
 .. contents::
    :local:
    :depth: 2
 
 Overview
 ********
-
-.. note::
-
-   A **Library** (the user-facing content library) has exactly one **Learning
-   Package** where it stores its content, but Learning Packages can also exist
-   independently. During a restore, the system first creates a standalone
-   Learning Package for inspection; once the operator confirms the content,
-   that Learning Package is associated with a newly created Library. Because of
-   this relationship, you will see the term ``learning_package`` used inside the
-   archive's metadata files.
 
 A backup ZIP is a self-contained snapshot of one learning package. It captures
 every component, collection, container (section / subsection / unit), and
@@ -50,7 +34,19 @@ The archive uses `TOML <https://toml.io>`_ for all metadata files and keeps the
 actual component XBlock content as XML (the same OLX format Studio has always
 used). This makes backups both machine-readable and human-inspectable.
 
-.. note::
+
+.. admonition:: A note on Learning Packages
+
+   Every user-facing *Library* is backed in the database by a *Learning Package*,
+   a general of repository of learning content. During the restore process,
+   the system creates a standalone Learning Package for inspection; once the
+   operator confirms the content, the Learning Package is promoted into a
+   proper Library.  Because of this relationship, you will see the term
+   ``learning_package`` used inside the archive's metadata files. In the
+   future, this same archive format may be used to restore other kinds of
+   Learning-Package-backed content.
+
+.. admonition:: Schema versioning
 
    The current archive ``format_version`` is **1**. Future incompatible changes
    to the schema will increment this number so that tooling can detect them
@@ -64,17 +60,17 @@ Archive Structure
     <package>.zip
     ├── package.toml                          # library metadata + archive metadata
     ├── collections/
-    │   └── <collection-key>.toml            # one file per collection
+    │   └── <collection-key>.toml             # one file per collection
     └── entities/
-        ├── <container-slug>.toml            # sections, subsections, units
+        ├── <container-key>.toml              # sections, subsections, units
         └── xblock.v1/
-            └── <block-type>/               # e.g. html, problem, video
-                ├── <uuid>.toml             # entity metadata + version list
-                └── <uuid>/
+            └── <block-type>/                 # e.g. html, problem, video
+                ├── <component-code>.toml     # entity metadata + version list
+                └── <component-code>/
                     └── component_versions/
                         └── v<N>/
-                            ├── block.xml   # XBlock content (XML)
-                            └── static/     # media assets referenced by block.xml
+                            ├── block.xml     # XBlock content (XML)
+                            └── static/       # media assets referenced by block.xml
 
 File Format Reference
 *********************
@@ -154,8 +150,8 @@ Example::
     created = 2025-08-19T04:25:10.988166Z
     updated = 2025-08-19T04:25:10.988166Z
 
-Component entity TOML (``entities/xblock.v1/<type>/<uuid>.toml``)
-================================================================
+Component entity TOML (``entities/xblock.v1/<type>/<code>.toml``)
+=================================================================
 
 Each XBlock component gets one TOML file.
 
@@ -173,7 +169,7 @@ Each XBlock component gets one TOML file.
      - Whether this component can be used independently (almost always ``true``)
    * - ``key``
      - yes
-     - Entity reference in the form ``xblock.v1:<type>:<uuid>``
+     - Entity reference in the form ``xblock.v1:<type>:<code>``
    * - ``created``
      - yes
      - UTC creation timestamp
@@ -226,13 +222,16 @@ Example::
     title = "Text"
     version_num = 4
 
-Container entity TOML (``entities/<slug>.toml``)
-================================================
+.. admonition:: Mapping archive keys to platform keys
 
-The ``<slug>`` is derived from the last segment of the container's
-``entity_ref``. If two containers share the same last segment (e.g. a Unit
-and a Subsection both named "intro"), a short hash is appended to the
-second to avoid filename collisions (e.g. ``intro-48afa3.toml``).
+   Restoring a component with an archive reference key
+   ``xblock.v1:<type>:<component_code>`` to a library with the key
+   ``lib:<org_code>:<lib_code>`` yields an XBlock with the usage key
+   ``lb:<org_code>:<lib_code>:<type>:<component_code>``.
+
+
+Container entity TOML (``entities/<key>.toml``)
+===============================================
 
 Sections, subsections, and units share the same base structure with an
 additional ``[entity.container.<type>]`` marker (``section``, ``subsection``,
@@ -262,6 +261,13 @@ Example (section)::
     [version.container]
     children = ["subsection1-48afa3"]
 
+.. admonition:: Mapping archive keys to platform keys
+
+   Restoring a container of kind ``<type>`` and archive reference ``<key>`` to
+   a library with the key ``lib:<org_code>:<lib_code>`` yields a container with
+   the key ``lct:<org_code>:<lib_code>:<type>:<key>``.
+
+
 Collection TOML (``collections/<key>.toml``)
 ============================================
 
@@ -286,7 +292,7 @@ Collection TOML (``collections/<key>.toml``)
      - UTC creation timestamp
    * - ``entities``
      - yes
-     - List of entity reference strings (``xblock.v1:<type>:<uuid>``)
+     - List of entity reference strings (e.g. ``xblock.v1:html:abc123``, ``unit-xyz789``)
 
 Example::
 
@@ -303,24 +309,25 @@ Example::
 XBlock content (``component_versions/v<N>/block.xml``)
 ======================================================
 
-:ref:`OLX (open learning XML) <What is Open Learning XML?>` for the component,
-in the same format Studio uses internally. Static assets (images, PDFs, etc.)
-referenced with ``/static/<filename>`` in the XML are stored alongside under
-``component_versions/v<N>/static/``.
+The library archive format uses
+:ref:`OLX (open learning XML) <What is Open Learning XML?>` to encode components,
+similar to the course archive format, although there are few notable differences:
 
-.. note::
+* Each library component version's OLX file is simply named ``block.xml``. Its key is
+  separetely defined in the component's TOML metadata file. In the course OLX
+  archive, the name of each XML file is derived from its block's key:
+  ``<block_id>.xml``.
 
-   Unlike the old modulestore OLX export — where each component's file was
-   named after its ``block_id`` (often a machine-generated UUID) — this format
-   always names the file ``block.xml``. The component's identifier lives in
-   the parent TOML file, not the filename.
+* Each library component stores its own static assets,
+  ``component_versions/v<N>/static/<filename>`` and references them in its OLX
+  file as ``/static/<filename>``. In the course archive, the course's static
+  assets are all in one shared ``static/`` folder.
 
-.. note::
-
-   **HTMLBlock limitation:** HTML content is currently serialized inline using
-   a CDATA section rather than stored in a separate ``.html`` file. This
-   differs from old course OLX exports and is a known limitation of the current
-   XBlock serialization layer.
+* Library HTML content is currently serialized inline using a CDATA section
+  within the ``.xml`` file rather than being split into a separate ``.html``
+  file. This differs from course archives, which support separate ``.xml`` and
+  ``.html`` files. This is a known limitation of the library XBlock
+  serialization layer.
 
 Example ``block.xml``::
 

--- a/source/educators/references/library_archive_format.rst
+++ b/source/educators/references/library_archive_format.rst
@@ -6,7 +6,7 @@ The Library Archive Format
 .. tags:: educator, reference
 
 The Library Archive Format is the ZIP-based format used to
-:ref:`Backup and Restore a Library` on the Open edX platform.
+:ref:`Backup and Restore a Library` on the Open edX Platform.
 
 With a library archive, authors can:
 
@@ -38,10 +38,10 @@ used). This makes backups both machine-readable and human-inspectable.
 .. admonition:: A note on Learning Packages
 
    Every user-facing *Library* is backed in the database by a *Learning Package*,
-   a general of repository of learning content. During the restore process,
+   a general repository of learning content. During the restore process,
    the system creates a standalone Learning Package for inspection; once the
    operator confirms the content, the Learning Package is promoted into a
-   proper Library.  Because of this relationship, you will see the term
+   proper Library. Because of this relationship, you will see the term
    ``learning_package`` used inside the archive's metadata files. In the
    future, this same archive format may be used to restore other kinds of
    Learning-Package-backed content.
@@ -311,15 +311,15 @@ XBlock content (``component_versions/v<N>/block.xml``)
 
 The library archive format uses
 :ref:`OLX (open learning XML) <What is Open Learning XML?>` to encode components,
-similar to the course archive format, although there are few notable differences:
+similar to the course archive format, although there are a few notable differences:
 
 * Each library component version's OLX file is simply named ``block.xml``. Its key is
-  separetely defined in the component's TOML metadata file. In the course OLX
+  separately defined in the component's TOML metadata file. In the course OLX
   archive, the name of each XML file is derived from its block's key:
   ``<block_id>.xml``.
 
-* Each library component stores its own static assets,
-  ``component_versions/v<N>/static/<filename>`` and references them in its OLX
+* Each library component stores its own static assets under
+  ``component_versions/v<N>/static/<filename>``, and references them in its OLX
   file as ``/static/<filename>``. In the course archive, the course's static
   assets are all in one shared ``static/`` folder.
 

--- a/source/educators/references/library_archive_format.rst
+++ b/source/educators/references/library_archive_format.rst
@@ -1,0 +1,348 @@
+.. _Library Archive Format:
+
+The Library Archive Format
+##########################
+
+.. tags:: educator, reference
+
+The Library Archive Format is the ZIP-based format used to back up and restore
+content libraries on the Open edX Platform.
+
+With a library archive, authors can:
+
+* Move a library between different Open edX instances.
+* Keep a portable backup copy of a library.
+* Inspect, or even hand-edit, the contents of a library outside of Studio.
+
+Because the archive keeps each component's content as OLX (open learning XML) —
+the same format Studio uses internally — authors already familiar with
+:ref:`OLX <What is Open Learning XML?>` will recognize the XML stored inside.
+
+.. note::
+
+   This page documents the *format* of a library archive. For step-by-step
+   instructions on creating and restoring one in Studio, see
+   :ref:`Backup and Restore a Library`.
+
+.. contents::
+   :local:
+   :depth: 2
+
+Overview
+********
+
+.. note::
+
+   A **Library** (the user-facing content library) has exactly one **Learning
+   Package** where it stores its content, but Learning Packages can also exist
+   independently. During a restore, the system first creates a standalone
+   Learning Package for inspection; once the operator confirms the content,
+   that Learning Package is associated with a newly created Library. Because of
+   this relationship, you will see the term ``learning_package`` used inside the
+   archive's metadata files.
+
+A backup ZIP is a self-contained snapshot of one learning package. It captures
+every component, collection, container (section / subsection / unit), and
+static asset. For each component and container, only the current draft and
+published versions are exported — the full version history is not preserved.
+
+The archive uses `TOML <https://toml.io>`_ for all metadata files and keeps the
+actual component XBlock content as XML (the same OLX format Studio has always
+used). This makes backups both machine-readable and human-inspectable.
+
+.. note::
+
+   The current archive ``format_version`` is **1**. Future incompatible changes
+   to the schema will increment this number so that tooling can detect them
+   before attempting a restore.
+
+Archive Structure
+*****************
+
+::
+
+    <package>.zip
+    ├── package.toml                          # library metadata + archive metadata
+    ├── collections/
+    │   └── <collection-key>.toml            # one file per collection
+    └── entities/
+        ├── <container-slug>.toml            # sections, subsections, units
+        └── xblock.v1/
+            └── <block-type>/               # e.g. html, problem, video
+                ├── <uuid>.toml             # entity metadata + version list
+                └── <uuid>/
+                    └── component_versions/
+                        └── v<N>/
+                            ├── block.xml   # XBlock content (XML)
+                            └── static/     # media assets referenced by block.xml
+
+File Format Reference
+*********************
+
+package.toml
+============
+
+Located at the root of the archive. Contains two sections:
+
+``[meta]`` — archive metadata (for inspection only):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Field
+     - Required
+     - Description
+   * - ``format_version``
+     - yes
+     - Integer schema version; currently ``1``
+   * - ``created_by``
+     - no
+     - Username of the operator who ran the export
+   * - ``created_by_email``
+     - no
+     - Email address of the exporting user
+   * - ``created_at``
+     - yes
+     - UTC timestamp when the archive was created
+   * - ``origin_server``
+     - no
+     - Free-form string identifying the origin CMS instance (typically a
+       hostname or URL; stored as-is with no format validation)
+
+``[learning_package]`` — library data. Note that ``key`` may be overridden when
+the library is restored under a new reference, and ``updated`` is written to the
+archive for reference but is not applied during a restore:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Field
+     - Required
+     - Description
+   * - ``title``
+     - yes
+     - Human-readable name of the library
+   * - ``key``
+     - yes
+     - Package reference string, e.g. ``lib:MyOrg:MyLib``
+   * - ``description``
+     - yes
+     - Free-text description (may be blank)
+   * - ``created``
+     - yes
+     - UTC timestamp when the library was originally created
+   * - ``updated``
+     - yes
+     - UTC timestamp of the library's last modification (written to the
+       archive for reference; **not** applied during restore)
+
+Example::
+
+    [meta]
+    format_version = 1
+    created_by = "lp_user"
+    created_by_email = "lp_user@example.com"
+    created_at = 2025-10-05T18:23:45.180535Z
+    origin_server = "cms.test"
+
+    [learning_package]
+    title = "Library test"
+    key = "lib:WGU:LIB_C001"
+    description = ""
+    created = 2025-08-19T04:25:10.988166Z
+    updated = 2025-08-19T04:25:10.988166Z
+
+Component entity TOML (``entities/xblock.v1/<type>/<uuid>.toml``)
+================================================================
+
+Each XBlock component gets one TOML file.
+
+``[entity]``:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Field
+     - Required
+     - Description
+   * - ``can_stand_alone``
+     - yes
+     - Whether this component can be used independently (almost always ``true``)
+   * - ``key``
+     - yes
+     - Entity reference in the form ``xblock.v1:<type>:<uuid>``
+   * - ``created``
+     - yes
+     - UTC creation timestamp
+
+``[entity.draft]`` / ``[entity.published]`` — each contains ``version_num``
+pointing at the current draft or published ``[[version]]`` entry respectively.
+``[entity.draft]`` is absent when the entity has no draft.
+``[entity.published]`` is **always present** — when the entity has no
+published version it is written as an empty table with an explanatory comment
+(see the container example below).
+
+``[[version]]`` — at most two entries: the current draft version first, then
+the current published version if it differs from draft. The full version
+history is not stored.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Field
+     - Required
+     - Description
+   * - ``title``
+     - yes
+     - Display name of the component at this version
+   * - ``version_num``
+     - yes
+     - Monotonically increasing integer starting at 1
+
+Example::
+
+    [entity]
+    can_stand_alone = true
+    key = "xblock.v1:html:e32d5479-9492-41f6-9222-550a7346bc37"
+    created = 2025-08-19T04:25:43.685529Z
+
+    [entity.draft]
+    version_num = 5
+
+    [entity.published]
+    version_num = 4
+
+    # ### Versions
+
+    [[version]]
+    title = "Text"
+    version_num = 5
+
+    [[version]]
+    title = "Text"
+    version_num = 4
+
+Container entity TOML (``entities/<slug>.toml``)
+================================================
+
+The ``<slug>`` is derived from the last segment of the container's
+``entity_ref``. If two containers share the same last segment (e.g. a Unit
+and a Subsection both named "intro"), a short hash is appended to the
+second to avoid filename collisions (e.g. ``intro-48afa3.toml``).
+
+Sections, subsections, and units share the same base structure with an
+additional ``[entity.container.<type>]`` marker (``section``, ``subsection``,
+or ``unit``) and a ``[version.container]`` table that lists child keys.
+
+Example (section)::
+
+    [entity]
+    can_stand_alone = true
+    key = "section1-8ca126"
+    created = 2025-09-04T22:51:40.919872Z
+
+    [entity.draft]
+    version_num = 2
+
+    [entity.published]
+    # unpublished: no published_version_num
+
+    [entity.container.section]
+
+    # ### Versions
+
+    [[version]]
+    title = "Section1"
+    version_num = 2
+
+    [version.container]
+    children = ["subsection1-48afa3"]
+
+Collection TOML (``collections/<key>.toml``)
+============================================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Field
+     - Required
+     - Description
+   * - ``title``
+     - yes
+     - Collection display name
+   * - ``key``
+     - yes
+     - Unique key within the library
+   * - ``description``
+     - yes
+     - Free-text description (may be blank)
+   * - ``created``
+     - yes
+     - UTC creation timestamp
+   * - ``entities``
+     - yes
+     - List of entity reference strings (``xblock.v1:<type>:<uuid>``)
+
+Example::
+
+    [collection]
+    title = "Collection test1"
+    key = "collection-test"
+    description = ""
+    created = 2025-08-19T04:25:27.754968Z
+    entities = [
+        "xblock.v1:html:e32d5479-9492-41f6-9222-550a7346bc37",
+        "xblock.v1:problem:256739e8-c2df-4ced-bd10-8156f6cfa90b",
+    ]
+
+XBlock content (``component_versions/v<N>/block.xml``)
+======================================================
+
+:ref:`OLX (open learning XML) <What is Open Learning XML?>` for the component,
+in the same format Studio uses internally. Static assets (images, PDFs, etc.)
+referenced with ``/static/<filename>`` in the XML are stored alongside under
+``component_versions/v<N>/static/``.
+
+.. note::
+
+   Unlike the old modulestore OLX export — where each component's file was
+   named after its ``block_id`` (often a machine-generated UUID) — this format
+   always names the file ``block.xml``. The component's identifier lives in
+   the parent TOML file, not the filename.
+
+.. note::
+
+   **HTMLBlock limitation:** HTML content is currently serialized inline using
+   a CDATA section rather than stored in a separate ``.html`` file. This
+   differs from old course OLX exports and is a known limitation of the current
+   XBlock serialization layer.
+
+Example ``block.xml``::
+
+    <html display_name="Text">
+      <![CDATA[<p>Hello <img src="/static/me.png" alt="Me" /></p>]]>
+    </html>
+
+.. seealso::
+
+   :ref:`Backup and Restore a Library` (how-to)
+
+   :ref:`What is Open Learning XML?` (concept)
+
+   :ref:`OLX Documentation <OLX TOC>` (reference)
+
+   :ref:`OLX Directory Structure` (reference)
+
+
+**Maintenance chart**
+
++--------------+-------------------------------+----------------+--------------------------------+
+| Review Date  | Working Group Reviewer        |   Release      |Test situation                  |
++--------------+-------------------------------+----------------+--------------------------------+
+|              |                               |                |                                |
++--------------+-------------------------------+----------------+--------------------------------+


### PR DESCRIPTION
## Description

I think it's better to keep the backup-restore docs with the rest of the educator documentation, so I've moved it here, with some changes. Most of the edits I've made you can see split out into their own commit.

* Removed the parts on using the management command and Python APIs. We haven't
  documented other management commands and APIs using how-tos like this. I
  think the right place for these docs, if we feel we need them, are in the
  docstrings in command & API definitions.

* Removed instances of "uuid" and changed them to "key" or "code" as
  appropriate. Although the keys and codes are sometimes UUIDs, there is
  nothing enforcing it. In fact, in Ulmo, the platform usually generates
  user-friendly keys and codes based on their title (suffixed as necessary to
  make them unique) rather than UUIDs.

* Added notes on how the container and component "keys" (refs) get mapped into
  the platform's usage key format.

* The doc was very heavy on `Note` blocks. I've moved some of that into into
  normal paragraphs and bullets, and I think it reads better now. I've also
  turned the remaining notes into admonitions with nice headings.

* Stopped calling the course archive format the "old format" or the
  "modulestore format". The course archive format will be around Forever(TM)
  and I don't want to get into the habit of pretending it's some wacky legacy
  thing that we don't need to treat carefully.

## Prior work

This is based on the work of @irfanuddinahmad and @ormsbee : https://github.com/openedx/openedx-core/blob/main/docs/openedx_content/backup_restore.rst

I'll delete that duplicate doc in a follow-up PR.

## AI

I used Claude to do the move (first commit),

>create a new reference page for the Library Archive Format. include helpful cross-links to and from `source/educators/how-tos/course_development/backup_restore_library.rst`, which is the page that describes how to backup a library to an archive and how to restore it.
>
>base it on  https://github.com/openedx/openedx-core/blob/main/docs/backup_restore.rst., including the "Archive Structure" and "File Format Reference" sections, and "Overview" as is relevant, but skipping the "Exporting/Restoring a Package" sections. duplicating text verbatim is encouraged; we will delete the openedx-core doc at the end of this. please use wording and tone simliar to that of what-is-olx.rst, which is the root page for our other existing file format guide (OLX).
>
> please note that OLX is actually used in the library archive format, so linking to existing OLX documentation as part of the library archive reference is appropriate.
>
>clarifying questions are encouraged!

I then edited it myself (second commit).

and then ran a spelling and grammar check with Claude (third commit).
