### PR TITLE
Add Verawood Marketing Release Note page and update homepage

### DIFF
--- a/source/community/release_notes/ulmo/ulmo_marketing_notes.rst
+++ b/source/community/release_notes/ulmo/ulmo_marketing_notes.rst
@@ -60,17 +60,11 @@ and extension by your development or operations team.
 🔮 Upcoming in Verawood (June 2026)
 ************************************
 
-We're working hard on even more improvements in our Verawood release! You can look
-forward to:
+We're working hard on even more improvements in our :ref:`Verawood release (out
+now) <Verawood Product Marketing Notes>`! You can look forward to:
 
 **Roles and Permissions Improvements in Studio**: A more granular, nuanced way
 of granting privileges to course staff and instructors.
-
-**Modular Pathway Support**: This initiative aims to create a unified,
-generalized, flexible way for course teams, instructional designers and
-administrators to sequence, bundle and deliver learning pathways, including
-microcredentials, small courses, pathways and more. For Verawood, the Open edX
-platform will support stackable pathways for programs.
 
 **Instructor Dashboad Overhaul**: A beautiful, themeable Instructor Dashboard
 with numerous usability improvements is coming your way.

--- a/source/community/release_notes/verawood.rst
+++ b/source/community/release_notes/verawood.rst
@@ -22,6 +22,7 @@ about :ref:`Open edX Release Notes` or learn more about the `Open edX Platform`_
 .. toctree::
     :maxdepth: 2
 
+    Verawood Overview <verawood/verawood_marketing_notes>
     Verawood Release Notes <verawood/feature_release_notes>
     Verawood Developer & Operator Release Notes <verawood/dev_op_release_notes>
 
@@ -35,8 +36,4 @@ about :ref:`Open edX Release Notes` or learn more about the `Open edX Platform`_
 | Review Date  | Working Group Reviewer        |   Release      |Test situation                  |
 +--------------+-------------------------------+----------------+--------------------------------+
 | 2025-07-30   | BTR WG                        | Verawood       | Pass                           |
-+--------------+-------------------------------+----------------+--------------------------------+
-| 2025-12-18   | BTR WG                        | Ulmo           | Pass                           |
-+--------------+-------------------------------+----------------+--------------------------------+
-| 2025-06-04   | BTR WG                        | Teak           | Pass                           |
 +--------------+-------------------------------+----------------+--------------------------------+

--- a/source/community/release_notes/verawood/ai_extension_framework.rst
+++ b/source/community/release_notes/verawood/ai_extension_framework.rst
@@ -1,4 +1,4 @@
-.. _AI Extensions Framework:
+.. _AI Extensions Framework (Verawood):
 
 AI Extensions Framework
 #######################

--- a/source/community/release_notes/verawood/dev_op_release_notes.rst
+++ b/source/community/release_notes/verawood/dev_op_release_notes.rst
@@ -571,6 +571,8 @@ run migrations.
   validation, since Casbin state can lag behind the flag when automatic
   migration is disabled or the global flag changes.
 
+.. _frontend-base in Verawood:
+
 Frontend-base
 *************
 

--- a/source/community/release_notes/verawood/lti_notifications.rst
+++ b/source/community/release_notes/verawood/lti_notifications.rst
@@ -3,6 +3,8 @@
 Updates to LTI and Notifications
 #################################
 
+.. _Verawood LTI Improvements:
+
 LTI Improvements
 *****************
 
@@ -35,6 +37,7 @@ reliability improvements.
    three, easier to manage screens: "Setup", "Advantage Settings", and finally,
    "Review Settings".
 
+.. _Verawood Notifications Improvements:
 
 Notifications Improvements
 ***************************

--- a/source/community/release_notes/verawood/verawood_marketing_notes.rst
+++ b/source/community/release_notes/verawood/verawood_marketing_notes.rst
@@ -12,17 +12,17 @@ while making everyday tasks simpler. Here's what's ready for you now:
 :ref:`Streamlined Team Management, Starting with Studio <Introducing More Granular Team Management>`: Assign
 Course Admin or Course Staff roles to multiple users across organizations,
 courses, and libraries in a single action — with a unified console for auditing
-who has access to what, and automatic migration of existing role assignments.
+who has access to what and automatic migration of existing role assignments.
 
 :ref:`AI-Powered Question Generation, Built to Extend <AI Extensions Framework (Verawood)>`:
 Generate and review AI-drafted multiple-choice questions right in Studio, saved
 to a content library for reuse across courses. Since the framework is open for
 extension, your developers can build custom AI workflows that work directly in
-author or learner facing platform areas.
+author- or learner-facing platform areas.
 
 :ref:`A Modernized Instructor Dashboard <New Instructor Dashboard Experience>`:
 Find what you need faster with sortable, searchable tables, streamlined page
-actions, and tabbed content grouping—plus clearer tool names like Course Team,
+actions, and tabbed content grouping — plus clearer tool names like Course Team,
 Enrollments, and Grading that keep related actions together.
 
 :ref:`Reuse and Simplify LTI Setup <Verawood LTI Improvements>`:
@@ -30,8 +30,8 @@ Duplicate fully configured LTI blocks across any course on your site and set up
 new integrations faster with a simplified, tabbed interface that only shows the
 settings you need.
 
-:ref:`LTI Certified ✅ <Verawood LTI Certification>`: The Open edX Verawood Release
-has achieved the `LTI Advantage Complete
+:ref:`Learning Tools Interoperability (LTI) Certified ✅ <Verawood LTI Certification>`:
+The Open edX Verawood Release has achieved the `LTI Advantage Complete
 <https://www.imsglobal.org/lti-advantage-overview>`_ certification!
 
 :ref:`Require Agreement Acceptance Before Uploads <Verawood Copyright Acceptance>`:
