### PR TITLE
Document Typesense command-line access

### DIFF
--- a/source/site_ops/how-tos/use_typesense_search_backend.rst
+++ b/source/site_ops/how-tos/use_typesense_search_backend.rst
@@ -163,6 +163,21 @@ visit the web dashboard url, and enter the following details at the login screen
 * port: ``8108``
 * path: (leave blank)
 
+Typesense command-line access
+*****************************
+
+You can also inspect the Typesense server from a terminal with
+`TypesenseKit <https://github.com/akshitkrnagpal/typesensekit>`_.
+For example, to check health and list collections for a local Tutor devstack:
+
+.. code-block:: shell
+
+   TYPESENSE_URL=http://localhost:8108 TYPESENSE_API_KEY=$(tutor config printvalue TYPESENSE_API_KEY) \
+     npm exec --yes --package @typesensekit/cli -- tsk health --input '{}'
+
+   TYPESENSE_URL=http://localhost:8108 TYPESENSE_API_KEY=$(tutor config printvalue TYPESENSE_API_KEY) \
+     npm exec --yes --package @typesensekit/cli -- tsk collections.list --input '{}'
+
 
 .. seealso::
 


### PR DESCRIPTION
## Summary

Adds a short Typesense command-line access section to the Typesense search backend how-to. The examples show how to use TypesenseKit to check health and list collections for a local Tutor devstack.

## Testing

- Not run; docs-only change.