### PR TITLE
docs: point Verawood RNs at real frontend-base porting docs

### DIFF
--- a/source/community/release_notes/verawood/dev_op_release_notes.rst
+++ b/source/community/release_notes/verawood/dev_op_release_notes.rst
@@ -591,10 +591,9 @@ Documentation on how to do so is provided at:
 
 * `frontend-base theming docs
   <https://github.com/openedx/frontend-base/blob/main/docs/how_tos/theming.md>`_
-* `docs.openedx.org PR #1459
-  <https://github.com/openedx/docs.openedx.org/pull/1459>`_
+* :ref:`Port a Frontend Plugin to frontend-base`
 * `Migrate a frontend app how-to
-  <https://github.com/brian-smith-tcril/frontend-base/blob/main/docs/how_tos/migrate-frontend-app.md>`_
+  <https://github.com/openedx/frontend-base/blob/main/docs/how_tos/migrate-frontend-app.md>`_
 
 As a migration aid for unconverted legacy plugins, a `frontend-base-compat
 <https://github.com/openedx/frontend-base-compat>`_ shim lets legacy


### PR DESCRIPTION
### Description

Repoints the frontend-base porting links in the Verawood dev/operator release notes at the real docs: an internal cross-reference to the ported how-to, and the openedx org copy of the migration guide.

The build will fail until `main` is pulled into the target branch.

### LLM usage notice

Built with assistance from Claude.