@@ -50,17 +50,17 @@ content, without ever leaving the page. Fully configurable with your choice of
 OpenAI, Anthropic, or self-hosted models.
 
 :ref:`Smarter Notifications for Learners and Authors <Verawood Notifications Improvements>`:
-Learners get ORA reminders, digest emails that reduce noise, and the ability to
-unsubscribe from their own post notifications — while course authors now have
-visibility into course activity right in Studio.
+Learners get open response assessment (ORA) reminders, digest emails that reduce
+noise, and the ability to opt out of their own post notifications — while course
+authors now have visibility into course activity right in Studio.
 
 ⚙️ For Site Operators 
 **********************
 
-:ref:`Faster builds and reduced page load time with frontend-base <frontend-base in Verawood>`: This
-new frontend architecture paradigm is now available for site operators to test
-out. We encourage operators to enable frontend-base on staging or sandbox
-instances and provide feedback on the `Open edX forums
+:ref:`Faster Builds and Reduced Page Load Time with frontend-base <frontend-base in Verawood>`: This
+new frontend architecture paradigm is now available for site operators to test.
+We encourage operators to enable frontend-base on staging or sandbox instances
+and provide feedback on the `Open edX forums
 <https://discuss.openedx.org/c/working-groups/fe-wg/37>`_.
 
 
