### PR TITLE
Update Verawood to be the current release

### DIFF
--- a/source/community/release_notes/index.rst
+++ b/source/community/release_notes/index.rst
@@ -12,9 +12,9 @@ migrations, and other changes and updates to the Open edX platform.
 .. toctree::
     :maxdepth: 2
 
-    Ulmo: The Current Release <ulmo>
-    Verawood: June 2026 Release <verawood>
+    Verawood: The Current Release <verawood>
     Willow: December 2026 Release <willow>
+    Xylon: June 2027 Release <xylon>    
 
 .. toctree::
     :maxdepth: 1

--- a/source/community/release_notes/named_release_branches_and_tags.rst
+++ b/source/community/release_notes/named_release_branches_and_tags.rst
@@ -39,11 +39,29 @@ From Teak onwards we have changed the nomanclature from ``open-release/<named-re
 
 If an installation of a tag fails, try the corresponding release line master branch, it may have a fix.
 
+Verawood
+========
+
+* **Code cut date:** 2026-04-23
+* **Status:** supported
+* :doc:`Release Notes <./verawood>`
+
+.. list-table::
+   :header-rows: 1
+
+   * - Release Name
+     - Release Date
+     - Git Tag
+
+   * - Verawood.1
+     - 2026-07-30
+     - release/verawood.1
+
 Ulmo
 ====
 
 * **Code cut date:** 2025-10-30
-* **Status:** supported
+* **Status:** unsupported
 * :doc:`Release Notes <./ulmo>`
 
 .. list-table::
@@ -56,6 +74,18 @@ Ulmo
    * - Ulmo.1
      - 2026-01-15
      - release/ulmo.1
+
+   * - Ulmo.2
+     - 2026-03-06
+     - release/ulmo.2
+
+   * - Ulmo.3
+     - 2026-04-30
+     - release/ulmo.3
+
+   * - Ulmo.4
+     - 2026-07-29
+     - release/ulmo.4
 
 Teak
 ====

--- a/source/community/release_notes/old_releases.rst
+++ b/source/community/release_notes/old_releases.rst
@@ -11,6 +11,7 @@ fixes and features. These older releases will not receive any of those.
 .. toctree::
    :maxdepth: 2
 
+   ulmo
    teak
    sumac
    redwood

--- a/source/community/release_notes/verawood.rst
+++ b/source/community/release_notes/verawood.rst
@@ -1,8 +1,8 @@
-Open edX Verawood - June 2026 Release
+Open edX Verawood - July 2026 Release
 ##########################################
 
 These are the release notes for the Verawood release, the 22st community release
-of the Open edX Platform, which will be released in June 2026. You can also review details
+of the Open edX Platform, which was released on July 30, 2026. You can also review details
 about :ref:`Open edX Release Notes` or learn more about the `Open edX Platform`_.
 
 .. highlights::
@@ -33,6 +33,8 @@ about :ref:`Open edX Release Notes` or learn more about the `Open edX Platform`_
 
 +--------------+-------------------------------+----------------+--------------------------------+
 | Review Date  | Working Group Reviewer        |   Release      |Test situation                  |
++--------------+-------------------------------+----------------+--------------------------------+
+| 2025-07-30   | BTR WG                        | Verawood       | Pass                           |
 +--------------+-------------------------------+----------------+--------------------------------+
 | 2025-12-18   | BTR WG                        | Ulmo           | Pass                           |
 +--------------+-------------------------------+----------------+--------------------------------+

--- a/source/community/release_notes/xylon/dev_op_release_notes.rst
+++ b/source/community/release_notes/xylon/dev_op_release_notes.rst
@@ -1,0 +1,50 @@
+.. _Xylon Dev Notes:
+
+Open edX Xylon Developer & Operator Release Notes
+#####################################################
+
+*Releasing June, 2027!*
+
+These are the developer & operator release notes for the Xylon release, the 24th
+community release of the Open edX Platform, spanning changes from December
+2026 to June 2027. You can also review details about :ref:`Open edX Release Notes` or
+learn more about the `Open edX Platform`_.
+
+To view the end-user facing docs, see the :ref:`Xylon Product Notes`.
+
+.. _Open edX Platform: https://openedx.org
+
+.. contents::
+ :depth: 1
+ :local:
+
+Breaking Changes
+****************
+
+Deprecations & Removals
+***********************
+
+Aspects Analytics
+*****************************
+
+Administrators & Operators
+**************************
+
+Settings and Toggles
+********************
+
+Developer Experience
+********************
+
+Known Issues
+************
+
+See the `Build Test Release project board <https://github.com/orgs/openedx/projects/28>`_ for known open issues.
+
+**Maintenance chart**
+
++--------------+-------------------------------+----------------+--------------------------------+
+| Review Date  | Working Group Reviewer        |   Release      |Test situation                  |
++--------------+-------------------------------+----------------+--------------------------------+
+|              |                               |                |                                |
++--------------+-------------------------------+----------------+--------------------------------+

--- a/source/community/release_notes/xylon/feature_release_notes.rst
+++ b/source/community/release_notes/xylon/feature_release_notes.rst
@@ -1,0 +1,24 @@
+.. _Xylon Product Notes:
+
+Open edX Xylon Release - Product Release Notes
+##################################################
+
+*Releasing June, 2027!*
+
+.. toctree::
+   :maxdepth: 1
+
+   stay_up_to_date
+
+Information for site operators and developers, including information on how to
+enable and/or configure new features that require additional work, can be found
+in the :ref:`Xylon Dev Notes`.
+
+
+**Maintenance chart**
+
++--------------+-------------------------------+----------------+--------------------------------+
+| Review Date  | Working Group Reviewer        |   Release      |Test situation                  |
++--------------+-------------------------------+----------------+--------------------------------+
+|              |                               |                |                                |
++--------------+-------------------------------+----------------+--------------------------------+

--- a/source/community/release_notes/xylon/stay_up_to_date.rst
+++ b/source/community/release_notes/xylon/stay_up_to_date.rst
@@ -1,0 +1,26 @@
+Stay Up To Date with Xylon
+##############################
+
+Beginning with the Redwood release, the community has come together to pre-plan
+major product deliverables well in advance of the release's code cut off date.
+This planning process is an open, synchronous meeting which anyone may join,
+whether to discuss projects they're contributing or to follow along to get a
+front row seat to the next release's deliverables. Coordination across community
+projects in this way allows us to have more predictable feature sets available
+in each release, facilitates assistance across the community for projects that
+may be falling behind, and prevent duplicative work - which streamlines efforts
+and reduces redundancy.
+
+The Named Release Planning meeting occurs biweekly on Thursdays starting January
+9th 2025, and can be found on the `Open edX Meeting Calendar`_.
+Join asynchronously in the `#release-planning room in Slack <openedx.org/slack>`_.
+
+.. include:: /links.txt
+
+**Maintenance chart**
+
++--------------+-------------------------------+----------------+--------------------------------+
+| Review Date  | Working Group Reviewer        |   Release      |Test situation                  |
++--------------+-------------------------------+----------------+--------------------------------+
+|  2025-12-18  | sarina                        | Ulmo           |   Pass                         |
++--------------+-------------------------------+----------------+--------------------------------+


### PR DESCRIPTION
- Updates Verawood to be the current release
- Moves Ulmo to unsupported
- Adds stubs for Xylon
- Updates named release branches and tags file