@@ -70,23 +70,24 @@ instances and provide feedback on the `Open edX forums
 We're working hard on even more improvements in our Willow release! You can look
 forward to:
 
-**Modular Pathway Support**: This initiative aims to create a unified,
-generalized, flexible way for course teams, instructional designers and
-administrators to sequence, bundle and deliver learning pathways, including
-microcredentials, small courses, pathways and more. For Willow, the Open edX
-platform will support stackable pathways for programs.
+**Modular Pathway Support**: This initiative aims to create a unified and
+flexible way for course teams, instructional designers, and administrators to
+sequence, bundle and deliver learning pathways, including microcredentials,
+small courses, and more. For Willow, the Open edX platform will support
+stackable pathways for programs.
 
-**Competency Frameworks**: Competency based education (CBE) is a flexible and
-efficient model of learning that focuses on skills mastery over seat time or
-semesters. Designed around skills-aligned assessment, it can more accurately and
+**Competency Frameworks**: Competency-based education (CBE) is a flexible and
+efficient model of learning that focuses on skills mastery over seat time.
+Designed around skills-aligned assessment, it can more accurately and
 incrementally direct learners to job opportunities. The Willow release marks a
 huge first step into native CBE support in the Open edX platform: attaching
-competencies with assessment criteria to courses, tracking learner attainments,
-and tracking learner progress through their attained skills.
+competencies with assessment criteria to courses and tracking learner progress
+through their attained skills.
 
 **Roles and Permissions Improvements in Studio**: New Studio roles are planned
-to separate authoring responsibilities from managing an active course, and to
-introduce a read-only role for reviewing course content in Studio.
+to separate authoring responsibilities from the day-to-day responsibilities of
+managing an active course, and to introduce a read-only role for reviewing
+course content in Studio.
 
 **Your Open edX Instance As An LTI Provider**: Work to enable Open edX
 Studio and Libraries to function as an LTI Provider with an intuitive course

--- a/source/community/release_notes/verawood/verawood_marketing_notes.rst
+++ b/source/community/release_notes/verawood/verawood_marketing_notes.rst
@@ -1,0 +1,100 @@
+.. _Verawood Product Marketing Notes:
+
+Open edX Verawood Release (July 2026)
+######################################
+
+Welcome to the Verawood release! This release puts powerful new tools in your hands
+while making everyday tasks simpler. Here's what's ready for you now:
+
+🧑‍🏫 For Course Authors
+********************************
+
+:ref:`Streamlined Team Management, Starting with Studio <Introducing More Granular Team Management>`: Assign
+Course Admin or Course Staff roles to multiple users across organizations,
+courses, and libraries in a single action — with a unified console for auditing
+who has access to what, and automatic migration of existing role assignments.
+
+:ref:`AI-Powered Question Generation, Built to Extend <AI Extensions Framework (Verawood)>`:
+Generate and review AI-drafted multiple-choice questions right in Studio, saved
+to a content library for reuse across courses. Since the framework is open for
+extension, your developers can build custom AI workflows that work directly in
+author or learner facing platform areas.
+
+:ref:`A Modernized Instructor Dashboard <New Instructor Dashboard Experience>`:
+Find what you need faster with sortable, searchable tables, streamlined page
+actions, and tabbed content grouping—plus clearer tool names like Course Team,
+Enrollments, and Grading that keep related actions together.
+
+:ref:`Reuse and Simplify LTI Setup <Verawood LTI Improvements>`:
+Duplicate fully configured LTI blocks across any course on your site and set up
+new integrations faster with a simplified, tabbed interface that only shows the
+settings you need.
+
+:ref:`LTI Certified ✅ <Verawood LTI Certification>`: The Open edX Verawood Release
+has achieved the `LTI Advantage Complete
+<https://www.imsglobal.org/lti-advantage-overview>`_ certification!
+
+:ref:`Require Agreement Acceptance Before Uploads <Verawood Copyright Acceptance>`:
+Configure custom agreements that authors must accept before accessing file or
+video upload pages in Studio, with automatic re-prompting whenever an agreement
+is updated.
+
+
+🎓 For Learners
+*****************
+
+:ref:`An AI Assistant That Knows the Lesson <AI Extensions Framework (Verawood)>`:
+Learners can chat with an AI assistant right inside a course unit — asking
+questions, clarifying concepts, and getting answers grounded in that unit's
+content, without ever leaving the page. Fully configurable with your choice of
+OpenAI, Anthropic, or self-hosted models.
+
+:ref:`Smarter Notifications for Learners and Authors <Verawood Notifications Improvements>`:
+Learners get ORA reminders, digest emails that reduce noise, and the ability to
+unsubscribe from their own post notifications — while course authors now have
+visibility into course activity right in Studio.
+
+⚙️ For Site Operators 
+**********************
+
+:ref:`Faster builds and reduced page load time with frontend-base <frontend-base in Verawood>`: This
+new frontend architecture paradigm is now available for site operators to test
+out. We encourage operators to enable frontend-base on staging or sandbox
+instances and provide feedback on the `Open edX forums
+<https://discuss.openedx.org/c/working-groups/fe-wg/37>`_.
+
+
+🔮 Upcoming in Willow (December 2026)
+**************************************
+
+We're working hard on even more improvements in our Willow release! You can look
+forward to:
+
+**Modular Pathway Support**: This initiative aims to create a unified,
+generalized, flexible way for course teams, instructional designers and
+administrators to sequence, bundle and deliver learning pathways, including
+microcredentials, small courses, pathways and more. For Willow, the Open edX
+platform will support stackable pathways for programs.
+
+**Competency Frameworks**: Competency based education (CBE) is a flexible and
+efficient model of learning that focuses on skills mastery over seat time or
+semesters. Designed around skills-aligned assessment, it can more accurately and
+incrementally direct learners to job opportunities. The Willow release marks a
+huge first step into native CBE support in the Open edX platform: attaching
+competencies with assessment criteria to courses, tracking learner attainments,
+and tracking learner progress through their attained skills.
+
+**Roles and Permissions Improvements in Studio**: New Studio roles are planned
+to separate authoring responsibilities from managing an active course, and to
+introduce a read-only role for reviewing course content in Studio.
+
+**Your Open edX Instance As An LTI Provider**: Work to enable Open edX
+Studio and Libraries to function as an LTI Provider with an intuitive course
+author/admin UI is targeted for the Willow release.
+
+⌚ Ready to Upgrade?
+***********************
+
+Have your site operations team check out the `Tutor upgrading guide
+<https://docs.tutor.edly.io/install.html#upgrading>`_ so they can upgrade your
+Open edX instance to the Verawood release!

--- a/source/index.rst
+++ b/source/index.rst
@@ -16,17 +16,17 @@ Open edX Documentation
          :maxdepth: 1
          :hidden:
 
-         📰 What's New? <community/release_notes/ulmo/ulmo_marketing_notes>
+         📰 What's New? <community/release_notes/verawood/verawood_marketing_notes>
 
-      The Open edX Ulmo release is out, featuring:
+      The Open edX Verawood release is out, featuring:
 
-      🔔 Platform & Email Notifications!
+      🤖 Native, Extendable AI Capabilities for Learners and Authors
 
-      📚 Section Reuse and Granular Permissions with Libraries!
+      👥 Streamlined Team Role Management
 
-      🚀 Reusable LTI Configuration!
+      📊 A Modernized Instructor Dashboard
 
-      ... and lots more! :ref:`Continue reading... <Ulmo Product Marketing Notes>`
+      ... and lots more! :ref:`Continue reading... <Verawood Product Marketing Notes>`
 
    .. grid-item-card::
       :class-card: sd-shadow-md sd-p-2


### PR DESCRIPTION
Adds the Marketing Release Notes (quick summaries of each product feature that has a full release note) as well as update the docs.openedx.org homepage with three highlights from the Verawood marketing notes.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>